### PR TITLE
refactor: Start to extract record level access enforcement out of Postgresio adapter

### DIFF
--- a/apps/platform/pkg/meta/collection.go
+++ b/apps/platform/pkg/meta/collection.go
@@ -3,6 +3,7 @@ package meta
 import (
 	"errors"
 
+	"github.com/thecloudmasters/uesio/pkg/constant/commonfields"
 	"gopkg.in/yaml.v3"
 )
 
@@ -41,6 +42,7 @@ type Collection struct {
 	Type            string   `yaml:"type,omitempty" json:"uesio/studio.type"`
 	PluralLabel     string   `yaml:"pluralLabel,omitempty" json:"uesio/studio.plurallabel"`
 	UniqueKeyFields []string `yaml:"uniqueKey,omitempty" json:"uesio/studio.uniquekey"`
+	IdField         string   `yaml:"idField,omitempty" json:"uesio/studio.idfield"`
 	NameField       string   `yaml:"nameField,omitempty" json:"uesio/studio.namefield"`
 	ReadOnly        bool     `yaml:"readOnly,omitempty" json:"-"`
 	Access          string   `yaml:"access,omitempty" json:"uesio/studio.access"`
@@ -100,7 +102,11 @@ func (c *Collection) UnmarshalYAML(node *yaml.Node) error {
 	c.IntegrationRef = GetFullyQualifiedKey(c.IntegrationRef, c.Namespace)
 	c.NameField = GetFullyQualifiedKey(c.NameField, c.Namespace)
 	if c.NameField == "" {
-		c.NameField = "uesio/core.id"
+		c.NameField = commonfields.Id
+	}
+	c.IdField = GetFullyQualifiedKey(c.IdField, c.Namespace)
+	if c.IdField == "" {
+		c.IdField = commonfields.Id
 	}
 	c.LoadBot = GetFullyQualifiedKey(c.LoadBot, c.Namespace)
 	c.SaveBot = GetFullyQualifiedKey(c.SaveBot, c.Namespace)
@@ -114,7 +120,8 @@ func (c *Collection) UnmarshalYAML(node *yaml.Node) error {
 
 func (c *Collection) MarshalYAML() (interface{}, error) {
 	c.IntegrationRef = removeDefault(GetLocalizedKey(c.IntegrationRef, c.Namespace), PLATFORM_DATA_SOURCE)
-	c.NameField = removeDefault(GetLocalizedKey(c.NameField, c.Namespace), "uesio/core.id")
+	c.NameField = removeDefault(GetLocalizedKey(c.NameField, c.Namespace), commonfields.Id)
+	c.IdField = removeDefault(GetLocalizedKey(c.IdField, c.Namespace), commonfields.Id)
 	c.LoadBot = GetLocalizedKey(c.LoadBot, c.Namespace)
 	c.SaveBot = GetLocalizedKey(c.SaveBot, c.Namespace)
 	if len(c.UniqueKeyFields) > 0 {

--- a/apps/platform/pkg/meta/collection_test.go
+++ b/apps/platform/pkg/meta/collection_test.go
@@ -73,6 +73,7 @@ func TestCollectionUnmarshal(t *testing.T) {
 					"my/namespace.field1",
 					"my/namespace.field2",
 				},
+				IdField:        "uesio/core.id",
 				NameField:      "my/namespace.somefield",
 				Type:           "EXTERNAL",
 				IntegrationRef: "my/namespace.someintegration",
@@ -96,6 +97,7 @@ func TestCollectionUnmarshal(t *testing.T) {
 					"my/namespace.field1",
 					"my/namespace.field2",
 				},
+				IdField:        "uesio/core.id",
 				NameField:      "my/namespace.somefield",
 				Type:           "EXTERNAL",
 				IntegrationRef: "my/namespace.someintegration",
@@ -119,6 +121,7 @@ func TestCollectionUnmarshal(t *testing.T) {
 					"luigi/foo.field1",
 					"luigi/foo.field2",
 				},
+				IdField:        "uesio/core.id",
 				NameField:      "luigi/foo.somefield",
 				Type:           "EXTERNAL",
 				IntegrationRef: "luigi/foo.someintegration",
@@ -149,7 +152,7 @@ func TestCollectionUnmarshal(t *testing.T) {
 			if err != nil {
 				assert.Nil(t, err, "Unexpected failure unmarshalling: %s", err.Error())
 			} else {
-				assert.EqualValues(t, initial, tc.expected)
+				assert.EqualValues(t, tc.expected, initial)
 			}
 		})
 	}

--- a/apps/platform/pkg/meta/permissionset.go
+++ b/apps/platform/pkg/meta/permissionset.go
@@ -321,6 +321,17 @@ func (ps *PermissionSet) HasModifyAllRecordsPermission(key string) bool {
 	}
 }
 
+func (ps *PermissionSet) HasViewAllRecordsPermission(key string) bool {
+	if ps.ViewAllRecords {
+		return true
+	}
+	if collectionPermission, ok := ps.CollectionRefs[key]; !ok {
+		return false
+	} else {
+		return collectionPermission.ViewAll
+	}
+}
+
 func (ps *PermissionSet) HasNamedPermission(namedPermission string) bool {
 	if ps.NamedRefs == nil {
 		return false

--- a/apps/platform/pkg/types/wire/load.go
+++ b/apps/platform/pkg/types/wire/load.go
@@ -31,8 +31,9 @@ type LoadOp struct {
 	ViewOnly           bool                   `json:"viewOnly,omitempty"`
 	Aggregate          bool                   `json:"aggregate,omitempty"`
 	// Internal only conveniences for LoadBots to be able to access prefetched metadata
-	metadata              *MetadataCache
-	integrationConnection *IntegrationConnection
+	metadata                    *MetadataCache
+	integrationConnection       *IntegrationConnection
+	needsRecordLevelAccessCheck bool
 }
 
 type LoadOpWrapper LoadOp
@@ -117,6 +118,15 @@ func (op *LoadOp) AttachMetadataCache(response *MetadataCache) *LoadOp {
 func (op *LoadOp) AttachIntegrationConnection(integrationConnection *IntegrationConnection) *LoadOp {
 	op.integrationConnection = integrationConnection
 	return op
+}
+
+func (op *LoadOp) SetNeedsRecordLevelAccessCheck() *LoadOp {
+	op.needsRecordLevelAccessCheck = true
+	return op
+}
+
+func (op *LoadOp) NeedsRecordLevelAccessCheck() bool {
+	return op.needsRecordLevelAccessCheck
 }
 
 type LoadRequestBatch struct {

--- a/apps/platform/pkg/types/wire/metadata.go
+++ b/apps/platform/pkg/types/wire/metadata.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/thecloudmasters/uesio/pkg/constant"
+	"github.com/thecloudmasters/uesio/pkg/constant/commonfields"
 
 	"github.com/thecloudmasters/uesio/pkg/meta"
 )
@@ -64,6 +65,7 @@ type CollectionMetadata struct {
 	Type                  string                       `json:"-"`
 	UniqueKey             []string                     `json:"uniqueKey"`
 	NameField             string                       `json:"nameField"`
+	IdField               string                       `json:"-"`
 	Createable            bool                         `json:"createable"`
 	Accessible            bool                         `json:"accessible"`
 	Updateable            bool                         `json:"updateable"`
@@ -100,6 +102,15 @@ func (cm *CollectionMetadata) IsWriteProtected() bool {
 
 func (cm *CollectionMetadata) IsReadProtected() bool {
 	return cm.Access == "protected"
+}
+
+func (cm *CollectionMetadata) GetTableName() string {
+	// For Uesio DB collections, all data is in one table: data
+	if cm.Integration == "" {
+		return "data"
+	}
+	// For external collections, the table name should be defined in TableName
+	return cm.TableName
 }
 
 func (cm *CollectionMetadata) GetBytes() ([]byte, error) {
@@ -159,6 +170,19 @@ func (cm *CollectionMetadata) GetFieldWithMetadata(key string, metadata *Metadat
 
 func (cm *CollectionMetadata) SetField(metadata *FieldMetadata) {
 	cm.Fields[metadata.GetFullName()] = metadata
+}
+
+func (cm *CollectionMetadata) GetIdFieldName() string {
+	// For Uesio DB collections, the id field is always the common id field,
+	// but for external collections, it can be customized.
+	if cm.Integration != "" && cm.IdField != "" {
+		return cm.IdField
+	}
+	return commonfields.Id
+}
+
+func (cm *CollectionMetadata) GetIdField() (*FieldMetadata, error) {
+	return cm.GetField(cm.GetIdFieldName())
 }
 
 func (cm *CollectionMetadata) GetNameField() (*FieldMetadata, error) {

--- a/libs/apps/uesio/studio/bundle/fields/uesio/studio/collection/idfield.yaml
+++ b/libs/apps/uesio/studio/bundle/fields/uesio/studio/collection/idfield.yaml
@@ -1,0 +1,5 @@
+name: idfield
+type: METADATA
+label: Id Field
+metadata:
+  type: FIELD


### PR DESCRIPTION
# What does this PR do?

1. Drops total queries performed during Uesio Integration tests by 25%, by reducing the number of unnecessary record level access queries that Uesio makes by doing a better job of checking to see whether there are collections in a Load request actually needing record level access checks. 
2. Begins to refactor Postgres Load adapter to be able to function against an external PG database other than Uesio's multi-tenant, single-table structure.
3. Adds a new IdField field on Collections, which will be used to identify metadata related to the "id" field of external Postgres Collections.

## Queries: Master

```
{"queryStats":{"totalWorkspaceQueries":2113,"totalQueries":15841}}
```

## Queries: This branch
```
{"queryStats":{"totalWorkspaceQueries":2103,"totalQueries":12119}}
```

## Delta: 25%

# Testing

There should be no functional changes to the app at this point, only reduced queries.
