### PR TITLE
Fix builder scrolling

### DIFF
--- a/libs/apps/uesio/builder/bundle/componentpacks/main/src/components/mainwrapper/canvas.tsx
+++ b/libs/apps/uesio/builder/bundle/componentpacks/main/src/components/mainwrapper/canvas.tsx
@@ -13,6 +13,11 @@ import SelectBorder from "./selectborder"
 import { getDragOverHandler, getDropHandler } from "../../helpers/dragdrop"
 import { get } from "../../api/defapi"
 
+interface BasicEvent {
+	stopPropagation: () => void
+	preventDefault: () => void
+}
+
 const Canvas: FunctionComponent<definition.UtilityProps> = (props) => {
 	const context = props.context
 
@@ -67,6 +72,11 @@ const Canvas: FunctionComponent<definition.UtilityProps> = (props) => {
 	const contentRef = useRef<HTMLDivElement>(null)
 
 	if (!route || !viewDefId || !viewDef) return null
+
+	const onChangeCapture = (e: BasicEvent) => {
+		e.stopPropagation()
+		e.preventDefault()
+	}
 
 	const onClickCapture = (e: MouseEvent) => {
 		e.stopPropagation()
@@ -133,6 +143,7 @@ const Canvas: FunctionComponent<definition.UtilityProps> = (props) => {
 						onDragLeave={onDragLeave}
 						onDrop={onDrop}
 						onClickCapture={onClickCapture}
+						onChangeCapture={onChangeCapture}
 					>
 						{props.children}
 					</div>

--- a/libs/apps/uesio/builder/bundle/componentpacks/main/src/components/mainwrapper/canvas.tsx
+++ b/libs/apps/uesio/builder/bundle/componentpacks/main/src/components/mainwrapper/canvas.tsx
@@ -70,6 +70,7 @@ const Canvas: FunctionComponent<definition.UtilityProps> = (props) => {
 
 	const onClickCapture = (e: MouseEvent) => {
 		e.stopPropagation()
+		e.preventDefault()
 		// Step 1: Find the closest slot that is accepting the current dragpath.
 		let target = document.elementFromPoint(e.clientX, e.clientY)
 		if (!target) return


### PR DESCRIPTION
# What does this PR do?

1. uses onClickCapture in the canvas to cancel any click events there. This way it can use clicking only for selection. All events in the canvas will still work though. But later we can use event capturing to capture those events too if we wanted.

# Testing

1. The builder should work as before. Selection of components should work, and components in the canvas should not perform their normal behavior when clicked.
2. You should also be able to scroll using your mouse's scrollwheel.
