### PR TITLE
ci: Build and upload artifacts separately

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -102,15 +102,32 @@ jobs:
       - name: Build CLI
         shell: bash
         env:
-          outputPath: "dist/${{ matrix.asset_name }}/${{ matrix.artifact_name }}"
+          outputPath: "dist/bin/${{ matrix.artifact_name }}"
         run: |
           cd apps/cli
           GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -o $outputPath
           cd ../..
-      - name: Upload release artifact
+      - name: Upload binary artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: binaries
+          path: |
+            apps/cli/dist/bin/${{ matrix.artifact_name }}
+  upload_release_binaries:
+    name: Upload binaries to release
+    runs-on: ubuntu-latest
+    needs:
+      - cli_release_artifacts
+    steps:
+      - name: Download binary artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: binaries
+          path: binaries
+      - name: Upload release artifacts
         uses: Roang-zero1/github-upload-release-artifacts-action@v2
         with:
-          args: "apps/cli/dist/${{ matrix.asset_name }}/${{ matrix.artifact_name }}"
+          args: "binaries/uesio.exe binaries/uesio-macos-amd64 binaries/uesio-macos-arm64 binaries/uesio-linux"
           created_tag: ${{ github.ref_name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# What does this PR do?

In order to get Windows and Mac release binaries to work, we have to build them, temporarily store them in GH artifacts, then upload them to the GH release separately running on a Linux runner.