### PR TITLE
Adds Route Assignments to the client

### DIFF
--- a/apps/platform/pkg/meta/routeassignment.go
+++ b/apps/platform/pkg/meta/routeassignment.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path"
 
+	"github.com/francoispqt/gojay"
 	"gopkg.in/yaml.v3"
 )
 
@@ -29,6 +30,21 @@ type RouteAssignment struct {
 }
 
 type RouteAssignmentWrapper RouteAssignment
+
+func (r *RouteAssignment) GetBytes() ([]byte, error) {
+	return gojay.MarshalJSONObject(r)
+}
+
+func (r *RouteAssignment) MarshalJSONObject(enc *gojay.Encoder) {
+	enc.AddStringKey("type", r.Type)
+	enc.AddStringKey("collection", r.Collection)
+	enc.AddStringKey("namespace", r.Namespace)
+	enc.AddStringKey("name", r.Collection+"_"+r.Type)
+}
+
+func (r *RouteAssignment) IsNil() bool {
+	return r == nil
+}
 
 func (r *RouteAssignment) GetDBID(workspace string) string {
 	return fmt.Sprintf("%s:%s:%s", workspace, r.Collection, r.Type)

--- a/apps/platform/pkg/routing/deps.go
+++ b/apps/platform/pkg/routing/deps.go
@@ -442,6 +442,17 @@ func GetMetadataDeps(route *meta.Route, session *sess.Session) (*PreloadMetadata
 		return nil, errors.New("Failed to get config values: " + err.Error())
 	}
 
+	// Add in route assignments
+	var routeAssignments meta.RouteAssignmentCollection
+	err = bundle.LoadAllFromAny(&routeAssignments, nil, session, nil)
+	if err != nil {
+		return nil, errors.New("Failed to load route assignments: " + err.Error())
+	}
+
+	for _, assignment := range routeAssignments {
+		deps.RouteAssignment.AddItem(assignment)
+	}
+
 	for key, value := range labels {
 		label, err := meta.NewLabel(key)
 		if err != nil {

--- a/apps/platform/pkg/routing/preload.go
+++ b/apps/platform/pkg/routing/preload.go
@@ -109,6 +109,7 @@ func NewPreloadMetadata() *PreloadMetadata {
 		ConfigValue:      NewItem(),
 		FeatureFlag:      NewItem(),
 		Label:            NewItem(),
+		RouteAssignment:  NewItem(),
 		SelectList:       NewItem(),
 		StaticFile:       NewItem(),
 		Theme:            NewItem(),
@@ -126,6 +127,7 @@ type PreloadMetadata struct {
 	ConfigValue      *MetadataMergeData `json:"configvalue,omitempty"`
 	FeatureFlag      *MetadataMergeData `json:"featureflag,omitempty"`
 	Label            *MetadataMergeData `json:"label,omitempty"`
+	RouteAssignment  *MetadataMergeData `json:"routeassignment,omitempty"`
 	SelectList       *MetadataMergeData `json:"selectlist,omitempty"`
 	StaticFile       *MetadataMergeData `json:"file,omitempty"`
 	Theme            *MetadataMergeData `json:"theme,omitempty"`

--- a/libs/ui/src/bands/route/types.ts
+++ b/libs/ui/src/bands/route/types.ts
@@ -12,6 +12,7 @@ import { SelectListMetadata } from "../../wireexports"
 import { ServerWire } from "../wire/types"
 import { ThemeState } from "../../definition/theme"
 import { ViewMetadata } from "../../definition/ViewMetadata"
+import { RouteAssignmentState } from "../../definition/routeassignment"
 
 type WorkspaceState = {
 	name: string
@@ -34,6 +35,7 @@ type Dependencies = {
 	featureflag?: FeatureFlagState[]
 	file?: FileState[]
 	label?: LabelState[]
+	routeassignment?: RouteAssignmentState[]
 	selectlist?: SelectListMetadata[]
 	theme?: ThemeState[]
 	viewdef?: ViewMetadata[]

--- a/libs/ui/src/bands/route/utils.ts
+++ b/libs/ui/src/bands/route/utils.ts
@@ -9,6 +9,7 @@ import { setMany as setFeatureFlag } from "../featureflag"
 import { setMany as setComponent } from "../component"
 import { setMany as setComponentTypes } from "../componenttype"
 import { setMany as setSelectList } from "../selectlist"
+import { setMany as setRouteAssignment } from "../routeassignment"
 import { initAll as initWire } from "../wire"
 import { init as initCollection } from "../collection"
 import { ViewMetadata } from "../../definition/ViewMetadata"
@@ -46,6 +47,7 @@ const dispatchRouteDeps = (deps: Dependencies | undefined) => {
 	if (deps.configvalue) dispatch(setConfigValue(deps.configvalue))
 	if (deps.featureflag) dispatch(setFeatureFlag(deps.featureflag))
 	if (deps.label) dispatch(setLabel(deps.label))
+	if (deps.routeassignment) dispatch(setRouteAssignment(deps.routeassignment))
 	if (deps.selectlist) dispatch(setSelectList(deps.selectlist))
 	if (deps.theme) dispatch(setTheme(deps.theme))
 	if (deps.viewdef) dispatch(setViewDef(deps.viewdef))

--- a/libs/ui/src/bands/routeassignment/index.ts
+++ b/libs/ui/src/bands/routeassignment/index.ts
@@ -1,0 +1,29 @@
+import { createSlice, createEntityAdapter } from "@reduxjs/toolkit"
+import { RouteAssignmentState } from "../../definition/routeassignment"
+import { RootState } from "../../store/store"
+import { getKey } from "../../metadata/metadata"
+
+const adapter = createEntityAdapter<RouteAssignmentState>({
+	selectId: getKey,
+})
+
+const selectors = adapter.getSelectors(
+	(state: RootState) => state.routeassignment
+)
+
+const selectById = (state: RootState, name: string) =>
+	selectors.selectById(state, name)
+
+const metadataSlice = createSlice({
+	name: "routeassignment",
+	initialState: adapter.getInitialState(),
+	reducers: {
+		set: adapter.upsertOne,
+		setMany: adapter.upsertMany,
+	},
+})
+
+export { selectById, selectors, adapter }
+
+export const { set, setMany } = metadataSlice.actions
+export default metadataSlice.reducer

--- a/libs/ui/src/definition/routeassignment.ts
+++ b/libs/ui/src/definition/routeassignment.ts
@@ -1,0 +1,6 @@
+import { BundleableBase } from "../metadata/types"
+
+export type RouteAssignmentState = {
+	type: string
+	collection: string
+} & BundleableBase

--- a/libs/ui/src/store/store.ts
+++ b/libs/ui/src/store/store.ts
@@ -11,6 +11,7 @@ import label from "../bands/label"
 import notification from "../bands/notification"
 import panel from "../bands/panel"
 import route from "../bands/route"
+import routeassignment from "../bands/routeassignment"
 import selectlist from "../bands/selectlist"
 import session from "../bands/session"
 import site, { SiteState } from "../bands/site"
@@ -47,6 +48,7 @@ const create = (initialState: InitialState) => {
 			notification,
 			panel,
 			route,
+			routeassignment,
 			selectlist,
 			session,
 			site,


### PR DESCRIPTION
# What does this PR do?

Adds a routeassignment band and sends all route assignments to the client. These route assignments can be used in components for a follow-up PR.

# Testing

Load a view. Verify in redux-dev-tools that the routeassignment band exists.
