### PR TITLE
fix: unable to create collection after save bots

### DIFF
--- a/libs/apps/uesio/core/bundle/bots/generator/bot/bot.js
+++ b/libs/apps/uesio/core/bundle/bots/generator/bot/bot.js
@@ -18,7 +18,7 @@ function bot(botapi) {
 	// Create the corresponding bot's TS and YAML files
 	let path = `bots/${type}`
 	if (type === "aftersave" || type === "beforesave") {
-		path += `/${collection.replaceAll(".", "/")}`
+		path += `/${collection.replace(".", "/")}`
 	}
 	path += `/${name}/bot`
 	botapi.generateFile(


### PR DESCRIPTION
# What does this PR do?

I wasn't able to create an after-save bot, I think Goja doesn't support the replaceAll function.
In any case, I think we don't need to replace all since a collection should be **_WWW/KKK.QQQ_**

# Testing

Try to create an after-save bot
