### PR TITLE
Allow studio to work on localhost

### DIFF
--- a/apps/platform/pkg/bot/systemdialect/systembot_load_blogentry.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_load_blogentry.go
@@ -2,12 +2,13 @@ package systemdialect
 
 import (
 	"github.com/thecloudmasters/uesio/pkg/auth"
+	"github.com/thecloudmasters/uesio/pkg/env"
 	"github.com/thecloudmasters/uesio/pkg/sess"
 	"github.com/thecloudmasters/uesio/pkg/types/wire"
 )
 
 func runBlogEntryLoadBot(op *wire.LoadOp, connection wire.Connection, session *sess.Session) error {
-	site, err := auth.GetSiteFromHost(session.GetSite().Domain)
+	site, err := auth.GetSiteFromHost(env.GetPrimaryDomain())
 	if err != nil {
 		//Ignore the errors if the site is not found
 		return nil

--- a/apps/platform/pkg/bot/systemdialect/systembot_load_recentdoc.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_load_recentdoc.go
@@ -3,6 +3,7 @@ package systemdialect
 import (
 	"github.com/thecloudmasters/uesio/pkg/auth"
 	"github.com/thecloudmasters/uesio/pkg/datasource"
+	"github.com/thecloudmasters/uesio/pkg/env"
 	"github.com/thecloudmasters/uesio/pkg/meta"
 	"github.com/thecloudmasters/uesio/pkg/sess"
 	"github.com/thecloudmasters/uesio/pkg/types/wire"
@@ -65,7 +66,7 @@ func getArticleLoad(op *wire.LoadOp, connection wire.Connection, session *sess.S
 }
 
 func runRecentDocLoadBot(op *wire.LoadOp, connection wire.Connection, session *sess.Session) error {
-	site, err := auth.GetSiteFromHost("docs." + session.GetSite().Domain)
+	site, err := auth.GetSiteFromHost("docs." + env.GetPrimaryDomain())
 	if err != nil {
 		//Ignore the errors if the site is not found
 		return nil


### PR DESCRIPTION
# What does this PR do?

Allows the studio to work locally at `localhost:3000`

# Testing

1. Turn off SSL by setting the `UESIO_USE_HTTPS` environment variable to false.
2. Visit the studio locally at `localhost:3000`
