### PR TITLE
fix: breadcrumb in builder context

### DIFF
--- a/libs/apps/uesio/builder/bundle/componentpacks/main/src/components/mainwrapper/mainheader.tsx
+++ b/libs/apps/uesio/builder/bundle/componentpacks/main/src/components/mainwrapper/mainheader.tsx
@@ -51,6 +51,7 @@ const MainHeader: definition.UtilityComponent = (props) => {
 						iconcolor: nsInfo?.color,
 						tileVariant: "uesio/builder.apptag",
 						path: `/app/${workspace.app}`,
+						namespace: "uesio/studio",
 					}}
 					context={context.deleteWorkspace()}
 				/>

--- a/libs/apps/uesio/builder/bundle/components/breadcrumb.yaml
+++ b/libs/apps/uesio/builder/bundle/components/breadcrumb.yaml
@@ -27,6 +27,7 @@ definition:
       signals:
         - signal: "route/NAVIGATE"
           path: $Prop{path}
+          namespace: $Prop{namespace}
       title: $Prop{title}
       icon: $Prop{icon}
       iconcolor: $Prop{iconcolor}


### PR DESCRIPTION
# What does this PR do?

This was harder to understand than to fix! 
So I try to explain it to see it clear for you @humandad.
Basically, route/NAVIGATE does a platform.getRoute() that has getViewDefId() the view in context matters for the navigate.
In this builder use case and in the studio use case when we use the breadcrumb I guess we want to keep everything in the studio namespace.



# Testing

If relevant, explain how to test the change locally
