### PR TITLE
Nicer validation errors when deploying yaml

### DIFF
--- a/apps/platform/pkg/validation/yamlschema.go
+++ b/apps/platform/pkg/validation/yamlschema.go
@@ -8,28 +8,17 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-const (
-	InfoColor    = "\033[1;34m%s\033[0m"
-	NoticeColor  = "\033[1;36m%s\033[0m"
-	WarningColor = "\033[1;33m%s\033[0m"
-	ErrorColor   = "\033[1;31m%s\033[0m"
-	DebugColor   = "\033[0;36m%s\033[0m"
-)
+const WarningColor = "\033[1;33m%s\033[0m"
 
 type customLocale struct {
 	gojsonschema.DefaultLocale
 }
 
-const (
-	Const                        = "value does not match: {{.allowed}}"
-	AdditionalPropertyNotAllowed = "Additional property \033[0;36m{{.property}}\033[0m is not allowed"
-)
-
 func (l customLocale) Const() string {
-	return fmt.Sprintf(WarningColor, Const)
+	return fmt.Sprintf(WarningColor, "value does not match: {{.allowed}}")
 }
 func (l customLocale) AdditionalPropertyNotAllowed() string {
-	return fmt.Sprintf(WarningColor, AdditionalPropertyNotAllowed)
+	return fmt.Sprintf(WarningColor, "Additional property \033[0;36m{{.property}}\033[0m is not allowed")
 }
 
 // ValidateYaml validates YAML content against a target schema,

--- a/apps/platform/pkg/validation/yamlschema.go
+++ b/apps/platform/pkg/validation/yamlschema.go
@@ -2,15 +2,43 @@ package validation
 
 import (
 	"errors"
+	"fmt"
+
 	"github.com/xeipuuv/gojsonschema"
 	"gopkg.in/yaml.v3"
 )
+
+const (
+	InfoColor    = "\033[1;34m%s\033[0m"
+	NoticeColor  = "\033[1;36m%s\033[0m"
+	WarningColor = "\033[1;33m%s\033[0m"
+	ErrorColor   = "\033[1;31m%s\033[0m"
+	DebugColor   = "\033[0;36m%s\033[0m"
+)
+
+type customLocale struct {
+	gojsonschema.DefaultLocale
+}
+
+const (
+	Const                        = "value does not match: {{.allowed}}"
+	AdditionalPropertyNotAllowed = "Additional property \033[0;36m{{.property}}\033[0m is not allowed"
+)
+
+func (l customLocale) Const() string {
+	return fmt.Sprintf(WarningColor, Const)
+}
+func (l customLocale) AdditionalPropertyNotAllowed() string {
+	return fmt.Sprintf(WarningColor, AdditionalPropertyNotAllowed)
+}
 
 // ValidateYaml validates YAML content against a target schema,
 // returning a Result object with the validation results.
 // If the YAML content is invalid syntactically, an error will be returned,
 // and no schema validation will be performed.
 func ValidateYaml(yamlSchema *gojsonschema.Schema, yamlText []byte) (*gojsonschema.Result, error) {
+	gojsonschema.Locale = customLocale{}
+
 	// Load the YAML into a document that can be validated
 	var document map[interface{}]interface{}
 	if err := yaml.Unmarshal(yamlText, &document); err != nil {


### PR DESCRIPTION
# What does this PR do?


Old:
<img width="1389" alt="image" src="https://github.com/TheCloudMasters/uesio/assets/38309266/930ab011-b457-490b-a265-b310a2c69f5b">

New:
<img width="669" alt="image" src="https://github.com/TheCloudMasters/uesio/assets/38309266/a3e14eee-b8b1-4c55-9792-35bf7a83a601">

Maybe we can get rid of the `Field 'Definition' failed YAML schema validations:` entirely?
I'm not sure where the trailing `:` is coming from after the first error block:
<img width="45" alt="image" src="https://github.com/TheCloudMasters/uesio/assets/38309266/c8ac223e-62e2-45ae-8ab9-af4a85ee5703">

# Testing

If relevant, explain how to test the change locally
