### PR TITLE
Adds instance administration section

### DIFF
--- a/libs/apps/uesio/studio/bundle/permissionsets/admin.yaml
+++ b/libs/apps/uesio/studio/bundle/permissionsets/admin.yaml
@@ -1,8 +1,11 @@
 name: admin
 views:
+  uesio/studio.admin: true
+  uesio/studio.adminnav: true
   uesio/studio.sitemanagebundles: true
   uesio/studio.sitemanageappbundles: true
 routes:
+  uesio/studio.admin: true
   uesio/studio.sitemanagebundles: true
   uesio/studio.sitemanageappbundles: true
 collections:

--- a/libs/apps/uesio/studio/bundle/routes/admin.yaml
+++ b/libs/apps/uesio/studio/bundle/routes/admin.yaml
@@ -1,0 +1,5 @@
+name: admin
+path: admin
+view: admin
+theme: default
+title: Instance Admin

--- a/libs/apps/uesio/studio/bundle/routes/sitemanageappbundles.yaml
+++ b/libs/apps/uesio/studio/bundle/routes/sitemanageappbundles.yaml
@@ -1,5 +1,8 @@
 name: sitemanageappbundles
-path: app/{app:\w*\/\w*}/site/{sitename}/managebundles/{appBundle:\w*\/\w*}
+path: managebundles/{appBundle:\w*\/\w*}
 view: sitemanageappbundles
 theme: default
 title: Manage App Bundles
+params:
+  app: "uesio/studio"
+  sitename: "prod"

--- a/libs/apps/uesio/studio/bundle/routes/sitemanagebundles.yaml
+++ b/libs/apps/uesio/studio/bundle/routes/sitemanagebundles.yaml
@@ -1,5 +1,8 @@
 name: sitemanagebundles
-path: app/{app:\w*\/\w*}/site/{sitename}/managebundles
+path: managebundles
 view: sitemanagebundles
 theme: default
 title: Manage Bundles
+params:
+  app: "uesio/studio"
+  sitename: "prod"

--- a/libs/apps/uesio/studio/bundle/views/admin.yaml
+++ b/libs/apps/uesio/studio/bundle/views/admin.yaml
@@ -1,0 +1,23 @@
+name: admin
+definition:
+  # Wires are how we pull in data
+  wires:
+  # Components are how we describe the layout of our view
+  components:
+    - uesio/io.viewlayout:
+        uesio.variant: uesio/studio.main
+        left:
+          - uesio/core.view:
+              view: adminnav
+              params:
+                selected: home
+        content:
+          - uesio/io.titlebar:
+              uesio.variant: uesio/io.main
+              title: Instance Administration
+              subtitle: You're the boss.
+          - uesio/io.box:
+              uesio.variant: uesio/io.section
+              components:
+                - uesio/io.text:
+                    text: This is where you manage your ues.io instance. More features are coming here soon.

--- a/libs/apps/uesio/studio/bundle/views/adminnav.yaml
+++ b/libs/apps/uesio/studio/bundle/views/adminnav.yaml
@@ -1,0 +1,66 @@
+name: adminnav
+definition:
+  # Wires are how we pull in data
+  wires:
+  # Components are how we describe the layout of our view
+  components:
+    - uesio/io.scrollpanel:
+        uesio.variant: uesio/studio.left
+        header:
+          - uesio/core.view:
+              view: appcrumb
+          - uesio/core.view:
+              view: crumbsbar
+              params:
+                itemType: $Param{itemType}
+                itemIcon: $Param{itemIcon}
+                itemName: $Param{itemName}
+                itemNameSpace: $Param{itemNameSpace}
+                itemNameSpaceIcon: $Param{itemNameSpaceIcon}
+                itemNameSpaceColor: $Param{itemNameSpaceColor}
+                subItemType: $Param{subItemType}
+                subItemName: $Param{subItemName}
+                subItemNameSpace: $Param{subItemNameSpace}
+        content:
+          - uesio/io.navsection:
+              title: Instance Admin
+              content:
+                - uesio/io.tile:
+                    uesio.variant: uesio/io.nav
+                    uesio.id: home
+                    uesio.classes:
+                      selected:
+                        - type: paramValue
+                          param: selected
+                          value: home
+                    signals:
+                      - signal: "route/NAVIGATE"
+                        path: admin
+                    content:
+                      - uesio/io.text:
+                          text: Home
+                    avatar:
+                      - uesio/io.text:
+                          uesio.variant: uesio/io.icon
+                          text: home
+                - uesio/io.tile:
+                    uesio.variant: uesio/io.nav
+                    uesio.id: managebundles
+                    uesio.classes:
+                      selected:
+                        - type: paramValue
+                          param: selected
+                          value: managebundles
+                    signals:
+                      - signal: "route/NAVIGATE"
+                        path: managebundles
+                    content:
+                      - uesio/io.text:
+                          text: Manage Bundles
+                    avatar:
+                      - uesio/io.text:
+                          uesio.variant: uesio/io.icon
+                          text: outbox
+        footer:
+          - uesio/core.view:
+              view: profiletag

