### PR TITLE
Simplify Create Bundle

### DIFF
--- a/apps/platform/pkg/bot/systemdialect/systembot_listener_createbundle.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_listener_createbundle.go
@@ -130,7 +130,7 @@ func createNewBundle(data []byte, bundle *meta.Bundle, params map[string]interfa
 	}
 
 	dest, err := bundlestore.GetConnection(bundlestore.ConnectionOptions{
-		Namespace: bundle.BuiltIn.UniqueKey,
+		Namespace: bundle.App.UniqueKey,
 		Version:   bundle.GetVersionString(),
 		Context:   session.Context(),
 	})

--- a/apps/platform/pkg/bot/systemdialect/systembot_listener_createbundle.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_listener_createbundle.go
@@ -1,22 +1,16 @@
 package systemdialect
 
 import (
-	"archive/zip"
 	"bytes"
 	"fmt"
-	"io"
 	"strconv"
-
-	"golang.org/x/sync/errgroup"
 
 	"github.com/thecloudmasters/uesio/pkg/bundlestore"
 	"github.com/thecloudmasters/uesio/pkg/constant/commonfields"
 	"github.com/thecloudmasters/uesio/pkg/datasource"
 	"github.com/thecloudmasters/uesio/pkg/filesource"
 	"github.com/thecloudmasters/uesio/pkg/meta"
-	"github.com/thecloudmasters/uesio/pkg/retrieve"
 	"github.com/thecloudmasters/uesio/pkg/sess"
-	"github.com/thecloudmasters/uesio/pkg/types"
 	"github.com/thecloudmasters/uesio/pkg/types/exceptions"
 	"github.com/thecloudmasters/uesio/pkg/types/wire"
 )
@@ -95,10 +89,6 @@ func runCreateBundleListenerBot(params map[string]interface{}, connection wire.C
 		return nil, err
 	}
 
