### PR TITLE
fix: Support SELECT fields in Chart labels/categories, do count on non-numeric value fields

### DIFF
--- a/libs/apps/uesio/io/bundle/componentpacks/chart/src/shared/aggregate.spec.tsx
+++ b/libs/apps/uesio/io/bundle/componentpacks/chart/src/shared/aggregate.spec.tsx
@@ -1,0 +1,170 @@
+import { collection, context, wire } from "@uesio/ui"
+import { aggregate } from "./aggregate"
+import { LabelsDefinition } from "./labels"
+
+const makeFieldMetadata = (
+	def: Partial<collection.FieldMetadata>
+): collection.FieldMetadata => ({
+	accessible: true,
+	createable: true,
+	updateable: true,
+	type: "TEXT",
+	label: "some field",
+	name: "",
+	namespace: "",
+	...def,
+})
+const makePlainCollection = (
+	def: Partial<collection.PlainCollection>
+): collection.PlainCollection => ({
+	createable: true,
+	accessible: true,
+	updateable: true,
+	deleteable: true,
+	label: "foo",
+	pluralLabel: "foos",
+	namespace: "luigi/foo",
+	name: "foo",
+	fields: {},
+	nameField: "uesio/core.id",
+	...def,
+})
+
+describe("Chart: aggregate", () => {
+	const plainCollection = makePlainCollection({
+		name: "registrations",
+		namespace: "luigi/foo",
+		fields: {
+			"uesio/core.id": makeFieldMetadata({
+				type: "TEXT",
+				name: "id",
+				namespace: "uesio/core",
+			}),
+			"luigi/foo.status": makeFieldMetadata({
+				type: "SELECT",
+				name: "status",
+				namespace: "luigi/foo",
+			}),
+			"luigi/foo.number": makeFieldMetadata({
+				type: "NUMBER",
+				name: "number",
+				namespace: "luigi/foo",
+			}),
+		},
+	})
+	const wireInstance = new wire.Wire({
+		changes: {},
+		deletes: {},
+		original: {},
+		view: "",
+		name: "registrations",
+		collection: "luigi/foo",
+		data: {
+			"123": {
+				"luigi/foo.status": "A",
+				"uesio/core.id": "123",
+				"luigi/foo.number": 1,
+			},
+			"323": {
+				"luigi/foo.status": "A",
+				"uesio/core.id": "323",
+				"luigi/foo.number": 2,
+			},
+			"4423": {
+				"luigi/foo.status": "B",
+				"uesio/core.id": "4423",
+				"luigi/foo.number": 3,
+			},
+			"48322": {
+				"luigi/foo.status": "B",
+				"uesio/core.id": "48322",
+				"luigi/foo.number": 4,
+			},
+			"342": {
+				"luigi/foo.status": "C",
+				"uesio/core.id": "342",
+				"luigi/foo.number": 5,
+			},
+		},
+		fields: [{ id: "luigi/foo.status" }, { id: "uesio/core.id" }],
+	})
+	wireInstance.attachCollection(plainCollection)
+
+	it("should do a count by default on non-numeric value fields", () => {
+		const wires = {
+			registrations: wireInstance,
+		}
+		const labelsDefinition = {
+			source: "DATA",
+		} as LabelsDefinition
+		const serieses = [
+			{
+				wire: "registrations",
+				valueField: "uesio/core.id",
+				categoryField: "luigi/foo.status",
+				label: "Registrations by Status",
+				name: "RegistrationsByStatus",
+			},
+		]
+		const contextInstance = new context.Context()
+		const [datasets, categories] = aggregate(
+			wires,
+			labelsDefinition,
+			serieses,
+			contextInstance
+		)
+		expect(datasets).toEqual([
+			{
+				label: "Registrations by Status",
+				cubicInterpolationMode: "monotone",
+				data: [2, 2, 1],
+				backgroundColor: "rgb(255, 99, 132)",
+				borderColor: "rgb(255, 99, 132)",
+			},
+		])
+		expect(categories).toEqual({
+			A: "A",
+			B: "B",
+			C: "C",
+		})
+	})
+
+	it("should do do a sum by default on numeric value fields", () => {
+		const wires = {
+			registrations: wireInstance,
+		}
+		const labelsDefinition = {
+			source: "DATA",
+		} as LabelsDefinition
+		const serieses = [
+			{
+				wire: "registrations",
+				valueField: "luigi/foo.number",
+				categoryField: "luigi/foo.status",
+				label: "Total Number by Status",
+				name: "NumberByStatus",
+			},
+		]
+		const contextInstance = new context.Context()
+		const [datasets, categories] = aggregate(
+			wires,
+			labelsDefinition,
+			serieses,
+			contextInstance
+		)
+		expect(datasets).toEqual([
+			{
+				label: "Total Number by Status",
+				cubicInterpolationMode: "monotone",
+				data: [3, 7, 5],
+				backgroundColor: "rgb(255, 99, 132)",
+				borderColor: "rgb(255, 99, 132)",
+			},
+		])
+		expect(categories).toEqual({
+			A: "A",
+			B: "B",
+			C: "C",
+		})
+	})
+})

