### PR TITLE
fix: remove bad default values

### DIFF
--- a/libs/apps/uesio/core/bundle/bots/generator/view_detail/bot.yaml
+++ b/libs/apps/uesio/core/bundle/bots/generator/view_detail/bot.yaml
@@ -20,5 +20,4 @@ params:
   - name: name
     prompt: View Name (optional)
     type: METADATANAME
-    default: ${collection}_detail
 public: true

--- a/libs/apps/uesio/core/bundle/bots/generator/view_list/bot.yaml
+++ b/libs/apps/uesio/core/bundle/bots/generator/view_list/bot.yaml
@@ -20,5 +20,4 @@ params:
   - name: name
     prompt: View Name (optional)
     type: METADATANAME
-    default: ${collection}_list
 public: true

--- a/libs/apps/uesio/core/bundle/bots/generator/view_queue/bot.yaml
+++ b/libs/apps/uesio/core/bundle/bots/generator/view_queue/bot.yaml
@@ -25,5 +25,4 @@ params:
   - name: name
     prompt: View Name (optional)
     type: METADATANAME
-    default: ${collection}_queue
 public: true


### PR DESCRIPTION
# What does this PR do?

Manage this issue https://github.com/ues-io/uesio/issues/3811.
Basically, the bot gives a default name for the view if non is provided, since we where providing a bad default Uesio gives you a validation error. I tried to merge before-hand but since the user must select a collection first it won't work.

This is what I was trying but I guess we can keep it simple by just removing the defaults, it feels like we want placeholders. 
```
const getInitialValueFromParams = (
	params: param.ParamDefinition[] | undefined,
	context: context.Context
) => {
	if (!params || !params.length) return {}
	console.log({ params, context })
	return Object.fromEntries(
		params
			.filter((def) => def.default !== undefined)
			.map((def) => [
				def.name,
				context.merge(def.default as context.Mergeable),
			])
	)
}


```


# Testing

If relevant, explain how to test the change locally
