### PR TITLE
Fix select with a panel behind it auto-closing

### DIFF
--- a/libs/apps/uesio/builder/bundle/componentpacks/main/src/api/stateapi.ts
+++ b/libs/apps/uesio/builder/bundle/componentpacks/main/src/api/stateapi.ts
@@ -410,6 +410,7 @@ const getComponentIdsOfType = (
 	const componentIds = [] as string[]
 	if (componentType) {
 		walkViewComponents(context, (type, definition) => {
+			if (!definition) return true
 			const { [COMPONENT_ID]: id } = definition
 			if (type === componentType && id) {
 				componentIds.push(id as string)
@@ -423,6 +424,7 @@ const getComponentIdsOfType = (
 const getComponentById = (context: ctx.Context, componentId: string) => {
 	let targetComponentDef: definition.BaseDefinition | undefined
 	walkViewComponents(context, (_, definition) => {
+		if (!definition) return true
 		const { [COMPONENT_ID]: id } = definition
 		if (id === componentId) {
 			targetComponentDef = definition

--- a/libs/apps/uesio/builder/bundle/componentpacks/main/src/components/mainwrapper/canvas.tsx
+++ b/libs/apps/uesio/builder/bundle/componentpacks/main/src/components/mainwrapper/canvas.tsx
@@ -1,4 +1,10 @@
-import { DragEvent, FunctionComponent, MouseEvent, useRef } from "react"
+import {
+	DragEvent,
+	FormEvent,
+	FunctionComponent,
+	MouseEvent,
+	useRef,
+} from "react"
 import { definition, styles, api, component } from "@uesio/ui"
 import {
 	useBuilderState,
@@ -12,11 +18,6 @@ import { FullPath } from "../../api/path"
 import SelectBorder from "./selectborder"
 import { getDragOverHandler, getDropHandler } from "../../helpers/dragdrop"
 import { get } from "../../api/defapi"
-
-interface BasicEvent {
-	stopPropagation: () => void
-	preventDefault: () => void
-}
 
 const Canvas: FunctionComponent<definition.UtilityProps> = (props) => {
 	const context = props.context
@@ -73,7 +74,7 @@ const Canvas: FunctionComponent<definition.UtilityProps> = (props) => {
 
 	if (!route || !viewDefId || !viewDef) return null
 
-	const onChangeCapture = (e: BasicEvent) => {
+	const onChangeCapture = (e: FormEvent) => {
 		e.stopPropagation()
 		e.preventDefault()
 	}

--- a/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/popper/popper.tsx
+++ b/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/popper/popper.tsx
@@ -99,6 +99,13 @@ const Popper: definition.UtilityComponent<TooltipProps> = (props) => {
 						? "hidden"
 						: "visible",
 				}}
+				onClick={(e) => {
+					// This is important because it stops events from propagating
+					// under the popper. One example was that the FloatingOverlay
+					// component behind the dialog was causing select boxes to
+					// immediately close if the FloatingOverlay was behind this popper.
+					e.stopPropagation()
+				}}
 				className={classes.popper}
 			>
 				{props.children}


### PR DESCRIPTION
# What does this PR do?

Fixes #3807 . You should now be able to select on-close signals for a panel.

# Testing

Follow the repro steps in #3807 You should no longer be able to repro this.
