### PR TITLE
Fix default row action propagation

### DIFF
--- a/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/field/checkbox.tsx
+++ b/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/field/checkbox.tsx
@@ -48,6 +48,12 @@ const CheckboxField: definition.UtilityComponent<CheckboxFieldProps> = (
 				type="checkbox"
 				disabled={readonly}
 				onChange={(event) => setValue?.(event.target.checked)}
+				onClick={(event) => {
+					// Stopping propagation here to prevent actions higher in the
+					// hierarchy from firing. For example a default row action
+					// for a table row.
+					event.stopPropagation()
+				}}
 				autoFocus={focusOnRender}
 			/>
 		</div>

--- a/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/field/text.tsx
+++ b/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/field/text.tsx
@@ -84,6 +84,12 @@ const TextField: definition.UtilityComponent<TextFieldProps> = (props) => {
 					isReadMode && classes.readonly,
 					isPassword && classes.password
 				)}
+				onClick={(e) => {
+					// Stopping propagation here to prevent actions higher in the
+					// hierarchy from firing. For example a default row action
+					// for a table row.
+					e.stopPropagation()
+				}}
 				autoComplete={options?.autoComplete}
 				disabled={isReadMode}
 				autoFocus={focusOnRender}

--- a/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/table/table.tsx
+++ b/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/table/table.tsx
@@ -97,7 +97,7 @@ const Table: definition.UtilityComponent<
 						{rowNumberFunc?.(index + 1)}
 					</div>
 					<CheckboxField
-						className="numbercheck"
+						className={rowNumberFunc ? "numbercheck" : ""}
 						context={context}
 						value={isSelected}
 						setValue={(value: boolean) =>

--- a/libs/apps/uesio/io/bundle/components/searchbox.yaml
+++ b/libs/apps/uesio/io/bundle/components/searchbox.yaml
@@ -20,6 +20,11 @@ properties:
   - name: focusOnRender
     label: Focus on render
     type: CHECKBOX
+  - name: fieldVariant
+    type: METADATA
+    metadata:
+      type: COMPONENTVARIANT
+      grouping: uesio/io.field
 sections:
   - type: HOME
     properties:

--- a/libs/apps/uesio/io/bundle/components/table.yaml
+++ b/libs/apps/uesio/io/bundle/components/table.yaml
@@ -9,6 +9,7 @@ variants:
   - uesio/io.field:uesio/io.default
   - uesio/io.markdownfield:uesio/io.default
   - uesio/io.codefield:uesio/io.default
+  - uesio/io.checkboxfield:uesio/io.default
   - uesio/io.titlebar:uesio/io.infotag
   - uesio/io.table:uesio/io.default
   - uesio/io.button:uesio/io.rowaction

--- a/libs/apps/uesio/io/bundle/componentvariants/uesio/io/checkboxfield/default.yaml
+++ b/libs/apps/uesio/io/bundle/componentvariants/uesio/io/checkboxfield/default.yaml
@@ -4,7 +4,6 @@ extends: uesio/io.field:uesio/io.default
 definition:
   uesio.styleTokens:
     root:
-      - p-[11px]
       - leading-none
     checkbox:
 public: true

--- a/libs/apps/uesio/io/bundle/componentvariants/uesio/io/fieldwrapper/table.yaml
+++ b/libs/apps/uesio/io/bundle/componentvariants/uesio/io/fieldwrapper/table.yaml
@@ -7,4 +7,5 @@ definition:
       - p-2
       - relative
       - "[&_input]:bg-inherit"
+      - "[&_input[type=checkbox]]:ml-[11px]"
 public: true

--- a/libs/ui/src/hooks/signalapi.tsx
+++ b/libs/ui/src/hooks/signalapi.tsx
@@ -80,6 +80,10 @@ const useLinkHandler = (
 			const isMeta = e.getModifierState("Meta")
 			if (isMeta) return
 			e.preventDefault()
+			// Stopping propagation here to prevent actions higher in the
+			// hierarchy from firing. For example a default row action
+			// for a table row.
+			e.stopPropagation()
 			setPendingState?.(true)
 			await runMany(signals, context)
 			isMounted.current && setPendingState?.(false)


### PR DESCRIPTION
# What does this PR do?

Prevents row action default actions from running when editing input elements on that row.
