### PR TITLE
fix: Integration Actions in permissionsets UI

### DIFF
--- a/libs/apps/uesio/studio/bundle/fields/uesio/studio/permissionset/integrationactionrefs.yaml
+++ b/libs/apps/uesio/studio/bundle/fields/uesio/studio/permissionset/integrationactionrefs.yaml
@@ -3,7 +3,7 @@ type: MAP
 label: Integration Action Permissions
 subtype: STRUCT
 subfields:
-  - name: allowAll
+  - name: allowAllActions
     label: Allow All
     type: CHECKBOX
   - name: actions

--- a/libs/apps/uesio/studio/bundle/views/permissionset.yaml
+++ b/libs/apps/uesio/studio/bundle/views/permissionset.yaml
@@ -356,11 +356,11 @@ definition:
                                             signal: route/NAVIGATE
                                         uesio.display:
                                           - type: fieldValue
-                                            field: allowAll
+                                            field: allowAllActions
                                             operator: NOT_EQUALS
                                             value: true
                                     permissionFields:
-                                      - name: allowAll
+                                      - name: allowAllActions
                                         label: Allow all Actions provided by this Integration
                                         type: CHECKBOX
                                       - name: actions


### PR DESCRIPTION
# What does this PR do?

The integration part in the permission sets UI wasn't working.
I noticed that backend side we have this **_AllowAll    bool            `yaml:"allowAllActions" json:"allowAllActions"`_** for the IntegrationPermission meaning that on the frontend side is called **allowAllActions** while the backend side is called **allowAll**.  This should fix it and not create any problems. I can't see any reference in the frontend to this field apart from the permissions. 
  

# Testing

If relevant, explain how to test the change locally