--- a/libs/apps/uesio/io/bundle/componentpacks/chart/src/shared/labels.tsx
+++ b/libs/apps/uesio/io/bundle/componentpacks/chart/src/shared/labels.tsx
@@ -77,6 +77,7 @@ const getCategoryFunc = (
 				return (value && value.getIdFieldValue()) || ""
 			}
 		case "TEXT":
+		case "SELECT":
 			return (record: wire.WireRecord) =>
 				record.getFieldValue<string>(fieldId) || ""
 		default:
@@ -254,6 +255,7 @@ const getDataLabels = (
 		case "USER":
 			return getReferenceDataLabels(wire, labels, categoryField)
 		case "TEXT":
+		case "SELECT":
 			return getTextDataLabels(wire, labels, categoryField)
 		default:
 			throw new Error("Invalid Field Type: " + fieldType)

--- a/libs/apps/uesio/io/bundle/componentpacks/chart/src/shared/labels.tsx
+++ b/libs/apps/uesio/io/bundle/componentpacks/chart/src/shared/labels.tsx
@@ -206,7 +206,13 @@ const getTextDataLabels = (
 			categories[category] = value || ""
 		}
 	})
-	return categories
+	const sortedCategories: Categories = {}
+	Object.keys(categories)
+		.sort()
+		.forEach((k) => {
+			sortedCategories[k] = categories[k]
+		})
+	return sortedCategories
 }
 
 const getDateDataLabels = (

--- a/libs/ui/src/bands/wire/operations/initialize.ts
+++ b/libs/ui/src/bands/wire/operations/initialize.ts
@@ -177,8 +177,8 @@ const initExistingWire = (
 		changes: {},
 		original: { ...existingWire.data },
 		deletes: {},
-		...getWireDefInfo(wireDef),
-		...addViewOnlyFields(wireDef),
+		...getWireDefInfo(wireDef as RegularWireDefinition),
+		...addViewOnlyFields(wireDef as RegularWireDefinition),
 	}
 }
 
@@ -212,8 +212,8 @@ const initWire = (
 	}
 	return {
 		...getNewPlainWireBase(viewId, wireName),
-		...getWireDefInfo(wireDef),
-		...addViewOnlyFields(wireDef),
+		...getWireDefInfo(wireDef as RegularWireDefinition),
+		...addViewOnlyFields(wireDef as RegularWireDefinition),
 	}
 }
 

--- a/libs/ui/src/definition/wire.ts
+++ b/libs/ui/src/definition/wire.ts
@@ -91,7 +91,8 @@ type WireDefinitionBase = {
 }
 
 type AggregateWireDefinition = WireDefinitionBase & {
-	aggregate: true
+	aggregate?: true
+	batchsize?: number
 	viewOnly?: false
 	/**
 	 * @minLength 2

--- a/libs/ui/src/wireexports.ts
+++ b/libs/ui/src/wireexports.ts
@@ -65,7 +65,6 @@ export type {
 	ValueConditionState,
 	ViewOnlyField,
 	ViewOnlyWireDefinition,
-	Wire,
 	WireConditionState,
 	WireDefinition,
 	WireDefinitionMap,
@@ -75,4 +74,4 @@ export type {
 	WireRecord,
 }
 
-export { isValueCondition, isGroupCondition, isParamCondition }
+export { isValueCondition, isGroupCondition, isParamCondition, Wire }


### PR DESCRIPTION
# What does this PR do?

1. Allow SELECT fields to be used in Charts by treating them like TEXT fields.
2. Performs a count on non-numeric value fields.
3. Adds unit tests for the `aggregate` function.

# Testing
1. Add a chart with a series whose Category Field is a SELECT, and whose Value Field is uesio/core.id. Verify that the values for each Select value are counted.

# Screenshots

<img width="1043" alt="Screen Shot 2024-02-17 at 10 07 45 PM" src="https://github.com/ues-io/uesio/assets/886865/1f29815b-ea15-4be1-b4bc-97d07b5e2182">



