### PR TITLE
fix(tests): Switch to route/REDIRECT for App and Workspace creation

### DIFF
--- a/libs/apps/uesio/studio/bundle/views/appnav.yaml
+++ b/libs/apps/uesio/studio/bundle/views/appnav.yaml
@@ -346,7 +346,7 @@ definition:
               - signal: "wire/SAVE"
                 wires:
                   - newworkspace
-              - signal: "route/NAVIGATE"
+              - signal: "route/REDIRECT"
                 path: "app/$Param{app}/workspace/${newworkspace:uesio/studio.name}"
         - uesio/io.button:
             uesio.variant: "uesio/io.secondary"

--- a/libs/apps/uesio/studio/bundle/views/homeleftnav.yaml
+++ b/libs/apps/uesio/studio/bundle/views/homeleftnav.yaml
@@ -259,7 +259,7 @@ definition:
               - signal: wire/SAVE
                 wires:
                   - "newapp"
-              - signal: "route/NAVIGATE"
+              - signal: "route/REDIRECT"
                 path: "app/${uesio/core.uniquekey}"
         - uesio/io.button:
             uesio.variant: "uesio/io.secondary"


### PR DESCRIPTION
# What does this PR do?

This is an experiment to see if using route/REDIRECT is a more reliable way to navigate for the purposes of Cypress tests when creating apps and workspaces initially.

