### PR TITLE
ci: Publish to Github container registry on release tag push

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,4 @@
-name: Uesio CLI Release
+name: Uesio Release
 
 on:
   workflow_dispatch:
@@ -13,6 +13,13 @@ on:
         required: true
         default: "# Bug fixes\n - Fix One\n\n# Features\n - Feature one"
         type: string
+    secrets:
+      AWS_ACCOUNT_ID_DEV:
+        required: true
+      AWS_ECR_ROLE_DEV:
+        required: true
+      AWS_REGION_DEV:
+        required: true
 
 # Request permissions to be able to create releases
 permissions:
@@ -34,7 +41,54 @@ jobs:
             echo "Invalid release tag: $releaseTag"
             exit 1
           fi
-  publish:
+  docker_publish_to_ghcr:
+    name: Publish to GitHub Container Registry
+    runs-on: ubuntu-latest
+    needs:
+      - validate
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+      - name: Login to GitHub Container Registry
+        run: echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ secrets.AWS_ECR_ROLE_DEV }}
+          role-session-name: ecrpull
+          aws-region: ${{ secrets.AWS_REGION_DEV }}
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1.6.0
+      - name: Pull the latest Docker image from ECR
+        shell: bash
+        env:
+          FULL_SHA: ${{ github.sha }}
+          REGISTRY_ID: ${{ secrets.AWS_ACCOUNT_ID_DEV }}
+          IMAGE_TAG: ${{ steps.login-ecr.outputs.registry }}/uesio:${{ github.sha }}
+          GHCR_IMAGE_TAG_BASE: ghcr.io/${{ github.repository }}
+          RELEASE_TAG: ${{ inputs.releaseTag }}
+        run: |
+
+          # Make sure that the Docker image for this commit exists in ECR
+          image_exists=$(bash ./scripts/ecr-image-exists.sh $REGISTRY_ID uesio $FULL_SHA)
+
+          if [[ "$image_exists" == "no" ]]; then
+              echo "Docker image does not exist in ECR"
+              exit 1
+          fi
+
+          echo "Pulling Docker image from ECR..."
+          docker pull $IMAGE_TAG --all-tags
+          echo "Pushing tag $RELEASE_TAG to Github Container Registry..."=
+          docker tag $IMAGE_TAG $GHCR_IMAGE_BASE:$RELEASE_TAG
+          docker push GHCR_IMAGE_TAG_BASE:$RELEASE_TAG
+          echo "Pushing latest tag to Github Container Registry..."
+          docker tag $IMAGE_TAG $GHCR_IMAGE_BASE:latest
+          docker push GHCR_IMAGE_TAG_BASE:latest
+  cli_release:
     name: Build asset for ${{ matrix.goos }} - ${{ matrix.goarch }}
     runs-on: ${{ matrix.os }}
     needs:
@@ -96,5 +150,5 @@ jobs:
           asset_name: "${{ matrix.asset_name }}-${{ env.releaseTag }}"
           tag: ${{ env.releaseTag }}
           overwrite: true
-          release_name: "Uesio CLI: ${{ env.releaseTag }}"
+          release_name: "Uesio: ${{ env.releaseTag }}"
           body: ${{ env.releaseNotes }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,18 +1,9 @@
 name: Uesio Release
 
 on:
-  workflow_dispatch:
-    inputs:
-      releaseTag:
-        description: "Release tag"
-        required: true
-        default: "v0-0-1"
-        type: string
-      releaseNotes:
-        description: "Release notes"
-        required: true
-        default: "# Bug fixes\n - Fix One\n\n# Features\n - Feature one"
-        type: string
+  push:
+    tags:
+      - "v*"
     secrets:
       AWS_ACCOUNT_ID_DEV:
         required: true
@@ -27,25 +18,9 @@ permissions:
   contents: write # This is required for actions/checkout
 
 jobs:
-  validate:
-    name: Validate inputs
-    runs-on: ubuntu-latest
-    steps:
-      - name: Validate workflow inputs
-        shell: bash
-        env:
-          releaseTag: ${{ inputs.releaseTag }}
-        run: |
-          pattern="^v[0-9]{1,3}-[0-9]{1,3}-[0-9]{1,3}$"
-          if [[ ! $releaseTag =~ $pattern ]]; then
-            echo "Invalid release tag: $releaseTag"
-            exit 1
-          fi
   docker_publish_to_ghcr:
     name: Publish to GitHub Container Registry
     runs-on: ubuntu-latest
-    needs:
-      - validate
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -69,7 +44,7 @@ jobs:
           REGISTRY_ID: ${{ secrets.AWS_ACCOUNT_ID_DEV }}
           IMAGE_TAG: ${{ steps.login-ecr.outputs.registry }}/uesio:${{ github.sha }}
           GHCR_IMAGE_TAG_BASE: ghcr.io/${{ github.repository }}
-          RELEASE_TAG: ${{ inputs.releaseTag }}
+          RELEASE_TAG: ${{ github.ref_name }}
         run: |
 
           # Make sure that the Docker image for this commit exists in ECR
@@ -88,14 +63,9 @@ jobs:
           echo "Pushing latest tag to Github Container Registry..."
           docker tag $IMAGE_TAG $GHCR_IMAGE_BASE:latest
           docker push GHCR_IMAGE_TAG_BASE:latest
-  cli_release:
+  cli_release_artifacts:
     name: Build asset for ${{ matrix.goos }} - ${{ matrix.goarch }}
     runs-on: ${{ matrix.os }}
-    needs:
-      - validate
-    env:
-      releaseTag: ${{ inputs.releaseTag }}
-      releaseNotes: ${{ inputs.releaseNotes }}
     strategy:
       matrix:
         include:
@@ -141,14 +111,10 @@ jobs:
           cd apps/cli
           GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -o $outputPath
           cd ../..
-      - name: Upload binaries to release
-        uses: svenstaro/upload-release-action@v2
+      - name: Upload release artifact
+        uses: Roang-zero1/github-upload-release-artifacts-action@v2
+        with:
+          args: "apps/cli/dist/${{ matrix.asset_name }}/${{ matrix.artifact_name }}"
+          created_tag: ${{ github.ref_name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          file: apps/cli/dist/${{ matrix.asset_name }}/${{ matrix.artifact_name }}
-          asset_name: "${{ matrix.asset_name }}-${{ env.releaseTag }}"
-          tag: ${{ env.releaseTag }}
-          overwrite: true
-          release_name: "Uesio: ${{ env.releaseTag }}"
-          body: ${{ env.releaseNotes }}


### PR DESCRIPTION
# What does this PR do?

Modifies the release workflow to be the following:

1. Whenever a new "v*" tag is pushed, e.g. "v1.0.0", this workflow is run. The expectation is that a Github Release will already exist before this happens.
2. CLI assets for each OS/arch are created and then uploaded to the Github Release corresponding to this tag.
3. The existing Docker image in ECR will be pulled and then republished to GHCR with the version tag as well as the "latest" tag
