### PR TITLE
Improve performance by making fewer workspace context queries

### DIFF
--- a/apps/platform/pkg/adapt/postgresio/load.go
+++ b/apps/platform/pkg/adapt/postgresio/load.go
@@ -426,7 +426,7 @@ func (c *Connection) Load(op *wire.LoadOp, session *sess.Session) error {
 		return TranslatePGError(err)
 	}
 
-	//fmt.Printf("PG LOAD %v\n", op.CollectionName)
+	//fmt.Printf("PG LOAD %v -> %s %s\n", op.CollectionName, op.WireName, time.Since(start))
 	if env.InDevMode() {
 		val, _ := queryCounts.LoadOrStore(op.CollectionName, new(int64))
 		ptr := val.(*int64)

--- a/apps/platform/pkg/auth/auth.go
+++ b/apps/platform/pkg/auth/auth.go
@@ -242,6 +242,7 @@ func getUser(field, value string, withPicture bool, session *sess.Session, conne
 		&user,
 		&datasource.PlatformLoadOptions{
 			Connection: connection,
+			WireName:   "AuthGetUser",
 			Fields:     fields,
 			Conditions: []wire.LoadRequestCondition{
 				{
@@ -275,7 +276,7 @@ func getAuthSource(key string, session *sess.Session) (*meta.AuthSource, error) 
 	if err != nil {
 		return nil, err
 	}
-	err = bundle.Load(authSource, session, nil)
+	err = bundle.Load(authSource, nil, session, nil)
 
 	if err != nil {
 		return nil, err
@@ -289,7 +290,7 @@ func GetSignupMethod(key string, session *sess.Session) (*meta.SignupMethod, err
 	if err != nil {
 		return nil, err
 	}
-	err = bundle.Load(signupMethod, session, nil)
+	err = bundle.Load(signupMethod, nil, session, nil)
 
 	if err != nil {
 		return nil, err
@@ -304,6 +305,7 @@ func getLoginMethod(value, field, authSourceID string, session *sess.Session) (*
 	err := datasource.PlatformLoadOne(
 		&loginMethod,
 		&datasource.PlatformLoadOptions{
+			WireName: "AuthGetLoginMethod",
 			Fields: []wire.LoadRequestField{
 				{
 					ID: "uesio/core.federation_id",

--- a/apps/platform/pkg/auth/login.go
+++ b/apps/platform/pkg/auth/login.go
@@ -127,7 +127,7 @@ func getLoginRoute(session *sess.Session) (*meta.Route, error) {
 	if err != nil {
 		return nil, err
 	}
-	err = bundle.Load(loginRoute, session, nil)
+	err = bundle.Load(loginRoute, nil, session, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/apps/platform/pkg/bot/jsdialect/routebotapi.go
+++ b/apps/platform/pkg/bot/jsdialect/routebotapi.go
@@ -123,7 +123,7 @@ func HandleBotResponse(api *RouteBotAPI) (finalRoute *meta.Route, err error) {
 		if err != nil {
 			return nil, err
 		}
-		if err = bundle.Load(route, api.session, api.connection); err != nil {
+		if err = bundle.Load(route, nil, api.session, api.connection); err != nil {
 			return nil, exceptions.NewNotFoundException("could not find requested redirect route: " + localizedRouteKey)
 		}
 		finalRoute = route

--- a/apps/platform/pkg/bot/systemdialect/systembot_load_allmetadata.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_load_allmetadata.go
@@ -8,6 +8,7 @@ import (
 	"golang.org/x/exp/slices"
 
 	"github.com/thecloudmasters/uesio/pkg/bundle"
+	"github.com/thecloudmasters/uesio/pkg/bundlestore"
 	"github.com/thecloudmasters/uesio/pkg/constant/commonfields"
 	"github.com/thecloudmasters/uesio/pkg/datasource"
 	"github.com/thecloudmasters/uesio/pkg/goutils"
@@ -227,7 +228,9 @@ func runAllMetadataLoadBot(op *wire.LoadOp, connection wire.Connection, session 
 			return err
 		}
 		group.AddItem(item)
-		err = bundle.Load(item, session, nil)
+		err = bundle.Load(item, &bundlestore.GetItemOptions{
+			IncludeUserFields: true,
+		}, session, nil)
 		if err != nil {
 			return err
 		}
@@ -278,7 +281,10 @@ func runAllMetadataLoadBot(op *wire.LoadOp, connection wire.Connection, session 
 		}
 
 		if !onlyLoadCommonFields {
-			err = bundle.LoadAllFromNamespaces(namespaces, group, conditions, session, nil)
+			err = bundle.LoadAllFromNamespaces(namespaces, group, &bundlestore.GetAllItemsOptions{
+				Conditions:        conditions,
+				IncludeUserFields: true,
+			}, session, nil)
 			if err != nil {
 				return err
 			}

--- a/apps/platform/pkg/bot/systemdialect/systembot_load_myintegrationcredentials.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_load_myintegrationcredentials.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	"github.com/thecloudmasters/uesio/pkg/bundle"
+	"github.com/thecloudmasters/uesio/pkg/bundlestore"
 	"github.com/thecloudmasters/uesio/pkg/constant/commonfields"
 	"github.com/thecloudmasters/uesio/pkg/datasource"
 	"github.com/thecloudmasters/uesio/pkg/goutils"
@@ -132,11 +133,15 @@ func getAllPerUserIntegrationsUserHasAccessTo(session *sess.Session, connection 
 	// If we have unique namespaces to load from, do a more targeted load.
 	if len(uniqueNames) > 0 {
 		conditions["uesio/studio.name"] = goutils.MapKeys(uniqueNames)
-		if err := bundle.LoadAllFromNamespaces(goutils.MapKeys(uniqueNamespaces), group, conditions, session, connection); err != nil {
+		if err := bundle.LoadAllFromNamespaces(goutils.MapKeys(uniqueNamespaces), group, &bundlestore.GetAllItemsOptions{
+			Conditions: conditions,
+		}, session, connection); err != nil {
 			return nil, errors.New("unable to load integrations: " + err.Error())
 		}
 	} else {
-		if err := bundle.LoadAllFromAny(group, conditions, session, connection); err != nil {
+		if err := bundle.LoadAllFromAny(group, &bundlestore.GetAllItemsOptions{
+			Conditions: conditions,
+		}, session, connection); err != nil {
 			return nil, errors.New("unable to load integrations: " + err.Error())
 		}
 	}

--- a/apps/platform/pkg/bot/systemdialect/systembot_route_login.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_route_login.go
@@ -18,7 +18,7 @@ func runLoginRouteBot(route *meta.Route, request *http.Request, connection wire.
 	if err != nil {
 		return nil, err
 	}
-	err = bundle.Load(loginRoute, session, nil)
+	err = bundle.Load(loginRoute, nil, session, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/apps/platform/pkg/bot/systemdialect/systembot_route_signup.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_route_signup.go
@@ -18,7 +18,7 @@ func runSignupRouteBot(route *meta.Route, request *http.Request, connection wire
 	if err != nil {
 		return nil, err
 	}
-	err = bundle.Load(signupRoute, session, nil)
+	err = bundle.Load(signupRoute, nil, session, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/apps/platform/pkg/bundle/bundles.go
+++ b/apps/platform/pkg/bundle/bundles.go
@@ -112,13 +112,13 @@ func GetBundleStoreConnection(namespace string, session *sess.Session, connectio
 	})
 }
 
-func LoadAllFromAny(group meta.BundleableGroup, conditions meta.BundleConditions, session *sess.Session, connection wire.Connection) error {
-	return LoadAllFromNamespaces(session.GetContextNamespaces(), group, conditions, session, connection)
+func LoadAllFromAny(group meta.BundleableGroup, options *bundlestore.GetAllItemsOptions, session *sess.Session, connection wire.Connection) error {
+	return LoadAllFromNamespaces(session.GetContextNamespaces(), group, options, session, connection)
 }
 
-func LoadAllFromNamespaces(namespaces []string, group meta.BundleableGroup, conditions meta.BundleConditions, session *sess.Session, connection wire.Connection) error {
+func LoadAllFromNamespaces(namespaces []string, group meta.BundleableGroup, options *bundlestore.GetAllItemsOptions, session *sess.Session, connection wire.Connection) error {
 	for _, namespace := range namespaces {
-		err := LoadAll(group, namespace, conditions, session, connection)
+		err := LoadAll(group, namespace, options, session, connection)
 		if err != nil {
 			return err
 		}
@@ -126,24 +126,24 @@ func LoadAllFromNamespaces(namespaces []string, group meta.BundleableGroup, cond
 	return nil
 }
 
-func HasAny(group meta.BundleableGroup, namespace string, conditions meta.BundleConditions, session *sess.Session, connection wire.Connection) (bool, error) {
+func HasAny(group meta.BundleableGroup, namespace string, options *bundlestore.HasAnyOptions, session *sess.Session, connection wire.Connection) (bool, error) {
 	bs, err := GetBundleStoreConnection(namespace, session, connection)
 	if err != nil {
 		return false, err
 	}
-	return bs.HasAny(group, conditions)
+	return bs.HasAny(group, options)
 }
 
-func LoadAll(group meta.BundleableGroup, namespace string, conditions meta.BundleConditions, session *sess.Session, connection wire.Connection) error {
+func LoadAll(group meta.BundleableGroup, namespace string, options *bundlestore.GetAllItemsOptions, session *sess.Session, connection wire.Connection) error {
 	bs, err := GetBundleStoreConnection(namespace, session, connection)
 	if err != nil {
 		fmt.Println("Failed Load All: " + group.GetName())
 		return err
 	}
-	return bs.GetAllItems(group, conditions)
+	return bs.GetAllItems(group, options)
 }
 
-func LoadMany(items []meta.BundleableItem, allowMissingItems bool, session *sess.Session, connection wire.Connection) error {
+func LoadMany(items []meta.BundleableItem, options *bundlestore.GetManyItemsOptions, session *sess.Session, connection wire.Connection) error {
 	for namespace, nsItems := range groupItemsByNamespace(items) {
 		bs, err := GetBundleStoreConnection(namespace, session, connection)
 		if err != nil {
@@ -153,19 +153,19 @@ func LoadMany(items []meta.BundleableItem, allowMissingItems bool, session *sess
 			}
 			return err
 		}
-		if err = bs.GetManyItems(nsItems, allowMissingItems); err != nil {
+		if err = bs.GetManyItems(nsItems, options); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func Load(item meta.BundleableItem, session *sess.Session, connection wire.Connection) error {
+func Load(item meta.BundleableItem, options *bundlestore.GetItemOptions, session *sess.Session, connection wire.Connection) error {
 	bs, err := GetBundleStoreConnection(item.GetNamespace(), session, connection)
 	if err != nil {
 		return err
 	}
-	return bs.GetItem(item)
+	return bs.GetItem(item, options)
 }
 
 func GetItemAttachment(w io.Writer, item meta.AttachableItem, path string, session *sess.Session, connection wire.Connection) (file.Metadata, error) {

--- a/apps/platform/pkg/bundlestore/bundlestore.go
+++ b/apps/platform/pkg/bundlestore/bundlestore.go
@@ -58,11 +58,29 @@ type BundleZipOptions struct {
 	IncludeGeneratedTypes bool
 }
 
+type GetItemOptions struct {
+	IncludeUserFields bool
+}
+
+type GetManyItemsOptions struct {
+	AllowMissingItems bool
+	IncludeUserFields bool
+}
+
+type GetAllItemsOptions struct {
+	Conditions        meta.BundleConditions
+	IncludeUserFields bool
+}
+
+type HasAnyOptions struct {
+	Conditions meta.BundleConditions
+}
+
 type BundleStoreConnection interface {
-	GetItem(item meta.BundleableItem) error
-	GetManyItems(items []meta.BundleableItem, allowMissingItems bool) error
-	GetAllItems(group meta.BundleableGroup, conditions meta.BundleConditions) error
-	HasAny(group meta.BundleableGroup, conditions meta.BundleConditions) (bool, error)
+	GetItem(item meta.BundleableItem, options *GetItemOptions) error
+	GetManyItems(items []meta.BundleableItem, options *GetManyItemsOptions) error
+	GetAllItems(group meta.BundleableGroup, options *GetAllItemsOptions) error
+	HasAny(group meta.BundleableGroup, options *HasAnyOptions) (bool, error)
 	GetItemAttachment(w io.Writer, item meta.AttachableItem, path string) (file.Metadata, error)
 	GetItemAttachments(creator FileCreator, item meta.AttachableItem) error
 	GetBundleDef() (*meta.BundleDef, error)

--- a/apps/platform/pkg/configstore/configstore.go
+++ b/apps/platform/pkg/configstore/configstore.go
@@ -108,7 +108,7 @@ func GetValueFromKey(key string, session *sess.Session) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	err = bundle.Load(configValue, session, nil)
+	err = bundle.Load(configValue, nil, session, nil)
 	if err != nil {
 		return "", err
 	}
@@ -139,7 +139,7 @@ func SetValueFromKey(key, value string, session *sess.Session) error {
 	if err != nil {
 		return err
 	}
-	err = bundle.Load(configValue, session, nil)
+	err = bundle.Load(configValue, nil, session, nil)
 	if err != nil {
 		return err
 	}

--- a/apps/platform/pkg/controller/configvalue.go
+++ b/apps/platform/pkg/controller/configvalue.go
@@ -30,7 +30,7 @@ func getValue(session *sess.Session, key string) (*ConfigValueResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	err = bundle.Load(configValue, session, nil)
+	err = bundle.Load(configValue, nil, session, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/apps/platform/pkg/controller/file/componentpack.go
+++ b/apps/platform/pkg/controller/file/componentpack.go
@@ -31,7 +31,7 @@ func ServeComponentPackFile(w http.ResponseWriter, r *http.Request) {
 		ctlutil.HandleError(w, err)
 		return
 	}
-	if err = bundle.Load(componentPack, session, nil); err != nil {
+	if err = bundle.Load(componentPack, nil, session, nil); err != nil {
 		ctlutil.HandleError(w, err)
 		return
 	}

--- a/apps/platform/pkg/controller/file/serve_file.go
+++ b/apps/platform/pkg/controller/file/serve_file.go
@@ -55,7 +55,7 @@ func ServeFileContent(file *meta.File, version string, w http.ResponseWriter, r 
 		return
 	}
 
-	if err := bundle.Load(file, session, connection); err != nil {
+	if err := bundle.Load(file, nil, session, connection); err != nil {
 		ctlutil.HandleError(w, err)
 		return
 	}

--- a/apps/platform/pkg/controller/getbotparams.go
+++ b/apps/platform/pkg/controller/getbotparams.go
@@ -70,7 +70,7 @@ func GetBotParams(w http.ResponseWriter, r *http.Request) {
 		robot = meta.NewRunActionBot(namespace, name)
 	}
 
-	err := bundle.Load(robot, session, nil)
+	err := bundle.Load(robot, nil, session, nil)
 	if err != nil {
 		ctlutil.HandleError(w, err)
 		return

--- a/apps/platform/pkg/controller/getrouteparams.go
+++ b/apps/platform/pkg/controller/getrouteparams.go
@@ -69,7 +69,7 @@ func GetRouteParams(w http.ResponseWriter, r *http.Request) {
 	name := vars["name"]
 	session := middleware.GetSession(r)
 	loader := func(item meta.BundleableItem) error {
-		return bundle.Load(item, session, nil)
+		return bundle.Load(item, nil, session, nil)
 	}
 	route := meta.NewBaseRoute(namespace, name)
 	if err := loader(route); err != nil {

--- a/apps/platform/pkg/controller/getviewparams.go
+++ b/apps/platform/pkg/controller/getviewparams.go
@@ -62,7 +62,7 @@ func GetViewParams(w http.ResponseWriter, r *http.Request) {
 	name := vars["name"]
 	session := middleware.GetSession(r)
 	loader := func(item meta.BundleableItem) error {
-		return bundle.Load(item, session, nil)
+		return bundle.Load(item, nil, session, nil)
 	}
 	viewParams, err := getParamsForView(namespace, name, loader)
 	if err != nil {

--- a/apps/platform/pkg/controller/integrationaction.go
+++ b/apps/platform/pkg/controller/integrationaction.go
@@ -184,7 +184,7 @@ func DescribeIntegrationAction(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		robot := meta.NewRunActionBot(actionBotNamespace, actionBotName)
-		err = bundle.Load(robot, session, nil)
+		err = bundle.Load(robot, nil, session, nil)
 		if err != nil {
 			ctlutil.HandleError(w, err)
 			return

--- a/apps/platform/pkg/controller/metadatalist.go
+++ b/apps/platform/pkg/controller/metadatalist.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/thecloudmasters/uesio/pkg/bundlestore"
 	"github.com/thecloudmasters/uesio/pkg/controller/ctlutil"
 	"github.com/thecloudmasters/uesio/pkg/controller/filejson"
 	"github.com/thecloudmasters/uesio/pkg/goutils"
@@ -34,13 +35,17 @@ func getMetadataList(metadatatype, namespace, grouping string, session *sess.Ses
 	var appNames []string
 
 	if namespace != "" {
-		err = bundle.LoadAll(collection, namespace, conditions, session, nil)
+		err = bundle.LoadAll(collection, namespace, &bundlestore.GetAllItemsOptions{
+			Conditions: conditions,
+		}, session, nil)
 		if err != nil {
 			return nil, err
 		}
 		appNames = []string{namespace}
 	} else {
-		err := bundle.LoadAllFromAny(collection, conditions, session, nil)
+		err := bundle.LoadAllFromAny(collection, &bundlestore.GetAllItemsOptions{
+			Conditions: conditions,
+		}, session, nil)
 		if err != nil {
 			return nil, err
 		}

--- a/apps/platform/pkg/controller/oauth/callback.go
+++ b/apps/platform/pkg/controller/oauth/callback.go
@@ -86,7 +86,7 @@ func Callback(w http.ResponseWriter, r *http.Request) {
 
 func loadCallbackRoute(r *http.Request, coreSession *sess.Session, platformConn wire.Connection) (*meta.Route, error) {
 	route := meta.NewBaseRoute("uesio/core", "oauth2callback")
-	if err := bundle.Load(route, coreSession, platformConn); err != nil {
+	if err := bundle.Load(route, nil, coreSession, platformConn); err != nil {
 		return nil, errors.New("unable to load oauth callback route: " + err.Error())
 	}
 	// Make sure to do a copy to avoid mutating in-memory/cached metadata

--- a/apps/platform/pkg/controller/view.go
+++ b/apps/platform/pkg/controller/view.go
@@ -30,7 +30,7 @@ func ViewPreview(buildMode bool) http.HandlerFunc {
 		view := meta.NewBaseView(viewNamespace, viewName)
 
 		// Make sure this is a legit view that we have access to
-		err := bundle.Load(view, session, nil)
+		err := bundle.Load(view, nil, session, nil)
 		if err != nil {
 			HandleErrorRoute(w, r, session, "", err, false)
 			return

--- a/apps/platform/pkg/datasource/bots.go
+++ b/apps/platform/pkg/datasource/bots.go
@@ -49,7 +49,7 @@ func RunRouteBots(route *meta.Route, request *http.Request, session *sess.Sessio
 
 	bundleLoader := func(item meta.BundleableItem) error {
 		// TODO: WHY DOES connection have to be nil here
-		return bundle.Load(item, session, nil)
+		return bundle.Load(item, nil, session, nil)
 	}
 
 	routeBot = meta.NewRouteBot(botNamespace, botName)
@@ -87,9 +87,11 @@ func runBeforeSaveBots(request *wire.SaveOp, connection wire.Connection, session
 	var robots meta.BotCollection
 
 	// TODO why does connection have to be nil
-	err := bundle.LoadAllFromAny(&robots, meta.BundleConditions{
-		"uesio/studio.collection": collectionName,
-		"uesio/studio.type":       "BEFORESAVE",
+	err := bundle.LoadAllFromAny(&robots, &bundlestore.GetAllItemsOptions{
+		Conditions: meta.BundleConditions{
+			"uesio/studio.collection": collectionName,
+			"uesio/studio.type":       "BEFORESAVE",
+		},
 	}, session, nil)
 	if err != nil {
 		return err
@@ -168,7 +170,7 @@ func runExternalDataSourceLoadBot(botName string, op *wire.LoadOp, connection wi
 		Type: "LOAD",
 	}
 	// TODO: Figure out why connection has to be nil
-	err = bundle.Load(loadBot, session, nil)
+	err = bundle.Load(loadBot, nil, session, nil)
 	// See if there is a SYSTEM bot instead
 	if err != nil {
 		systemDialect, err2 := bot.GetBotDialect("SYSTEM")
@@ -212,7 +214,7 @@ func runExternalDataSourceSaveBot(botName string, op *wire.SaveOp, connection wi
 		Type: "SAVE",
 	}
 	// TODO: Figure out why connection has to be nil
-	err = bundle.Load(saveBot, session, nil)
+	err = bundle.Load(saveBot, nil, session, nil)
 	if err != nil {
 		return exceptions.NewNotFoundException("could not find requested SAVE bot: " + botName)
 	}
@@ -232,9 +234,11 @@ func runAfterSaveBots(request *wire.SaveOp, connection wire.Connection, session 
 	var robots meta.BotCollection
 
 	// TODO: Figure out why connection has to be nil
-	err := bundle.LoadAllFromAny(&robots, meta.BundleConditions{
-		"uesio/studio.collection": collectionName,
-		"uesio/studio.type":       "AFTERSAVE",
+	err := bundle.LoadAllFromAny(&robots, &bundlestore.GetAllItemsOptions{
+		Conditions: meta.BundleConditions{
+			"uesio/studio.collection": collectionName,
+			"uesio/studio.type":       "AFTERSAVE",
+		},
 	}, session, nil)
 	if err != nil {
 		return err
@@ -275,7 +279,7 @@ func CallGeneratorBot(create bundlestore.FileCreator, namespace, name string, pa
 	robot := meta.NewGeneratorBot(namespace, name)
 	bundleLoader := func(item meta.BundleableItem) error {
 		// TODO: WHY DOES connection have to be nil here
-		return bundle.Load(item, session, nil)
+		return bundle.Load(item, nil, session, nil)
 	}
 
 	if err := bundleLoader(robot); err != nil {
@@ -340,7 +344,7 @@ func CallListenerBot(namespace, name string, params map[string]interface{}, conn
 
 	bundleLoader := func(item meta.BundleableItem) error {
 		// TODO: WHY DOES connection have to be nil here
-		return bundle.Load(item, session, nil)
+		return bundle.Load(item, nil, session, nil)
 	}
 
 	// First try to run a system bot
@@ -450,7 +454,7 @@ func RunIntegrationAction(ic *wire.IntegrationConnection, actionKey string, requ
 
 	bundleLoader := func(item meta.BundleableItem) error {
 		// TODO: WHY DOES connection have to be nil here
-		return bundle.Load(item, session, nil)
+		return bundle.Load(item, nil, session, nil)
 	}
 	robot := meta.NewRunActionBot(botNamespace, botName)
 	if err = bundleLoader(robot); err != nil {

--- a/apps/platform/pkg/datasource/credentials.go
+++ b/apps/platform/pkg/datasource/credentials.go
@@ -29,7 +29,7 @@ func GetCredentials(key string, session *sess.Session) (*wire.Credentials, error
 		return nil, err
 	}
 
-	err = bundle.Load(credential, session, nil)
+	err = bundle.Load(credential, nil, session, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/apps/platform/pkg/datasource/integ.go
+++ b/apps/platform/pkg/datasource/integ.go
@@ -19,7 +19,7 @@ func GetIntegration(integrationID string, session *sess.Session, connection wire
 	if err != nil {
 		return nil, err
 	}
-	if err = bundle.Load(integrationInstance, session, connection); err != nil {
+	if err = bundle.Load(integrationInstance, nil, session, connection); err != nil {
 		return nil, exceptions.NewNotFoundException("could not find Integration: " + integrationID)
 	}
 	return integrationInstance, nil
@@ -31,7 +31,7 @@ func GetIntegrationType(integrationTypeName string, session *sess.Session, conne
 	if err != nil {
 		return nil, err
 	}
-	if err = bundle.Load(integrationType, session, connection); err != nil {
+	if err = bundle.Load(integrationType, nil, session, connection); err != nil {
 		return nil, exceptions.NewNotFoundException("could not find Integration Type: " + integrationTypeName)
 	}
 	return integrationType, nil
@@ -44,7 +44,7 @@ func GetIntegrationAction(integrationType, actionKey string, session *sess.Sessi
 	if err != nil {
 		return nil, exceptions.NewNotFoundException("could not find integration action: " + actionKey)
 	}
-	if err = bundle.Load(action, session, connection); err != nil {
+	if err = bundle.Load(action, nil, session, connection); err != nil {
 		return nil, exceptions.NewNotFoundException("could not find integration action: " + actionKey)
 	}
 	return action, nil

--- a/apps/platform/pkg/datasource/loadprofile.go
+++ b/apps/platform/pkg/datasource/loadprofile.go
@@ -11,7 +11,7 @@ func LoadAndHydrateProfile(profileKey string, session *sess.Session) (*meta.Prof
 	if err != nil {
 		return nil, err
 	}
-	if err = bundle.Load(profile, session, nil); err != nil {
+	if err = bundle.Load(profile, nil, session, nil); err != nil {
 		return nil, err
 	}
 	// LoadFromSite in the permission sets for this profile
@@ -20,7 +20,7 @@ func LoadAndHydrateProfile(profileKey string, session *sess.Session) (*meta.Prof
 		if err != nil {
 			return nil, err
 		}
-		if err := bundle.Load(permissionSet, session, nil); err != nil {
+		if err := bundle.Load(permissionSet, nil, session, nil); err != nil {
 			return nil, err
 		}
 		profile.PermissionSets = append(profile.PermissionSets, *permissionSet)

--- a/apps/platform/pkg/datasource/platformload.go
+++ b/apps/platform/pkg/datasource/platformload.go
@@ -20,6 +20,7 @@ type PlatformLoadOptions struct {
 	LoadAll            bool
 	Params             map[string]interface{}
 	RequireWriteAccess bool
+	WireName           string
 }
 
 func (plo *PlatformLoadOptions) GetConditionsDebug() string {
@@ -50,7 +51,7 @@ func PlatformLoad(group meta.CollectionableGroup, options *PlatformLoadOptions, 
 		fields = GetLoadRequestFields(group.GetFields())
 	}
 	return doPlatformLoad(&wire.LoadOp{
-		WireName:           group.GetName() + "Wire",
+		WireName:           "Platform Load: " + options.WireName,
 		CollectionName:     group.GetName(),
 		Collection:         group,
 		Conditions:         options.Conditions,

--- a/apps/platform/pkg/datasource/secrets.go
+++ b/apps/platform/pkg/datasource/secrets.go
@@ -15,7 +15,7 @@ func GetSecretFromKey(key string, session *sess.Session) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if err = bundle.Load(secret, session, nil); err != nil {
+	if err = bundle.Load(secret, nil, session, nil); err != nil {
 		return "", err
 	}
 	return secretstore.GetSecret(secret, session)
@@ -27,7 +27,7 @@ func SetSecretFromKey(key, value string, session *sess.Session) error {
 	if err != nil {
 		return err
 	}
-	if err = bundle.Load(secret, session, nil); err != nil {
+	if err = bundle.Load(secret, nil, session, nil); err != nil {
 		return err
 	}
 	return secretstore.SetSecret(secret, value, session)

--- a/apps/platform/pkg/datasource/usertokens.go
+++ b/apps/platform/pkg/datasource/usertokens.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	"github.com/thecloudmasters/uesio/pkg/bundle"
+	"github.com/thecloudmasters/uesio/pkg/bundlestore"
 	"github.com/thecloudmasters/uesio/pkg/meta"
 	"github.com/thecloudmasters/uesio/pkg/sess"
 	"github.com/thecloudmasters/uesio/pkg/templating"
@@ -60,7 +61,9 @@ func getTokensForRequest(connection wire.Connection, session *sess.Session, toke
 	}
 
 	// TBD: Why is connection nil here??
-	if err := bundle.LoadMany(tokens, false, session, nil); err != nil {
+	if err := bundle.LoadMany(tokens, &bundlestore.GetManyItemsOptions{
+		AllowMissingItems: false,
+	}, session, nil); err != nil {
 		return nil, err
 	}
 
@@ -134,7 +137,7 @@ func HydrateTokenMap(tokenMap sess.TokenMap, tokenDefs meta.UserAccessTokenColle
 			lookupResults := &wire.Collection{}
 			var loadOp = &wire.LoadOp{
 				CollectionName: token.Collection,
-				WireName:       "foo",
+				WireName:       "UserTokenRequest",
 				Collection:     lookupResults,
 				Conditions:     loadConditions,
 				Fields:         fieldsMap.getRequestFields(),

--- a/apps/platform/pkg/datasource/workspacecontext.go
+++ b/apps/platform/pkg/datasource/workspacecontext.go
@@ -127,6 +127,7 @@ func addWorkspaceContext(workspace *meta.Workspace, session *sess.Session, conne
 	// Lookup to see if this user wants to impersonate a profile.
 	_, err := Load([]*wire.LoadOp{
 		{
+			WireName:       "CheckImpersonationWorkspaceContext",
 			CollectionName: "uesio/studio.workspaceuser",
 			Collection:     results,
 			Query:          true,
@@ -242,7 +243,34 @@ func QueryWorkspaceForWrite(value, field string, session *sess.Session, connecti
 	err := PlatformLoadOne(
 		&workspace,
 		&PlatformLoadOptions{
+			WireName:   "QueryWorkspaceForWrite",
 			Connection: connection,
+			Fields: []wire.LoadRequestField{
+				{
+					ID: "uesio/studio.name",
+				},
+				{
+					ID: "uesio/studio.app",
+				},
+				{
+					ID: "uesio/studio.loginroute",
+				},
+				{
+					ID: "uesio/studio.signuproute",
+				},
+				{
+					ID: "uesio/studio.homeroute",
+				},
+				{
+					ID: "uesio/studio.defaulttheme",
+				},
+				{
+					ID: "uesio/studio.publicprofile",
+				},
+				{
+					ID: "uesio/studio.favicon",
+				},
+			},
 			Conditions: []wire.LoadRequestCondition{
 				{
 					Field: field,

--- a/apps/platform/pkg/featureflagstore/featureflagstore.go
+++ b/apps/platform/pkg/featureflagstore/featureflagstore.go
@@ -74,7 +74,7 @@ func SetValueFromKey(key string, value interface{}, userID string, session *sess
 	if err != nil {
 		return err
 	}
-	err = bundle.Load(FeatureFlag, session, nil)
+	err = bundle.Load(FeatureFlag, nil, session, nil)
 	if err != nil {
 		return err
 	}

--- a/apps/platform/pkg/fileadapt/fileadapter.go
+++ b/apps/platform/pkg/fileadapt/fileadapter.go
@@ -40,7 +40,7 @@ func GetFileConnection(fileSourceID string, session *sess.Session) (file.Connect
 	if err != nil {
 		return nil, err
 	}
-	err = bundle.Load(fs, session, nil)
+	err = bundle.Load(fs, nil, session, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/apps/platform/pkg/limits/limits.go
+++ b/apps/platform/pkg/limits/limits.go
@@ -33,7 +33,7 @@ func GetNumericLimit(numericLimitName, user string, session *sess.Session) (int,
 	if err != nil {
 		return 0, err
 	}
-	err = bundle.Load(featureFlag, session, nil)
+	err = bundle.Load(featureFlag, nil, session, nil)
 	if err != nil {
 		return 0, err
 	}

--- a/apps/platform/pkg/retrieve/retrieve.go
+++ b/apps/platform/pkg/retrieve/retrieve.go
@@ -48,7 +48,9 @@ func GenerateAppTypeScriptTypes(out io.Writer, bs bundlestore.BundleStoreConnect
 	for _, group := range meta.GetMetadataTypesWithTypescriptDefinitions() {
 		metadataType := group.GetName()
 		genOptions := group.GetTypeGenerationOptions()
-		err := bs.GetAllItems(group, genOptions.GetTypescriptableItemConditions())
+		err := bs.GetAllItems(group, &bundlestore.GetAllItemsOptions{
+			Conditions: genOptions.GetTypescriptableItemConditions(),
+		})
 		if err != nil {
 			return errors.New("failed to retrieve items of type: " + metadataType + ": " + err.Error())
 		}

--- a/apps/platform/pkg/routing/deps.go
+++ b/apps/platform/pkg/routing/deps.go
@@ -10,6 +10,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/thecloudmasters/uesio/pkg/bundle"
+	"github.com/thecloudmasters/uesio/pkg/bundlestore"
 	"github.com/thecloudmasters/uesio/pkg/configstore"
 	"github.com/thecloudmasters/uesio/pkg/datasource"
 	"github.com/thecloudmasters/uesio/pkg/featureflagstore"
@@ -40,7 +41,7 @@ func loadViewDef(key string, session *sess.Session) (*meta.View, error) {
 		return nil, err
 	}
 
-	err = bundle.Load(subViewDep, session, nil)
+	err = bundle.Load(subViewDep, nil, session, nil)
 	if err != nil {
 		return nil, errors.New("Failed to load SubView: " + key + " : " + err.Error())
 	}
@@ -54,7 +55,7 @@ func loadVariant(key string, session *sess.Session) (*meta.ComponentVariant, err
 		return nil, err
 	}
 
-	err = bundle.Load(variantDep, session, nil)
+	err = bundle.Load(variantDep, nil, session, nil)
 	if err != nil {
 		return nil, errors.New("Failed to load variant: " + key + " : " + err.Error())
 	}
@@ -83,7 +84,7 @@ func addComponentPackToDeps(deps *preload.PreloadMetadata, packNamespace, packNa
 		}
 	}
 	if pack.UpdatedAt == 0 {
-		if err := bundle.Load(pack, session, nil); err != nil || pack.UpdatedAt == 0 {
+		if err := bundle.Load(pack, nil, session, nil); err != nil || pack.UpdatedAt == 0 {
 			pack.UpdatedAt = time.Now().Unix()
 		}
 	}
@@ -102,7 +103,7 @@ func getDepsForUtilityComponent(key string, deps *preload.PreloadMetadata, sessi
 
 	utility := meta.NewBaseUtility(namespace, name)
 
-	if err = bundle.Load(utility, session, nil); err != nil {
+	if err = bundle.Load(utility, nil, session, nil); err != nil {
 		return err
 	}
 
@@ -353,7 +354,7 @@ func GetBuilderDependencies(viewNamespace, viewName string, deps *preload.Preloa
 		return err
 	}
 
-	err = bundle.Load(theme, session.RemoveWorkspaceContext(), nil)
+	err = bundle.Load(theme, nil, session.RemoveWorkspaceContext(), nil)
 	if err != nil {
 		return err
 	}
@@ -395,7 +396,7 @@ func GetMetadataDeps(route *meta.Route, session *sess.Session) (*preload.Preload
 		return nil, err
 	}
 
-	err = bundle.Load(theme, session, nil)
+	err = bundle.Load(theme, nil, session, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -454,12 +455,16 @@ func GetMetadataDeps(route *meta.Route, session *sess.Session) (*preload.Preload
 		collectionMap[assignment.Collection] = collection
 	}
 
-	err = bundle.LoadMany(routes, true, session, nil)
+	err = bundle.LoadMany(routes, &bundlestore.GetManyItemsOptions{
+		AllowMissingItems: true,
+	}, session, nil)
 	if err != nil {
 		return nil, errors.New("Failed to load routes for route assignments: " + err.Error())
 	}
 
-	err = bundle.LoadMany(collections, true, session, nil)
+	err = bundle.LoadMany(collections, &bundlestore.GetManyItemsOptions{
+		AllowMissingItems: true,
+	}, session, nil)
 	if err != nil {
 		return nil, errors.New("Failed to load collections for route assignments: " + err.Error())
 	}
@@ -781,7 +786,7 @@ func (vdm *ViewDepMap) AddComponent(key string, session *sess.Session) (*meta.Co
 	if err != nil {
 		return nil, err
 	}
-	err = bundle.Load(component, session, nil)
+	err = bundle.Load(component, nil, session, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/apps/platform/pkg/routing/routing.go
+++ b/apps/platform/pkg/routing/routing.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/thecloudmasters/uesio/pkg/bundle"
+	"github.com/thecloudmasters/uesio/pkg/bundlestore"
 	"github.com/thecloudmasters/uesio/pkg/datasource"
 	"github.com/thecloudmasters/uesio/pkg/merge"
 	"github.com/thecloudmasters/uesio/pkg/meta"
@@ -30,7 +31,7 @@ func GetHomeRoute(session *sess.Session) (*meta.Route, error) {
 	if err != nil {
 		return nil, exceptions.NewNotFoundException(err.Error())
 	}
-	err = bundle.Load(route, session, nil)
+	err = bundle.Load(route, nil, session, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -108,7 +109,9 @@ func GetRouteFromAssignment(r *http.Request, namespace, collection string, viewt
 	var routeAssignment *meta.RouteAssignment
 	var routeAssignments meta.RouteAssignmentCollection
 
-	err := bundle.LoadAllFromAny(&routeAssignments, map[string]interface{}{"uesio/studio.collection": namespace + "." + collection}, session, nil)
+	err := bundle.LoadAllFromAny(&routeAssignments, &bundlestore.GetAllItemsOptions{
+		Conditions: map[string]interface{}{"uesio/studio.collection": namespace + "." + collection},
+	}, session, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -129,7 +132,7 @@ func GetRouteFromAssignment(r *http.Request, namespace, collection string, viewt
 		return nil, err
 	}
 
-	err = bundle.Load(route, session, nil)
+	err = bundle.Load(route, nil, session, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -157,7 +160,7 @@ func GetRouteFromAssignment(r *http.Request, namespace, collection string, viewt
 func GetRouteByKey(r *http.Request, namespace, routeName string, session *sess.Session, connection wire.Connection) (*meta.Route, error) {
 	route := meta.NewBaseRoute(namespace, routeName)
 	// TODO: connection should not have to be nil
-	err := bundle.Load(route, session, nil)
+	err := bundle.Load(route, nil, session, nil)
 	if err != nil || route == nil {
 		return nil, exceptions.NewNotFoundException("route not found: " + fmt.Sprintf("%s.%s", namespace, routeName))
 	}

--- a/apps/platform/pkg/translate/translate.go
+++ b/apps/platform/pkg/translate/translate.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	"github.com/thecloudmasters/uesio/pkg/bundle"
+	"github.com/thecloudmasters/uesio/pkg/bundlestore"
 	"github.com/thecloudmasters/uesio/pkg/meta"
 	"github.com/thecloudmasters/uesio/pkg/sess"
 )
@@ -23,8 +24,10 @@ func GetTranslatedLabels(session *sess.Session) (map[string]string, error) {
 
 	var translations meta.TranslationCollection
 	if userLanguage != "" {
-		err = bundle.LoadAllFromAny(&translations, meta.BundleConditions{
-			"uesio/studio.language": userLanguage,
+		err = bundle.LoadAllFromAny(&translations, &bundlestore.GetAllItemsOptions{
+			Conditions: meta.BundleConditions{
+				"uesio/studio.language": userLanguage,
+			},
 		}, session, nil)
 
 		if err != nil {


### PR DESCRIPTION
# What does this PR do?

Reduces the number of queries that are made by uesio in a number of different places.

1. The workspace bundlestore no longer requests reference information for `user`, `workspace`, or `userfile` when making regular queries. This reduces the number of queries made to these collections substantially.
2. `QueryWorkspaceForWrite` no longer requests reference information for `user` or `userfile`.
3. We no longer query for `RecordChallengeTokens` on collections that are not protected.

# Integration Test Stats

```
 "uesio/core.user": 1971 -> 839,
"uesio/core.userfile": 220 -> 213,
"uesio/studio.recordchallengetoken": 626 -> 162,
"uesio/studio.workspace": 2126 -> 1014,

"totalQueries": 11364 -> 8648
```