--- a/libs/apps/uesio/studio/bundle/views/profiletag.yaml
+++ b/libs/apps/uesio/studio/bundle/views/profiletag.yaml
@@ -16,6 +16,16 @@ definition:
         actions:
           - uesio/io.button:
               uesio.variant: uesio/studio.headernavicon
+              icon: settings
+              uesio.id: settings
+              uesio.display:
+                - type: hasProfile
+                  profile: uesio/studio.admin
+              signals:
+                - signal: "route/NAVIGATE"
+                  path: "admin"
+          - uesio/io.button:
+              uesio.variant: uesio/studio.headernavicon
               icon: logout
               uesio.id: logout
               signals:

--- a/libs/apps/uesio/studio/bundle/views/sitemanageappbundles.yaml
+++ b/libs/apps/uesio/studio/bundle/views/sitemanageappbundles.yaml
@@ -141,9 +141,7 @@ definition:
         uesio.variant: uesio/studio.main
         left:
           - uesio/core.view:
-              view: sitenav
-              uesio.context:
-                wire: sites
+              view: adminnav
               params:
                 selected: managebundles
         content:

--- a/libs/apps/uesio/studio/bundle/views/sitemanagebundles.yaml
+++ b/libs/apps/uesio/studio/bundle/views/sitemanagebundles.yaml
@@ -66,9 +66,7 @@ definition:
         uesio.variant: uesio/studio.main
         left:
           - uesio/core.view:
-              view: sitenav
-              uesio.context:
-                wire: sites
+              view: adminnav
               params:
                 selected: managebundles
         content:
@@ -120,4 +118,4 @@ definition:
                       - text: Details
                         signals:
                           - signal: "route/NAVIGATE"
-                            path: "app/$Param{app}/site/$Param{sitename}/managebundles/${uesio/studio.app->uesio/core.uniquekey}"
+                            path: "managebundles/${uesio/studio.app->uesio/core.uniquekey}"

--- a/libs/apps/uesio/studio/bundle/views/sitenav.yaml
+++ b/libs/apps/uesio/studio/bundle/views/sitenav.yaml
@@ -57,15 +57,6 @@ definition:
                       - field: "uesio/studio.app->uesio/core.uniquekey"
                         value: "uesio/studio"
                 - uesio/studio.sitenavtile:
-                    title: Manage Bundles
-                    icon: outbox
-                    id: managebundles
-                    # Should only be visible to those administering a Studio PROD site
-                    # (which should require write access) on that site
-                    uesio.display:
-                      - field: "uesio/studio.app->uesio/core.uniquekey"
-                        value: "uesio/studio"
-                - uesio/studio.sitenavtile:
                     title: Domains
                     icon: verified_user
                     id: domains


### PR DESCRIPTION
# What does this PR do?

1. Adds the instance adminstration section for users with the uesio/studio.admin profile.
2. Moves the manage bundles section out of the site management settings.

This is preparing the way for a new section where you can add bundles from an external or "prod" bundlestore.

<img width="1369" alt="Screenshot 2024-02-01 at 10 19 44 AM" src="https://github.com/ues-io/uesio/assets/55447225/d567495d-e395-4f62-86e0-54962dc0c9f7">


# Testing

Manage bundles should work the same as before.
