### PR TITLE
refactor: Minimize metadata sent to the client

### DIFF
--- a/apps/platform/pkg/adapt/load.go
+++ b/apps/platform/pkg/adapt/load.go
@@ -27,6 +27,8 @@ type LoadOp struct {
 	Preloaded          bool                   `json:"preloaded"`
 	LoadAll            bool                   `json:"loadAll" bot:"loadAll"`
 	DebugQueryString   string                 `json:"debugQueryString"`
+	// Server-only flag to indicate that this is a server-initiated load, as opposed to client initiated
+	ServerInitiated bool `json:"-"`
 	// Internal only conveniences for LoadBots to be able to access prefetched metadata
 	metadata    *MetadataCache
 	integration IntegrationConnection

--- a/apps/platform/pkg/auth/auth.go
+++ b/apps/platform/pkg/auth/auth.go
@@ -3,7 +3,11 @@ package auth
 import (
 	"errors"
 	"fmt"
+	"os"
+	"strings"
+
 	"github.com/icza/session"
+
 	"github.com/thecloudmasters/uesio/pkg/adapt"
 	"github.com/thecloudmasters/uesio/pkg/bundle"
 	"github.com/thecloudmasters/uesio/pkg/configstore"
@@ -14,8 +18,6 @@ import (
 	"github.com/thecloudmasters/uesio/pkg/meta"
 	"github.com/thecloudmasters/uesio/pkg/sess"
 	"github.com/thecloudmasters/uesio/pkg/templating"
-	"os"
-	"strings"
 )
 
 func init() {
@@ -304,6 +306,7 @@ func GetLoginMethod(claims *AuthenticationClaims, authSourceID string, session *
 					Value: claims.Subject,
 				},
 			},
+			ServerInitiated: true,
 		},
 		session,
 	)

--- a/apps/platform/pkg/auth/site.go
+++ b/apps/platform/pkg/auth/site.go
@@ -29,6 +29,7 @@ func getDomain(domainType, domain string) (*meta.SiteDomain, error) {
 					Value: domainType,
 				},
 			},
+			ServerInitiated: true,
 		},
 		sess.GetStudioAnonSession(),
 	)

