### PR TITLE
fix number input cursor issue

### DIFF
--- a/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/field/number.tsx
+++ b/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/field/number.tsx
@@ -48,10 +48,7 @@ const NumberField: definition.UtilityComponent<NumberFieldProps> = (props) => {
 	const readOnly = mode === "READ" || props.readonly
 	const numberOptions = fieldMetadata?.getNumberMetadata()
 	const decimals = numberOptions?.decimals ?? 2
-	const initialValue =
-		typeof value === "number"
-			? (value as number).toFixed(decimals)
-			: parseFloat(value)
+	const initialValue = typeof value === "number" ? value : parseFloat(value)
 
 	const controlledInputProps = useControlledInputNumber({
 		value: initialValue,


### PR DESCRIPTION
# What does this PR do?

No longer formats number inputs in edit mode.
This was causing a bug with the cursor shifting.
