### PR TITLE
Fix Condition Operator Validation

### DIFF
--- a/libs/ui/src/bands/wire/conditions/conditions.ts
+++ b/libs/ui/src/bands/wire/conditions/conditions.ts
@@ -24,6 +24,8 @@ type ConditionOperators =
 	| "HAS_ANY"
 	| "HAS_ALL"
 	| "CONTAINS"
+	| "BETWEEN"
+	| "STARTS_WITH"
 
 type WireConditionState =
 	| ParamConditionState


### PR DESCRIPTION
# What does this PR do?

This fixes condition operator validation so that the `BETWEEN` and `STARTS_WITH` operators can be saved on wires.
