### PR TITLE
Allow one-level nested merges

### DIFF
--- a/libs/ui/src/context/context.ts
+++ b/libs/ui/src/context/context.ts
@@ -262,7 +262,14 @@ const providesWire = (o: ContextOptions): o is WireContext | RecordContext =>
 const providesFieldMode = (o: ContextOptions): o is FieldModeContext =>
 	Object.prototype.hasOwnProperty.call(o, "fieldMode")
 
-const defaultMergeRegex = /\$([.\w]*){(.*?)}/g
+//const originalRegex = /\$([.\w]*){(.*?)}/g
+//const oneLevelCapture = /\\$([.\w]*){([^{}]*)}/g
+//const twoLevelCapture = /\$([.\w]*){((?:[^{}]|{[^{}]*})*)}/g
+
+// We're currently using the two level capture regex. This means that we can capture
+// up to two levels of nested merges and it will still just be returned as the
+// outermost merge.
+const defaultMergeRegex = /\$([.\w]*){((?:[^{}]|{[^{}]*})*)}/g
 
 function injectDynamicContext(
 	context: Context,
@@ -302,7 +309,7 @@ function injectDynamicContext(
 }
 
 const getMergeRegexForTypes = (types: MergeType[]) =>
-	new RegExp(`\\$(${types.join("|")}){(.*?)}`, "g")
+	new RegExp(`\\$(${types.join("|")}){((?:[^{}]|{[^{}]*})*)}`, "g")
 
 const newContext = () => new Context()
 

--- a/libs/ui/src/context/merge.spec.ts
+++ b/libs/ui/src/context/merge.spec.ts
@@ -522,6 +522,21 @@ const mergeOptionsTestCases = [
 	},
 ] as MergeWithContextTestCase[]
 
+const mergeTextTestCases = [
+	{
+		name: "simple text merge",
+		context: new Context(),
+		input: "$Text{blah}",
+		expected: "blah",
+	},
+	{
+		name: "simple text merge",
+		context: new Context(),
+		input: "$Text{$SignalOutput{[ask][data]}}",
+		expected: "$SignalOutput{[ask][data]}",
+	},
+] as MergeWithContextTestCase[]
+
 describe("merge", () => {
 	describe("$SignalOutput context", () => {
 		signalOutputMergeTestCases.forEach((tc) => {
@@ -570,6 +585,21 @@ describe("merge", () => {
 	})
 	describe("merge", () => {
 		mergeTestCases.forEach((tc) => {
+			test(tc.name, () => {
+				let errCaught
+				let actual
+				try {
+					actual = tc.context.merge(tc.input)
+				} catch (e) {
+					errCaught = (e as Error).message
+				}
+				expect(errCaught).toEqual(tc.expectError)
+				expect(actual).toEqual(tc.expected)
+			})
+		})
+	})
+	describe("merge", () => {
+		mergeTextTestCases.forEach((tc) => {
 			test(tc.name, () => {
 				let errCaught
 				let actual

--- a/libs/ui/src/context/merge.ts
+++ b/libs/ui/src/context/merge.ts
@@ -17,6 +17,7 @@ type MergeType =
 	| "Prop"
 	| "User"
 	| "Time"
+	| "Text"
 	| "Date"
 	| "RecordMeta"
 	| "Collection"
@@ -143,6 +144,7 @@ const handlers: Record<MergeType, MergeHandler> = {
 		if (!value) return ""
 		return value.toLocaleDateString(undefined, { timeZone: "UTC" })
 	},
+	Text: (expression) => expression,
 	Route: (expression, context) => {
 		if (expression !== "path" && expression !== "title") return ""
 		return context.getRoute()?.[expression] ?? ""


### PR DESCRIPTION
# What does this PR do?

1. Allows one-level nested merges.
2. Adds the Text merge function that will just return the expression sent to the function.

`$Text{$SignalOutput{[ask][data]}}`
