### PR TITLE
Omit empty builtin user fields

### DIFF
--- a/apps/platform/pkg/meta/metadata.go
+++ b/apps/platform/pkg/meta/metadata.go
@@ -29,11 +29,11 @@ type BuiltIn struct {
 	ID        string    `yaml:"-" json:"uesio/core.id"`
 	UniqueKey string    `yaml:"-" json:"uesio/core.uniquekey"`
 	itemMeta  *ItemMeta `yaml:"-" json:"-"`
-	CreatedBy *User     `yaml:"-" json:"uesio/core.createdby"`
-	Owner     *User     `yaml:"-" json:"uesio/core.owner"`
-	UpdatedBy *User     `yaml:"-" json:"uesio/core.updatedby"`
-	UpdatedAt int64     `yaml:"-" json:"uesio/core.updatedat"`
-	CreatedAt int64     `yaml:"-" json:"uesio/core.createdat"`
+	CreatedBy *User     `yaml:"-" json:"uesio/core.createdby,omitempty"`
+	Owner     *User     `yaml:"-" json:"uesio/core.owner,omitempty"`
+	UpdatedBy *User     `yaml:"-" json:"uesio/core.updatedby,omitempty"`
+	UpdatedAt int64     `yaml:"-" json:"uesio/core.updatedat,omitempty"`
+	CreatedAt int64     `yaml:"-" json:"uesio/core.createdat,omitempty"`
 }
 
 func (bi *BuiltIn) SetModified(mod time.Time) {

--- a/apps/platform/pkg/reflecttool/tags.go
+++ b/apps/platform/pkg/reflecttool/tags.go
@@ -3,6 +3,7 @@ package reflecttool
 import (
 	"errors"
 	"reflect"
+	"strings"
 	"sync"
 )
 
@@ -72,7 +73,8 @@ func addTags(tagMap map[string]string, objType reflect.Type) {
 			if tag == "-" || tag == "" {
 				continue
 			}
-			tagMap[tag] = structField.Name
+			parts := strings.Split(tag, ",")
+			tagMap[parts[0]] = structField.Name
 		}
 	}
 }


### PR DESCRIPTION
# What does this PR do?

I came across this while inspecting some information that was stored in redis. There were a lot of null keys for these fields since they weren't queried. Since these are part of every object, it's nice to omit them if they are empty.

# Testing

Everything should work the same as before.
