### PR TITLE
Fix race condition for common fields

### DIFF
--- a/apps/platform/pkg/datasource/builtin.go
+++ b/apps/platform/pkg/datasource/builtin.go
@@ -6,14 +6,16 @@ import (
 	"github.com/thecloudmasters/uesio/pkg/types/wire"
 )
 
-var COMMON_COLLECTION_METADATA = wire.CollectionMetadata{
-	Name:        "common",
-	Namespace:   "uesio/core",
-	Label:       "Common",
-	PluralLabel: "Common",
-	Fields:      map[string]*wire.FieldMetadata{},
-	Type:        "DYNAMIC",
-	NameField:   commonfields.UniqueKey,
+func GetCommonCollectionMetadata() *wire.CollectionMetadata {
+	return &wire.CollectionMetadata{
+		Name:        "common",
+		Namespace:   "uesio/core",
+		Label:       "Common",
+		PluralLabel: "Common",
+		Fields:      map[string]*wire.FieldMetadata{},
+		Type:        "DYNAMIC",
+		NameField:   commonfields.UniqueKey,
+	}
 }
 
 var ID_FIELD_DEF = meta.Field{

--- a/apps/platform/pkg/datasource/metadata.go
+++ b/apps/platform/pkg/datasource/metadata.go
@@ -228,7 +228,7 @@ func LoadCollectionMetadata(key string, metadataCache *wire.MetadataCache, sessi
 
 	// special handling for the common collection metadata
 	if key == constant.CommonCollection {
-		collectionMetadata = &COMMON_COLLECTION_METADATA
+		collectionMetadata = GetCommonCollectionMetadata()
 		metadataCache.AddCollection(key, collectionMetadata)
 		return collectionMetadata, nil
 	}


### PR DESCRIPTION
# What does this PR do?

We were getting a `fatal error: concurrent map writes` error when using MULTI-REFERENCE fields in production. The issue is that we were writing to this Fields map on the collection metadata concurrently.

This PR changes it so that a new Fields map is created every time we get common field metadata.


