### PR TITLE
fix: Remove unnecessary docker pull --all-tags

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,7 +57,7 @@ jobs:
           fi
 
           echo "Pulling Docker image from ECR..."
-          docker pull $IMAGE_TAG --all-tags
+          docker pull $IMAGE_TAG
           echo "Pushing tag $RELEASE_TAG to Github Container Registry..."=
           docker tag $IMAGE_TAG $GHCR_IMAGE_BASE:$RELEASE_TAG
           docker push GHCR_IMAGE_TAG_BASE:$RELEASE_TAG


### PR DESCRIPTION
# What does this PR do?

`--all-tags` is unnecessary when requesting a specific tag already.