-	if err = datasource.PlatformSaveOne(bundle, nil, connection, session); err != nil {
-		return nil, err
-	}
-
 	source, err := bundlestore.GetConnection(bundlestore.ConnectionOptions{
 		Namespace:  appID,
 		Version:    workspace.Name,
@@ -110,57 +100,17 @@ func runCreateBundleListenerBot(params map[string]interface{}, connection wire.C
 		return nil, err
 	}
 
-	dest, err := bundlestore.GetConnection(bundlestore.ConnectionOptions{
-		Namespace: appID,
-		Version:   bundle.GetVersionString(),
-		Context:   session.Context(),
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	eg := errgroup.Group{}
-
 	// Also upload the entire bundle as a ZIP file attached as a user file,
 	// so that we can easily download everything when needed rather than having to get the individual bundle files.
 	buf := new(bytes.Buffer)
-	zipWriter := zip.NewWriter(buf)
 
-	creator := func(path string) (io.WriteCloser, error) {
-		r, w := io.Pipe()
-		eg.Go(func() error {
-			return dest.StoreItem(path, r)
-		})
-		zip, err := zipWriter.Create(path)
-		if err != nil {
-			return nil, err
-		}
-		return types.MultiWriteCloser(w, zip), nil
-	}
-
-	err = retrieve.RetrieveBundle("", creator, source)
+	err = source.GetBundleZip(buf, nil)
 	if err != nil {
 		return nil, err
 	}
-	// Wait for all goroutines spawned in the error group to complete,
-	// or return the first error
-	if err = eg.Wait(); err != nil {
-		return nil, err
-	}
 
-	if err = zipWriter.Close(); err != nil {
-		return nil, err
-	}
-
-	if _, err = filesource.Upload([]*filesource.FileUploadOp{
-		{
-			Data:         buf,
-			Path:         bundle.GetVersionString() + ".zip",
-			CollectionID: "uesio/studio.bundle",
-			RecordID:     bundle.ID,
-			FieldID:      "uesio/studio.contents",
-		},
-	}, connection, session, params); err != nil {
+	err = createNewBundle(buf.Bytes(), bundle, params, connection, session)
+	if err != nil {
 		return nil, err
 	}
 
@@ -170,6 +120,42 @@ func runCreateBundleListenerBot(params map[string]interface{}, connection wire.C
 		"patch":       patch,
 		"description": description,
 	}, nil
+
+}
+
+func createNewBundle(data []byte, bundle *meta.Bundle, params map[string]interface{}, connection wire.Connection, session *sess.Session) error {
+
+	if err := datasource.PlatformSaveOne(bundle, nil, connection, session); err != nil {
+		return err
+	}
+
+	dest, err := bundlestore.GetConnection(bundlestore.ConnectionOptions{
+		Namespace: bundle.BuiltIn.UniqueKey,
+		Version:   bundle.GetVersionString(),
+		Context:   session.Context(),
+	})
+	if err != nil {
+		return err
+	}
+
+	err = dest.SetBundleZip(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		return err
+	}
+
+	if _, err = filesource.Upload([]*filesource.FileUploadOp{
+		{
+			Data:         bytes.NewReader(data),
+			Path:         bundle.GetVersionString() + ".zip",
+			CollectionID: "uesio/studio.bundle",
+			RecordID:     bundle.ID,
+			FieldID:      "uesio/studio.contents",
+		},
+	}, connection, session, params); err != nil {
+		return err
+	}
+
+	return nil
 
 }
 

--- a/apps/platform/pkg/bundlestore/bundlestore.go
+++ b/apps/platform/pkg/bundlestore/bundlestore.go
@@ -65,11 +65,11 @@ type BundleStoreConnection interface {
 	HasAny(group meta.BundleableGroup, conditions meta.BundleConditions) (bool, error)
 	GetItemAttachment(w io.Writer, item meta.AttachableItem, path string) (file.Metadata, error)
 	GetItemAttachments(creator FileCreator, item meta.AttachableItem) error
-	StoreItem(path string, reader io.Reader) error
 	GetBundleDef() (*meta.BundleDef, error)
 	HasAllItems(items []meta.BundleableItem) error
 	DeleteBundle() error
 	GetBundleZip(writer io.Writer, options *BundleZipOptions) error
+	SetBundleZip(reader io.ReaderAt, size int64) error
 }
 
 func getBundleStore(namespace string, workspace *meta.Workspace) (BundleStore, error) {

--- a/apps/platform/pkg/bundlestore/platformbundlestore/platformbundlestore.go
+++ b/apps/platform/pkg/bundlestore/platformbundlestore/platformbundlestore.go
@@ -222,7 +222,7 @@ func (b *PlatformBundleStoreConnection) GetItemAttachments(creator bundlestore.F
 
 func (b *PlatformBundleStoreConnection) StoreItem(path string, reader io.Reader) error {
 
-	fullFilePath := filepath.Join(getBasePath(b.Namespace, b.Version), path)
+	fullFilePath := filepath.Join(b.Namespace, b.Version, path)
 
 	conn, err := b.getPlatformFileConnection()
 	if err != nil {

--- a/apps/platform/pkg/bundlestore/platformbundlestore/platformbundlestore.go
+++ b/apps/platform/pkg/bundlestore/platformbundlestore/platformbundlestore.go
@@ -279,6 +279,32 @@ func (b *PlatformBundleStoreConnection) HasAllItems(items []meta.BundleableItem)
 	return nil
 }
 
+func (b *PlatformBundleStoreConnection) SetBundleZip(reader io.ReaderAt, size int64) error {
+
+	// Create a zip reader from the zip file content
+	zipReader, err := zip.NewReader(reader, size)
+	if err != nil {
+		return err
+	}
+
+	// Iterate over the zip files
+	for _, zipFile := range zipReader.File {
+		rc, err := zipFile.Open()
+		if err != nil {
+			return err
+		}
+		defer rc.Close()
+
+		err = b.StoreItem(zipFile.Name, rc)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+
+}
+
 func (b *PlatformBundleStoreConnection) GetBundleZip(writer io.Writer, zipoptions *bundlestore.BundleZipOptions) error {
 
 	session := b.getStudioAnonSession()

--- a/apps/platform/pkg/bundlestore/systembundlestore/systembundlestore.go
+++ b/apps/platform/pkg/bundlestore/systembundlestore/systembundlestore.go
@@ -212,10 +212,6 @@ func (b *SystemBundleStoreConnection) GetItemAttachments(creator bundlestore.Fil
 	return nil
 }
 
-func (b *SystemBundleStoreConnection) StoreItem(path string, reader io.Reader) error {
-	return errors.New("Cannot Write to System Bundle Store")
-}
-
 func (b *SystemBundleStoreConnection) DeleteBundle() error {
 	return errors.New("tried to delete bundle in System Bundle Store")
 }
@@ -243,6 +239,10 @@ func (b *SystemBundleStoreConnection) HasAllItems(items []meta.BundleableItem) e
 		}
 	}
 	return nil
+}
+
+func (b *SystemBundleStoreConnection) SetBundleZip(reader io.ReaderAt, size int64) error {
+	return errors.New("tried to upload bundle zip in System Bundle Store")
 }
 
 func (b *SystemBundleStoreConnection) GetBundleZip(writer io.Writer, zipoptions *bundlestore.BundleZipOptions) error {

--- a/apps/platform/pkg/bundlestore/workspacebundlestore/workspacebundlestore.go
+++ b/apps/platform/pkg/bundlestore/workspacebundlestore/workspacebundlestore.go
@@ -304,10 +304,6 @@ func (b *WorkspaceBundleStoreConnection) GetItemAttachments(creator bundlestore.
 	return nil
 }
 
-func (b *WorkspaceBundleStoreConnection) StoreItem(path string, reader io.Reader) error {
-	return errors.New("Tried to store items in the workspace bundle store")
-}
-
 func (b *WorkspaceBundleStoreConnection) DeleteBundle() error {
 	return errors.New("tried to delete bundle in the workspace bundle store")
 }
@@ -400,6 +396,10 @@ func (b *WorkspaceBundleStoreConnection) HasAllItems(items []meta.BundleableItem
 		}
 		return nil
 	})
+}
+
+func (b *WorkspaceBundleStoreConnection) SetBundleZip(reader io.ReaderAt, size int64) error {
+	return errors.New("tried to upload bundle zip in Workspace Bundle Store")
 }
 
 func (b *WorkspaceBundleStoreConnection) GetBundleZip(writer io.Writer, zipoptions *bundlestore.BundleZipOptions) error {

--- a/apps/platform/pkg/controller/bundlesretrieve.go
+++ b/apps/platform/pkg/controller/bundlesretrieve.go
@@ -6,23 +6,17 @@ import (
 
 	"github.com/gorilla/mux"
 
-	"github.com/thecloudmasters/uesio/pkg/constant/commonfields"
+	"github.com/thecloudmasters/uesio/pkg/bundlestore"
 	"github.com/thecloudmasters/uesio/pkg/controller/ctlutil"
 	"github.com/thecloudmasters/uesio/pkg/controller/file"
-	"github.com/thecloudmasters/uesio/pkg/datasource"
-	"github.com/thecloudmasters/uesio/pkg/filesource"
-	"github.com/thecloudmasters/uesio/pkg/meta"
 	"github.com/thecloudmasters/uesio/pkg/middleware"
 	"github.com/thecloudmasters/uesio/pkg/types/exceptions"
-	"github.com/thecloudmasters/uesio/pkg/types/wire"
 )
 
 func BundlesRetrieve(w http.ResponseWriter, r *http.Request) {
 
 	session := middleware.GetSession(r)
 	vars := mux.Vars(r)
-	// to expose bundles to guest users, who don't have access, we will enter an admin context.
-	adminSession := datasource.GetSiteAdminSession(session)
 
 	appID, ok := vars["app"]
 	if !ok {
@@ -36,49 +30,22 @@ func BundlesRetrieve(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	major, minor, patch, err := meta.ParseVersionString(version)
+	source, err := bundlestore.GetConnection(bundlestore.ConnectionOptions{
+		Namespace:  appID,
+		Version:    version,
+		Connection: nil,
+		Workspace:  nil,
+		Context:    session.Context(),
+	})
 	if err != nil {
 		ctlutil.HandleError(w, exceptions.NewBadRequestException("Failed Getting Bundle: "+err.Error()))
 		return
 	}
 
-	var bundle meta.Bundle
-	err = datasource.PlatformLoadOne(
-		&bundle,
-		&datasource.PlatformLoadOptions{
-			Fields: []wire.LoadRequestField{
-				{
-					ID: "uesio/studio.contents",
-					Fields: []wire.LoadRequestField{
-						{
-							ID: commonfields.Id,
-						},
-					},
-				},
-			},
-			Conditions: []wire.LoadRequestCondition{
-				{
-					Field: commonfields.UniqueKey,
-					Value: fmt.Sprintf("%s:%s:%s:%s", appID, major, minor, patch),
-				},
-			},
-		},
-		adminSession,
-	)
-
-	if err != nil {
-		ctlutil.HandleError(w, exceptions.NewNotFoundException(fmt.Sprintf("could not find bundle: %s/%s", appID, version)))
-		return
-	}
-
-	// TODO: We could regenerate the bundle on demand, if not found
-	if bundle.Contents == nil {
-		ctlutil.HandleError(w, exceptions.NewNotFoundException("zip file not found for this bundle"))
-		return
-	}
 	w.Header().Set("Content-Disposition", fmt.Sprintf("; filename=\"%s.zip\"", version))
 	w.Header().Set("Cache-Control", file.CacheFor1Year)
-	if _, err := filesource.Download(w, bundle.Contents.ID, adminSession); err != nil {
+	err = source.GetBundleZip(w, nil)
+	if err != nil {
 		ctlutil.HandleError(w, exceptions.NewBadRequestException("Failed Getting Bundle: "+err.Error()))
 		return
 	}


### PR DESCRIPTION
# What does this PR do?

1. Consolidates bundle creation code into a single method.
2. Removes the `StoreItem` bundlestore API and adds the `SetBundleZip` api instead.

# Testing

Test creating a new bundle from a workspace.
Test adding an external bundle from a prod bundlestore.
