### PR TITLE
ci: Add write-all permissions to fix GHCR publish

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,6 +22,7 @@ jobs:
   docker_publish_to_ghcr:
     name: Publish to GitHub Container Registry
     runs-on: ubuntu-latest
+    permissions: write-all
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
# What does this PR do?

The publish to GHCR is still failing, this change should fix the latest error from the most recent build.