### PR TITLE
[PARKED] fix: FIELD of type USER should show the right users in workspace

### DIFF
--- a/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/field/user.tsx
+++ b/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/field/user.tsx
@@ -28,7 +28,11 @@ const UserField: definition.UtilityComponent<UserFieldProps> = (props) => {
 		return (
 			<ReferenceField
 				{...props}
-				options={refoptions}
+				context={context.deleteWorkspace()}
+				options={{
+					...refoptions,
+					requirewriteaccess: true,
+				}}
 				setValue={setValue}
 			/>
 		)

--- a/libs/apps/uesio/studio/bundle/recordchallengetokens/uesio/core/user/teammember2.yaml
+++ b/libs/apps/uesio/studio/bundle/recordchallengetokens/uesio/core/user/teammember2.yaml
@@ -1,0 +1,4 @@
+name: teammember2
+token: "${uesio/core.id}"
+useraccesstoken: "uesio/studio.teammember"
+access: read


### PR DESCRIPTION
# What does this PR do?

Some context:

- in the workspace context we give full access to all collections using the GetAdminPermissionSet function, since the variable ViewAllRecords is true we skip the AccessCheck.

- I force the component to always use the "site" context so we get the records that we expect by using the function deleteWorkspace.

Basically, we never query for users from a WS context, since doing this will give us all users.
I think we need to add more Record Challenge Tokens to get also the team members etc. (doing this in my local testing it out)


# Testing

If relevant, explain how to test the change locally
