### PR TITLE
multiselect filter improvements

### DIFF
--- a/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/field/multiselect.tsx
+++ b/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/field/multiselect.tsx
@@ -1,4 +1,5 @@
-import { component, definition, context, collection, wire } from "@uesio/ui"
+import { definition, context, collection, wire } from "@uesio/ui"
+import CustomSelect from "../customselect/customselect"
 
 interface SelectFieldProps {
 	setValue: (value: wire.PlainFieldValue[]) => void
@@ -7,13 +8,14 @@ interface SelectFieldProps {
 	fieldMetadata: collection.Field
 	mode?: context.FieldMode
 	options: wire.SelectOption[] | null
+	placeholder?: string
 }
 
 const MultiSelectField: definition.UtilityComponent<SelectFieldProps> = (
 	props
 ) => {
-	const CustomSelect = component.getUtility("uesio/io.customselect")
-	const { setValue, value, mode, options, context, variant } = props
+	const { setValue, value, mode, options, context, variant, placeholder } =
+		props
 	if (mode === "READ") {
 		let displayLabel
 		if (value !== undefined && value.length) {
@@ -51,6 +53,7 @@ const MultiSelectField: definition.UtilityComponent<SelectFieldProps> = (
 					.includes(search.toLocaleLowerCase())
 			}
 			getItemKey={(item: collection.SelectOption) => item.value}
+			placeholder={placeholder}
 		/>
 	)
 }


### PR DESCRIPTION
# What does this PR do?

1. Add the correct placeholder text to multi-select filters.
2. Allow variants to be sent to multi-select filters
3. Correctly handle the blank select option so that it handles both empty string and null values.

