### PR TITLE
Add site api to session api for bots

### DIFF
--- a/apps/platform/pkg/bot/jsdialect/sessionapi.go
+++ b/apps/platform/pkg/bot/jsdialect/sessionapi.go
@@ -14,7 +14,29 @@ type SessionAPI struct {
 	session *sess.Session
 	wsApi   *WorkspaceAPI
 	appApi  *AppAPI
+	siteApi *SiteAPI
 }
+
+type SiteAPI struct {
+	site *meta.Site
+}
+
+func (s *SiteAPI) GetName() string {
+	return s.site.Name
+}
+
+func (s *SiteAPI) GetTitle() string {
+	return s.site.Title
+}
+
+func (s *SiteAPI) GetDomain() string {
+	return s.site.Domain
+}
+
+func (s *SiteAPI) GetSubdomain() string {
+	return s.site.Subdomain
+}
+
 type WorkspaceAPI struct {
 	workspace *meta.Workspace
 }

--- a/libs/ui/src/public_types/server/index.d.ts
+++ b/libs/ui/src/public_types/server/index.d.ts
@@ -93,6 +93,19 @@ interface SessionApi {
 	// If in a Workspace context, returns a Workspace Api
 	// to obtain info about the context Workspace
 	getWorkspace: () => WorkspaceApi
+	// returns a Site Api
+	// to obtain info about the context Workspace
+	getSite: () => SiteApi
+}
+interface SiteApi {
+	// Return the name of the site
+	getName: () => string
+	// Return the title of the site
+	getTitle: () => string
+	// Return the domain of the site
+	getDomain: () => string
+	// Return the subdomain of the site
+	getSubDomain: () => string
 }
 interface WorkspaceApi {
 	// Return the name of the workspace


### PR DESCRIPTION
# What does this PR do?

Gives bots access to information about their site.