--- a/apps/platform/pkg/bot/jsdialect/apihelpers.go
+++ b/apps/platform/pkg/bot/jsdialect/apihelpers.go
@@ -22,15 +22,16 @@ func botLoad(request BotLoadOp, session *sess.Session, connection adapt.Connecti
 	collection := &adapt.Collection{}
 
 	op := &adapt.LoadOp{
-		BatchSize:      request.BatchSize,
-		CollectionName: request.Collection,
-		Collection:     collection,
-		WireName:       "botload",
-		Fields:         request.Fields,
-		Conditions:     request.Conditions,
-		Order:          request.Order,
-		Query:          true,
-		LoadAll:        request.LoadAll,
+		BatchSize:       request.BatchSize,
+		CollectionName:  request.Collection,
+		Collection:      collection,
+		WireName:        "botload",
+		Fields:          request.Fields,
+		Conditions:      request.Conditions,
+		Order:           request.Order,
+		Query:           true,
+		LoadAll:         request.LoadAll,
+		ServerInitiated: true,
 	}
 
 	_, err := datasource.Load([]*adapt.LoadOp{op}, session, &datasource.LoadOptions{

--- a/apps/platform/pkg/bot/systemdialect/namespaceswap.go
+++ b/apps/platform/pkg/bot/systemdialect/namespaceswap.go
@@ -102,7 +102,7 @@ func (c *NamespaceSwapCollection) SwapNSBack(value string) string {
 	return meta.SwapKeyNamespace(value, c.modified, c.original)
 }
 
-// Gets the conditions from the wire and translates them from core to studio
+// MapConditions Gets the conditions from the wire and translates them from core to studio
 func (c *NamespaceSwapCollection) MapConditions(coreConditions []adapt.LoadRequestCondition) []adapt.LoadRequestCondition {
 	var studioConditions []adapt.LoadRequestCondition
 	for _, elem := range coreConditions {

--- a/apps/platform/pkg/bulk/exportcollection.go
+++ b/apps/platform/pkg/bulk/exportcollection.go
@@ -59,12 +59,13 @@ func exportCollection(create retrieve.WriterCreator, spec *meta.JobSpec, session
 	}
 
 	_, err = datasource.Load([]*adapt.LoadOp{{
-		WireName:       "uesio_data_export",
-		CollectionName: spec.Collection,
-		Collection:     collection,
-		Fields:         fields,
-		Query:          true,
-		LoadAll:        true,
+		WireName:        "uesio_data_export",
+		CollectionName:  spec.Collection,
+		Collection:      collection,
+		Fields:          fields,
+		Query:           true,
+		LoadAll:         true,
+		ServerInitiated: true,
 	}}, session, nil)
 	if err != nil {
 		return err

--- a/apps/platform/pkg/bundle/cache.go
+++ b/apps/platform/pkg/bundle/cache.go
@@ -16,7 +16,7 @@ var bundleEntryCache cache.Cache[meta.BundleableItem]
 
 // Bundle entries should be very long-lived, so we will allow them to live in memory for a relatively long time,
 // and only expire them infrequently because the cost of doing a filesystem read is quite high.
-// TODO: Consider pre-loading common bundles into the cache on init, to prevent initial requests from being slow.
+// TODO: Consider preloading common bundles into the cache on init, to prevent initial requests from being slow.
 const (
 	defaultExpiry  = time.Duration(12 * time.Hour)
 	defaultCleanup = time.Duration(2 * time.Hour)

--- a/apps/platform/pkg/bundlestore/workspacebundlestore/workspacebundlestore.go
+++ b/apps/platform/pkg/bundlestore/workspacebundlestore/workspacebundlestore.go
@@ -50,9 +50,10 @@ func processItems(items []meta.BundleableItem, workspace *meta.Workspace, connec
 			Collection: group,
 			Namespace:  namespace,
 		}, &datasource.PlatformLoadOptions{
-			LoadAll:    true,
-			Connection: connection,
-			Params:     getParamsFromWorkspace(workspace),
+			LoadAll:         true,
+			Connection:      connection,
+			Params:          getParamsFromWorkspace(workspace),
+			ServerInitiated: true,
 			Conditions: []adapt.LoadRequestCondition{
 				{
 					Field:    adapt.UNIQUE_KEY_FIELD,
@@ -114,8 +115,9 @@ func (b *WorkspaceBundleStoreConnection) GetItem(item meta.BundleableItem) error
 				Value: item.GetDBID(b.Workspace.UniqueKey),
 			},
 		},
-		Params:     getParamsFromWorkspace(b.Workspace),
-		Connection: b.Connection,
+		Params:          getParamsFromWorkspace(b.Workspace),
+		Connection:      b.Connection,
+		ServerInitiated: true,
 	}, sess.GetStudioAnonSession())
 }
 
@@ -158,10 +160,11 @@ func (b *WorkspaceBundleStoreConnection) GetAllItems(group meta.BundleableGroup,
 		Collection: group,
 		Namespace:  b.Namespace,
 	}, &datasource.PlatformLoadOptions{
-		Conditions: loadConditions,
-		Params:     getParamsFromWorkspace(b.Workspace),
-		Connection: b.Connection,
-		LoadAll:    true,
+		Conditions:      loadConditions,
+		Params:          getParamsFromWorkspace(b.Workspace),
+		Connection:      b.Connection,
+		LoadAll:         true,
+		ServerInitiated: true,
 		Orders: []adapt.LoadRequestOrder{{
 			Field: adapt.UNIQUE_KEY_FIELD,
 		}},
@@ -207,6 +210,7 @@ func (b *WorkspaceBundleStoreConnection) GetAttachmentPaths(item meta.Attachable
 					Value: recordID,
 				},
 			},
+			ServerInitiated: true,
 		},
 		sess.GetStudioAnonSession(),
 	)
@@ -236,8 +240,9 @@ func (b *WorkspaceBundleStoreConnection) GetBundleDef() (*meta.BundleDef, error)
 	err := datasource.PlatformLoad(
 		&bdc,
 		&datasource.PlatformLoadOptions{
-			Connection: b.Connection,
-			Params:     getParamsFromWorkspace(b.Workspace),
+			Connection:      b.Connection,
+			Params:          getParamsFromWorkspace(b.Workspace),
+			ServerInitiated: true,
 			Fields: []adapt.LoadRequestField{
 				{
 					ID: "uesio/studio.workspace",

--- a/apps/platform/pkg/configstore/platform/platform.go
+++ b/apps/platform/pkg/configstore/platform/platform.go
@@ -15,6 +15,7 @@ func (cs *ConfigStore) Get(key string, session *sess.Session) (string, error) {
 	err := datasource.PlatformLoadOne(
 		&cv,
 		&datasource.PlatformLoadOptions{
+			ServerInitiated: true,
 			Conditions: []adapt.LoadRequestCondition{
 				{
 					Field: adapt.UNIQUE_KEY_FIELD,

--- a/apps/platform/pkg/controller/collection.go
+++ b/apps/platform/pkg/controller/collection.go
@@ -1,10 +1,12 @@
 package controller
 
 import (
-	"github.com/thecloudmasters/uesio/pkg/controller/file"
 	"net/http"
 
+	"github.com/thecloudmasters/uesio/pkg/controller/file"
+
 	"github.com/gorilla/mux"
+
 	"github.com/thecloudmasters/uesio/pkg/adapt"
 	"github.com/thecloudmasters/uesio/pkg/datasource"
 	"github.com/thecloudmasters/uesio/pkg/middleware"
@@ -33,7 +35,7 @@ func GetCollectionMetadata(w http.ResponseWriter, r *http.Request) {
 	}
 
 	file.RespondJSON(w, r, &adapt.LoadResponseBatch{
-		Collections: metadataResponse.Collections,
+		Collections: metadataResponse.GetCollectionsMapForClient(),
 	})
 
 }

--- a/apps/platform/pkg/controller/load.go
+++ b/apps/platform/pkg/controller/load.go
@@ -34,6 +34,6 @@ func Load(w http.ResponseWriter, r *http.Request) {
 	}
 	file.RespondJSON(w, r, &adapt.LoadResponseBatch{
 		Wires:       batch.Wires,
-		Collections: metadata.Collections,
+		Collections: metadata.GetCollectionsMapForClient(),
 	})
 }

--- a/apps/platform/pkg/controller/rest.go
+++ b/apps/platform/pkg/controller/rest.go
@@ -7,6 +7,7 @@ import (
 	"github.com/thecloudmasters/uesio/pkg/controller/file"
 
 	"github.com/gorilla/mux"
+
 	"github.com/thecloudmasters/uesio/pkg/adapt"
 	"github.com/thecloudmasters/uesio/pkg/datasource"
 	"github.com/thecloudmasters/uesio/pkg/logger"

--- a/apps/platform/pkg/datasource/appdata.go
+++ b/apps/platform/pkg/datasource/appdata.go
@@ -37,6 +37,7 @@ func GetAppData(namespaces []string) (map[string]NamespaceInfo, error) {
 				ID: "uesio/studio.icon",
 			},
 		},
+		ServerInitiated: true,
 	}, sess.GetStudioAnonSession())
 	if err != nil {
 		return nil, err

--- a/apps/platform/pkg/datasource/cascade.go
+++ b/apps/platform/pkg/datasource/cascade.go
@@ -21,7 +21,7 @@ func getCascadeDeletes(
 
 	metadata := connection.GetMetadata()
 
-	for _, collectionMetadata := range metadata.Collections {
+	for _, collectionMetadata := range metadata.GetCollectionsMap() {
 		collectionKey := collectionMetadata.GetFullName()
 		for _, field := range collectionMetadata.Fields {
 			if field.Type == "FILE" {
@@ -108,8 +108,9 @@ func getCascadeDeletes(
 							Operator: "IN",
 						},
 					},
-					Query:  true,
-					Params: wire.Params,
+					Query:           true,
+					Params:          wire.Params,
+					ServerInitiated: true,
 				}
 
 				err := connection.Load(op, session)

--- a/apps/platform/pkg/datasource/domain.go
+++ b/apps/platform/pkg/datasource/domain.go
@@ -27,7 +27,8 @@ func QueryDomainFromSite(siteID string) (*meta.SiteDomain, error) {
 					Value: siteID,
 				},
 			},
-			BatchSize: 1,
+			BatchSize:       1,
+			ServerInitiated: true,
 		},
 		sess.GetStudioAnonSession(),
 	)

--- a/apps/platform/pkg/datasource/licensing.go
+++ b/apps/platform/pkg/datasource/licensing.go
@@ -61,6 +61,7 @@ func GetLicenses(namespace string, connection adapt.Connection) (LicenseMap, err
 				Operator: "=",
 			},
 		},
+		ServerInitiated: true,
 	}, anonSession)
 	if err != nil {
 		return nil, err
@@ -88,6 +89,7 @@ func GetLicenses(namespace string, connection adapt.Connection) (LicenseMap, err
 					Operator: "=",
 				},
 			},
+			ServerInitiated: true,
 		},
 		anonSession,
 	)

--- a/apps/platform/pkg/datasource/load.go
+++ b/apps/platform/pkg/datasource/load.go
@@ -339,7 +339,7 @@ func getMetadataForConditionLoad(
 
 	if condition.Type == "SUBQUERY" {
 		// Request metadata for the sub-query condition's Collection and subfield
-		err = collections.AddCollection(condition.SubCollection)
+		err = collections.AddTransientCollectionDependency(condition.SubCollection)
 		if err != nil {
 			return err
 		}
@@ -401,7 +401,14 @@ func GetMetadataForLoad(
 
 	// Keep a running tally of all requested collections
 	collections := MetadataRequest{}
-	err := collections.AddCollection(collectionKey)
+	var err error
+
+	if op.ServerInitiated {
+		err = collections.AddTransientCollectionDependency(collectionKey)
+	} else {
+		err = collections.AddCollection(collectionKey)
+	}
+
 	if err != nil {
 		return err
 	}

--- a/apps/platform/pkg/datasource/platformload.go
+++ b/apps/platform/pkg/datasource/platformload.go
@@ -19,10 +19,11 @@ type PlatformLoadOptions struct {
 	LoadAll            bool
 	Params             map[string]string
 	RequireWriteAccess bool
+	ServerInitiated    bool
 }
 
 func (plo *PlatformLoadOptions) GetConditionsDebug() string {
-	conditionStrings := []string{}
+	var conditionStrings []string
 	for _, c := range plo.Conditions {
 		conditionStrings = append(conditionStrings, fmt.Sprintf("%s :: %s", c.Field, c.Value))
 	}
@@ -42,7 +43,7 @@ func NewRecordNotFoundError(message string) *RecordNotFoundError {
 }
 
 func GetLoadRequestFields(fieldStrings []string) []adapt.LoadRequestField {
-	fields := []adapt.LoadRequestField{}
+	var fields []adapt.LoadRequestField
 	for _, field := range fieldStrings {
 		fields = append(fields, adapt.LoadRequestField{
 			ID: field,
@@ -54,7 +55,9 @@ func GetLoadRequestFields(fieldStrings []string) []adapt.LoadRequestField {
 func PlatformLoad(group meta.CollectionableGroup, options *PlatformLoadOptions, session *sess.Session) error {
 
 	if options == nil {
-		options = &PlatformLoadOptions{}
+		options = &PlatformLoadOptions{
+			ServerInitiated: true,
+		}
 	}
 	fields := options.Fields
 	if fields == nil {
@@ -71,6 +74,7 @@ func PlatformLoad(group meta.CollectionableGroup, options *PlatformLoadOptions, 
 		BatchSize:          options.BatchSize,
 		Params:             options.Params,
 		RequireWriteAccess: options.RequireWriteAccess,
+		ServerInitiated:    options.ServerInitiated,
 	}, options, session)
 }
 

--- a/apps/platform/pkg/datasource/recordtokens.go
+++ b/apps/platform/pkg/datasource/recordtokens.go
@@ -17,6 +17,7 @@ func ResetRecordTokens(collection string, session *sess.Session) error {
 				ID: adapt.ID_FIELD,
 			},
 		},
+		ServerInitiated: true,
 	}
 
 	connection, err := GetPlatformConnection(nil, session.RemoveWorkspaceContext(), nil)

--- a/apps/platform/pkg/datasource/siteadmincontext.go
+++ b/apps/platform/pkg/datasource/siteadmincontext.go
@@ -181,6 +181,7 @@ func querySite(value, field string, session *sess.Session, connection adapt.Conn
 				},
 			},
 			RequireWriteAccess: true,
+			ServerInitiated:    true,
 		},
 		session,
 	)

--- a/apps/platform/pkg/datasource/usertokens.go
+++ b/apps/platform/pkg/datasource/usertokens.go
@@ -21,10 +21,8 @@ func getTokensForRequest(connection adapt.Connection, session *sess.Session, tok
 	tokens := []meta.BundleableItem{}
 
 	userAccessTokenNames := map[string]bool{}
-	for _, collectionMetadata := range metadata.Collections {
-
+	for _, collectionMetadata := range metadata.GetCollectionsMap() {
 		challengeMetadata := collectionMetadata
-
 		for challengeMetadata.AccessField != "" {
 			fieldMetadata, err := challengeMetadata.GetField(challengeMetadata.AccessField)
 			if err != nil {
@@ -35,7 +33,6 @@ func getTokensForRequest(connection adapt.Connection, session *sess.Session, tok
 				return nil, err
 			}
 		}
-
 		for _, challengeToken := range challengeMetadata.RecordChallengeTokens {
 			if challengeToken.UserAccessToken != "" {
 				if !tokenMap.Has(challengeToken.UserAccessToken) {
@@ -149,12 +146,13 @@ func HydrateTokenMap(tokenMap sess.TokenMap, tokenDefs meta.UserAccessTokenColle
 
 			lookupResults := &adapt.Collection{}
 			var loadOp = &adapt.LoadOp{
-				CollectionName: token.Collection,
-				WireName:       "foo",
-				Collection:     lookupResults,
-				Conditions:     loadConditions,
-				Fields:         fieldsMap.getRequestFields(),
-				Query:          true,
+				CollectionName:  token.Collection,
+				WireName:        "foo",
+				Collection:      lookupResults,
+				Conditions:      loadConditions,
+				Fields:          fieldsMap.getRequestFields(),
+				Query:           true,
+				ServerInitiated: true,
 			}
 
 			err := GetMetadataForLoad(loadOp, metadata, []*adapt.LoadOp{loadOp}, adminSession)

--- a/apps/platform/pkg/datasource/workspacecontext.go
+++ b/apps/platform/pkg/datasource/workspacecontext.go
@@ -50,6 +50,7 @@ func addWorkspaceContext(workspace *meta.Workspace, session *sess.Session, conne
 					Value: workspace.ID,
 				},
 			},
+			ServerInitiated: true,
 		},
 	}, session, nil)
 	if err != nil {
@@ -130,6 +131,7 @@ func queryWorkspace(value, field string, session *sess.Session, connection adapt
 				},
 			},
 			RequireWriteAccess: true,
+			ServerInitiated:    true,
 		},
 		session.RemoveWorkspaceContext(),
 	)

--- a/apps/platform/pkg/featureflagstore/platform/platform.go
+++ b/apps/platform/pkg/featureflagstore/platform/platform.go
@@ -28,6 +28,7 @@ func (ffs *FeatureFlagStore) Get(user string, assignments *meta.FeatureFlagAssig
 					Operator: "=",
 				},
 			},
+			ServerInitiated: true,
 		},
 		session,
 	)

--- a/apps/platform/pkg/routing/deps.go
+++ b/apps/platform/pkg/routing/deps.go
@@ -285,7 +285,7 @@ func processView(key string, viewInstanceID string, deps *PreloadMetadata, param
 	}
 
 	if viewInstanceID != "" {
-		ops := []*adapt.LoadOp{}
+		var ops []*adapt.LoadOp
 
 		for _, pair := range depMap.Wires {
 
@@ -313,7 +313,12 @@ func processView(key string, viewInstanceID string, deps *PreloadMetadata, param
 			return err
 		}
 
-		for _, collection := range metadata.Collections {
+		for _, collectionCache := range metadata.Collections {
+			// Ignore collections we only needed for transient server-side processing
+			if !collectionCache.IsClientDependency() {
+				continue
+			}
+			collection := collectionCache.GetValue()
 			// If this collection is already in the metadata, we need to merge the new and existing
 			// to create a union of all metadata requested by any wires
 			if existingItem, alreadyExists := deps.Collection.AddItemIfNotExists(collection); alreadyExists {

--- a/apps/platform/pkg/secretstore/platform/platform.go
+++ b/apps/platform/pkg/secretstore/platform/platform.go
@@ -26,6 +26,7 @@ func (ss *SecretStore) Get(key string, session *sess.Session) (string, error) {
 					ID: "uesio/core.value",
 				},
 			},
+			ServerInitiated: true,
 		},
 		session,
 	)

--- a/libs/apps/uesio/tests/hurl_specs/allmetadata.hurl
+++ b/libs/apps/uesio/tests/hurl_specs/allmetadata.hurl
@@ -49,6 +49,10 @@ jsonpath "$.wires[0].data[3]['uesio/core.uniquekey']" == "uesio/tests.animal:ues
 jsonpath "$.wires[0].data[4]['uesio/core.uniquekey']" == "uesio/tests.animal:uesio/tests.species"
 jsonpath "$.wires[0].data[5]['uesio/core.uniquekey']" == "uesio/tests.animal:uesio/tests.status"
 jsonpath "$.wires[0].data[6]['uesio/core.uniquekey']" == "uesio/tests.animal:uesio/tests.total_population"
+jsonpath "$.collections[*]['name']" count < 10 # We should not be fetching a ton of studio collections
+jsonpath "$.collections['uesio/studio.field']['name']" == "field"
+jsonpath "$.collections['uesio/studio.field']['namespace']" == "uesio/studio"
+# jsonpath "$.collections['uesio/studio.field']['fields'][*]['name']" count == 3
 
 # Get a list of common fields available to our workspace for the animal collection
 POST https://{{host}}:{{port}}/site/wires/load


### PR DESCRIPTION
# What does this PR do?

closes #3030 

1. Introduces the concept of a "transient" collection dependency, to allow us server-side in Go to request metadata for a collection without causing it to be sent to the client. Leverages this for access fields and reference group processing. (Potentially there are other places we could use this as well).

This massively reduces the number of Collections' metadata being sent to the browser, in the Studio particularly

## Redux collections before changes

<img width="852" alt="Screen Shot 2023-09-26 at 3 17 33 PM" src="https://github.com/TheCloudMasters/uesio/assets/886865/073e84ee-cfb8-449f-9209-92f2e3c2f48f">


## Redux collections AFTER changes

<img width="807" alt="Screen Shot 2023-09-26 at 3 53 58 PM" src="https://github.com/TheCloudMasters/uesio/assets/886865/b211bc8b-eab4-4182-a786-877df0f58a9b">

