### PR TITLE
Add public bundlestore listings

### DIFF
--- a/libs/apps/uesio/io/bundle/componentpacks/main/src/components/emptystate/emptystate.tsx
+++ b/libs/apps/uesio/io/bundle/componentpacks/main/src/components/emptystate/emptystate.tsx
@@ -1,0 +1,43 @@
+import { styles, definition } from "@uesio/ui"
+
+import Icon from "../../utilities/icon/icon"
+
+type EmptyStateDefinition = {
+	title?: string
+	subtitle?: string
+	icon?: string
+	iconFill?: boolean
+}
+
+const StyleDefaults = Object.freeze({
+	root: [],
+	title: [],
+	subtitle: [],
+	icon: [],
+})
+
+const EmptyState: definition.UC<EmptyStateDefinition> = (props) => {
+	const { definition, context } = props
+	const classes = styles.useStyleTokens(StyleDefaults, props)
+
+	const { title, subtitle, icon, iconFill } = definition
+
+	return (
+		<div className={classes.root}>
+			<Icon
+				classes={{
+					root: classes.icon,
+				}}
+				fill={iconFill}
+				context={context}
+				icon={context.mergeString(icon)}
+			/>
+			<div className={classes.title}>{context.mergeString(title)}</div>
+			<div className={classes.subtitle}>
+				{context.mergeString(subtitle)}
+			</div>
+		</div>
+	)
+}
+
+export default EmptyState

--- a/libs/apps/uesio/io/bundle/componentpacks/main/src/components/titlebar/titlebar.tsx
+++ b/libs/apps/uesio/io/bundle/componentpacks/main/src/components/titlebar/titlebar.tsx
@@ -14,6 +14,7 @@ const StyleDefaults = Object.freeze({
 	title: [],
 	subtitle: [],
 	actions: [],
+	avatar: [],
 })
 
 const TitleBar: definition.UC<TitleBarDefinition> = (props) => {

--- a/libs/apps/uesio/io/bundle/components/emptystate.yaml
+++ b/libs/apps/uesio/io/bundle/components/emptystate.yaml
@@ -1,0 +1,25 @@
+name: emptystate
+category: CONTENT
+pack: main
+entrypoint: components/emptystate/emptystate
+description: A placeholder for missing content
+discoverable: true
+defaultDefinition:
+  uesio.variant: uesio/io.default
+properties:
+  - name: title
+    label: Title
+    type: TEXT
+  - name: subtitle
+    label: Subtitle
+    type: TEXT
+  - name: icon
+    label: Icon
+    type: ICON
+sections:
+  - type: HOME
+    properties:
+      - title
+      - subtitle
+      - icon
+  - type: DISPLAY

--- a/libs/apps/uesio/io/bundle/componentvariants/uesio/io/emptystate/default.yaml
+++ b/libs/apps/uesio/io/bundle/componentvariants/uesio/io/emptystate/default.yaml
@@ -1,0 +1,27 @@
+name: default
+label: Default
+definition:
+  uesio.styleTokens:
+    root:
+      - grid
+      - justify-items-center
+      - m-10
+      - rounded-lg
+      - md:p-24
+      - p-6
+      - gap-2
+    title:
+      - text-xl
+      - text-slate-800
+      - "[text-wrap:balance]"
+      - text-center
+    subtitle:
+      - text-sm
+      - font-light
+      - text-slate-500
+      - text-center
+      - "[text-wrap:balance]"
+    icon:
+      - text-7xl
+      - mb-10
+public: true

--- a/libs/apps/uesio/studio/bundle/collections/bundlelisting.yaml
+++ b/libs/apps/uesio/studio/bundle/collections/bundlelisting.yaml
@@ -3,5 +3,5 @@ uniqueKey:
   - uesio/studio.app
 label: bundlelisting
 pluralLabel: Bundle Listings
-access: protected
+access: protected_write
 accessField: uesio/studio.app

--- a/libs/apps/uesio/studio/bundle/collections/licensetemplate.yaml
+++ b/libs/apps/uesio/studio/bundle/collections/licensetemplate.yaml
@@ -2,7 +2,7 @@ name: licensetemplate
 uniqueKey:
   - uesio/studio.app
 nameField: uesio/studio.app
-access: protected
+access: protected_write
 accessField: uesio/studio.app
 label: license template
 pluralLabel: license template

--- a/libs/apps/uesio/studio/bundle/components/bundlelistingvisual.yaml
+++ b/libs/apps/uesio/studio/bundle/components/bundlelistingvisual.yaml
@@ -11,8 +11,6 @@ definition:
           - overflow-hidden
           - bg-white
           - shadow-lg
-          - max-h-80
-          - max-w-md
       components:
         - uesio/io.box:
             uesio.styleTokens:
@@ -20,7 +18,7 @@ definition:
                 - bg-slate-50
                 - flex
                 - bg-[$Prop{color}]
-                - pt-[50%]
+                - pt-64
                 - items-center
                 - justify-center
                 - text-white
@@ -61,6 +59,13 @@ definition:
                   uesio.variant: uesio/io.aside
                   text: $Prop{subtitle}
                   element: p
+              - uesio/io.text:
+                  uesio.variant: uesio/io.aside
+                  text: $Prop{description}
+                  uesio.display:
+                    - type: hasNoValue
+                      value: $Prop{subtitle}
+                  element: p
 title: Bundle Listing Visual
 discoverable: true
 description: A component that wraps other components
@@ -77,6 +82,9 @@ properties:
   - type: TEXT
     name: subtitle
     label: Subtitle
+  - type: TEXT
+    name: description
+    label: Description
   - type: CHECKBOX
     name: verified
     label: Verified

--- a/libs/apps/uesio/studio/bundle/fields/uesio/studio/bundlelisting/splash.yaml
+++ b/libs/apps/uesio/studio/bundle/fields/uesio/studio/bundlelisting/splash.yaml
@@ -1,0 +1,5 @@
+name: splash
+label: Splash Image
+type: FILE
+file:
+  accept: IMAGE

--- a/libs/apps/uesio/studio/bundle/fields/uesio/studio/bundlelisting/title.yaml
+++ b/libs/apps/uesio/studio/bundle/fields/uesio/studio/bundlelisting/title.yaml
@@ -1,0 +1,3 @@
+name: title
+type: TEXT
+label: Title

--- a/libs/apps/uesio/studio/bundle/fields/uesio/studio/externalbundlelisting/title.yaml
+++ b/libs/apps/uesio/studio/bundle/fields/uesio/studio/externalbundlelisting/title.yaml
@@ -1,0 +1,3 @@
+name: title
+type: TEXT
+label: Title

--- a/libs/apps/uesio/studio/bundle/permissionsets/public.yaml
+++ b/libs/apps/uesio/studio/bundle/permissionsets/public.yaml
@@ -2,15 +2,24 @@ name: public
 named:
 views:
   uesio/studio.signup: true
+  uesio/studio.publicbundlelisting: true
+  uesio/studio.publicbundleheader: true
 routes:
   uesio/studio.login: true
   uesio/studio.signup: true
   uesio/studio.signuplanding: true
   uesio/studio.changepassword: true
+  uesio/studio.publicbundlelisting: true
   uesio/studio.requestpassword: true
 files:
 bots:
   uesio/studio.checkavailability: true
 collections:
   uesio/studio.externalbundlelisting: true
+  uesio/studio.app:
+    read: true
+  uesio/studio.bundlelisting:
+    read: true
+  uesio/studio.licensetemplate:
+    read: true
   uesio/studio.externalbundleversion: true

--- a/libs/apps/uesio/studio/bundle/permissionsets/standard.yaml
+++ b/libs/apps/uesio/studio/bundle/permissionsets/standard.yaml
@@ -64,6 +64,7 @@ views:
   uesio/studio.profile: true
   uesio/studio.profiletag: true
   uesio/studio.profiles: true
+  uesio/studio.publicbundlelisting: true
   uesio/studio.route: true
   uesio/studio.routes: true
   uesio/studio.secret: true
@@ -166,6 +167,7 @@ routes:
   uesio/studio.permissionsetintegration: true
   uesio/studio.profile: true
   uesio/studio.profiles: true
+  uesio/studio.publicbundlelisting: true
   uesio/studio.route: true
   uesio/studio.routes: true
   uesio/studio.secret: true

--- a/libs/apps/uesio/studio/bundle/routes/publicbundlelisting.yaml
+++ b/libs/apps/uesio/studio/bundle/routes/publicbundlelisting.yaml
@@ -1,0 +1,4 @@
+name: publicbundlelisting
+path: bundles/{id:\w*\/\w*}
+view: publicbundlelisting
+theme: default

--- a/libs/apps/uesio/studio/bundle/views/apppublish.yaml
+++ b/libs/apps/uesio/studio/bundle/views/apppublish.yaml
@@ -27,7 +27,9 @@ definition:
       collection: uesio/studio.bundlelisting
       fields:
         uesio/core.id:
+        uesio/studio.title:
         uesio/studio.description:
+        uesio/studio.splash:
         uesio/studio.app:
           fields:
             uesio/studio.color:
@@ -208,7 +210,8 @@ definition:
                                       color: ${uesio/studio.color}
                                       icon: ${uesio/studio.icon}
                                       title: ${uesio/studio.fullname}
-                                      subtitle: ${uesio/studio.description}
+                                      subtitle: ${uesio/studio.title}
+                                      description: ${uesio/studio.description}
                                       verified: false
           - uesio/io.list:
               uesio.display:
@@ -258,7 +261,12 @@ definition:
                             - uesio/io.box:
                                 components:
                                   - uesio/io.field:
+                                      fieldId: uesio/studio.title
+                                  - uesio/io.field:
                                       fieldId: uesio/studio.description
+                                  - uesio/io.field:
+                                      fieldId: uesio/studio.splash
+                                      displayAs: IMAGE
                                   - uesio/io.field:
                                       fieldId: uesio/studio.status
                                   - uesio/io.field:
@@ -269,7 +277,8 @@ definition:
                                       color: ${uesio/studio.app->uesio/studio.color}
                                       icon: ${uesio/studio.app->uesio/studio.icon}
                                       title: ${uesio/studio.app->uesio/studio.fullname}
-                                      subtitle: ${uesio/studio.description}
+                                      subtitle: ${uesio/studio.title}
+                                      description: ${uesio/studio.description}
                                       verified: false
           - uesio/io.box:
               uesio.display:

--- a/libs/apps/uesio/studio/bundle/views/bundlelisting.yaml
+++ b/libs/apps/uesio/studio/bundle/views/bundlelisting.yaml
@@ -36,6 +36,7 @@ definition:
       collection: uesio/studio.bundlelisting
       fields:
         uesio/core.uniquekey:
+        uesio/studio.title:
         uesio/studio.description:
         uesio/studio.app:
           fields:
@@ -182,7 +183,7 @@ definition:
                 - uesio/io.titlebar:
                     uesio.variant: uesio/io.main
                     title: ${uesio/studio.app->uesio/studio.fullname}
-                    subtitle: ${uesio/studio.description}
+                    subtitle: ${uesio/studio.title}
                     avatar:
                       - uesio/io.text:
                           uesio.variant: uesio/io.icon
@@ -230,6 +231,15 @@ definition:
                                             - workspaces
                                             - dependencies
                                             - dependencyAlreadyInstalled
+          - uesio/io.box:
+              uesio.variant: uesio/io.section
+              components:
+                - uesio/io.text:
+                    uesio.styleTokens:
+                      root:
+                        - whitespace-pre-line
+                        - font-light
+                    text: ${listing:description}
           - uesio/io.box:
               uesio.variant: uesio/io.section
               components:

--- a/libs/apps/uesio/studio/bundle/views/bundlestore.yaml
+++ b/libs/apps/uesio/studio/bundle/views/bundlestore.yaml
@@ -18,6 +18,7 @@ definition:
       collection: uesio/studio.bundlelisting
       fields:
         uesio/core.id:
+        uesio/studio.title:
         uesio/studio.description:
         uesio/studio.status:
         uesio/studio.approved:
@@ -27,6 +28,9 @@ definition:
             uesio/studio.fullname:
             uesio/studio.color:
             uesio/studio.icon:
+      conditions:
+        - field: uesio/studio.status
+          value: PUBLISHED
   # Components are how we describe the layout of our view
   components:
     - uesio/io.viewlayout:
@@ -58,6 +62,7 @@ definition:
                           searchFields:
                             - uesio/core.uniquekey
                             - uesio/studio.description
+                            - uesio/studio.title
                           focusOnRender: true
                           uesio.styleTokens:
                             root:
@@ -86,5 +91,6 @@ definition:
                                 color: ${uesio/studio.app->uesio/studio.color}
                                 icon: ${uesio/studio.app->uesio/studio.icon}
                                 title: ${uesio/studio.app->uesio/studio.fullname}
-                                subtitle: ${uesio/studio.description}
+                                subtitle: ${uesio/studio.title}
+                                description: ${uesio/studio.description}
                                 verified: false

--- a/libs/apps/uesio/studio/bundle/views/officialbundlestore.yaml
+++ b/libs/apps/uesio/studio/bundle/views/officialbundlestore.yaml
@@ -7,6 +7,7 @@ definition:
       fields:
         uesio/core.id:
         uesio/studio.description:
+        uesio/studio.title:
         uesio/studio.status:
         uesio/studio.approved:
         uesio/studio.app:
@@ -60,5 +61,6 @@ definition:
                                 color: ${uesio/studio.app->uesio/studio.color}
                                 icon: ${uesio/studio.app->uesio/studio.icon}
                                 title: ${uesio/studio.app->uesio/studio.fullname}
-                                subtitle: ${uesio/studio.description}
+                                subtitle: ${uesio/studio.title}
+                                description: ${uesio/studio.description}
                                 verified: false

--- a/libs/apps/uesio/studio/bundle/views/publicbundleheader.yaml
+++ b/libs/apps/uesio/studio/bundle/views/publicbundleheader.yaml
@@ -1,0 +1,126 @@
+name: publicbundleheader
+definition:
+  # Wires are how we pull in data
+  wires:
+    # The details of the listing, nothing special going on here
+  components:
+    - uesio/io.box:
+        uesio.styleTokens:
+          root:
+            - md:py-8
+            - py-6
+            - sticky
+            - top-0
+            - z-10
+            - from-indigo-700/95
+            - to-violet-600/95
+            - bg-gradient-to-br
+            - "[background-size:100%_500%]"
+            - backdrop-blur
+        components:
+          - uesio/io.box:
+              uesio.styleTokens:
+                root:
+                  - "[max-width:1248px]"
+                  - m-auto
+                  - "[container-type:inline-size]"
+                  - md:px-20
+                  - px-6
+              components:
+                - uesio/io.group:
+                    uesio.styleTokens:
+                      root:
+                        - grid
+                        - justify-between
+                    components:
+                      - uesio/io.group:
+                          uesio.styleTokens:
+                            root:
+                              - gap-4
+                          components:
+                            - uesio/io.image:
+                                file: uesio/core.logowhite
+                                height: 44
+                                signals:
+                                  - signal: "route/NAVIGATE"
+                                    path: "home"
+                            - uesio/io.text:
+                                uesio.variant: uesio/io.icon
+                                text: deployed_code
+                                uesio.styleTokens:
+                                  root:
+                                    - text-white
+                                    - text-5xl
+                            - uesio/io.box:
+                                components:
+                                  - uesio/io.text:
+                                      text: Bundle Store
+                                      element: div
+                                      uesio.styleTokens:
+                                        root:
+                                          - text-white
+                                          - text-xl
+                                          - font-light
+                                          - leading-none
+                      - uesio/io.group:
+                          uesio.styleTokens:
+                            root:
+                              - grid
+                              - md:hidden
+                              - justify-right
+                          components:
+                            - uesio/io.button:
+                                uesio.styleTokens:
+                                  root:
+                                    - text-3xl
+                                    - text-white
+                                    - p-2
+                                icon: menu
+                                signals:
+                                  - signal: panel/TOGGLE
+                                    panel: navmenu
+                      - uesio/io.group:
+                          uesio.styleTokens:
+                            root:
+                              - gap-8
+                              - hidden
+                              - md:grid
+                          components:
+                            - uesio/io.group:
+                                components:
+                                  - uesio/io.button:
+                                      uesio.variant: uesio/io.secondary
+                                      uesio.styleTokens:
+                                        root:
+                                          - min-w-[80px]
+                                          - text-white
+                                          - bg-transparent
+                                          - rounded-full
+                                          - border-0
+                                          - px-6
+                                          - hover:shadow-none
+                                          - focus:shadow-none
+                                          - bg-transparent
+                                      text: Log In
+                                      signals:
+                                        - signal: route/NAVIGATE
+                                          path: login
+                            - uesio/io.button:
+                                uesio.variant: uesio/io.secondary
+                                uesio.styleTokens:
+                                  root:
+                                    - min-w-[80px]
+                                    - text-white
+                                    - bg-transparent
+                                    - rounded-full
+                                    - border-0
+                                    - px-6
+                                    - hover:shadow-none
+                                    - focus:shadow-none
+                                    - bg-transparent
+                                    - border-2
+                                    - border-white
+                                text: Sign Up
+                                signals:
+                                  - signal: route/NAVIGATE
+                                    path: signup

--- a/libs/apps/uesio/studio/bundle/views/publicbundlelisting.yaml
+++ b/libs/apps/uesio/studio/bundle/views/publicbundlelisting.yaml
@@ -1,0 +1,201 @@
+name: publicbundlelisting
+definition:
+  # Wires are how we pull in data
+  wires:
+    # The details of the listing, nothing special going on here
+    listing:
+      collection: uesio/studio.bundlelisting
+      fields:
+        uesio/core.uniquekey:
+        uesio/studio.title:
+        uesio/studio.description:
+        uesio/studio.splash:
+        uesio/studio.app:
+          fields:
+            uesio/core.uniquekey:
+            uesio/studio.fullname:
+            uesio/studio.color:
+            uesio/studio.icon:
+      conditions:
+        - field: uesio/core.uniquekey
+          value: $Param{id}
+    licensetemplate:
+      collection: uesio/studio.licensetemplate
+      fields:
+        uesio/core.id:
+        uesio/studio.app:
+        uesio/studio.autocreate:
+        uesio/studio.monthlyprice:
+      conditions:
+        - field: uesio/studio.app
+          valueSource: LOOKUP
+          lookupWire: listing
+          lookupField: uesio/studio.app->uesio/core.id
+  components:
+    - uesio/core.view:
+        view: uesio/studio.publicbundleheader
+    - uesio/io.box:
+        uesio.styleTokens:
+          root:
+            - "[max-width:1248px]"
+            - m-auto
+            - "[container-type:inline-size]"
+            - md:px-20
+            - px-6
+        uesio.display:
+          - type: wireHasNoRecords
+            wire: listing
+        components:
+          - uesio/io.emptystate:
+              title: We can't find a bundle called $Param{id}.
+              subtitle: The bundle you're looking for may not be published yet.
+              icon: unknown_document
+    - uesio/io.item:
+        uesio.display:
+          - type: wireHasRecords
+            wire: listing
+        wire: listing
+        mode: READ
+        components:
+          - uesio/io.box:
+              uesio.styleTokens:
+                root:
+                  - "[max-width:1248px]"
+                  - m-auto
+                  - "[container-type:inline-size]"
+                  - md:px-20
+                  - px-6
+              components:
+                - uesio/io.grid:
+                    uesio.variant: uesio/io.three_columns
+                    uesio.styleTokens:
+                      root:
+                        - my-16
+                        - items-start
+                        - gap-14
+                    items:
+                      - uesio/io.box:
+                          components:
+                            - uesio/io.titlebar:
+                                uesio.variant: uesio/io.section
+                                uesio.styleTokens:
+                                  root:
+                                    - gap-4
+                                  title:
+                                    - text-xl
+                                  subtitle:
+                                    - text-xs
+                                  avatar:
+                                    - text-2xl
+                                    - h-12
+                                    - w-12
+                                    - grid
+                                    - items-center
+                                    - justify-center
+                                    - bg-slate-50
+                                    - rounded-full
+                                title: ${uesio/studio.app->uesio/studio.fullname}
+                                subtitle: ${uesio/studio.title}
+                                avatar:
+                                  - uesio/io.text:
+                                      uesio.variant: uesio/io.icon
+                                      text: ${uesio/studio.app->uesio/studio.icon}
+                                      color: ${uesio/studio.app->uesio/studio.color}
+                                actions:
+                                  - uesio/io.group:
+                                      components:
+                                        - uesio/io.box:
+                                            uesio.styleTokens:
+                                              root:
+                                                - rounded
+                                                - bg-lime-200
+                                                - py-0.5
+                                                - px-2.5
+                                                - flex
+                                                - items-center
+                                                - gap-2
+                                            components:
+                                              - uesio/io.text:
+                                                  uesio.variant: uesio/io.icon
+                                                  uesio.styleTokens:
+                                                    root:
+                                                      - text-base
+                                                      - text-lime-700
+                                                  text: redeem
+                                              - uesio/io.text:
+                                                  uesio.styleTokens:
+                                                    root:
+                                                      - mt-[1px]
+                                                      - text-xs
+                                                      - uppercase
+                                                      - text-lime-700
+                                                      - leading-none
+                                                      - font-bold
+                                                      - tracking-wider
+                                                  text: Free
+                            - uesio/io.text:
+                                element: div
+                                uesio.styleTokens:
+                                  root:
+                                    - font-light
+                                    - text-sm
+                                    - text-slate-800
+                                    - leading-loose
+                                    - whitespace-pre-line
+                                text: ${description}
+                            - uesio/io.button:
+                                uesio.variant: uesio/io.secondary
+                                uesio.styleTokens:
+                                  root:
+                                    - mt-10
+                                    - mb-4
+                                    - min-w-[80px]
+                                    - text-white
+                                    - bg-slate-800
+                                    - rounded-full
+                                    - border-0
+                                    - px-6
+                                    - hover:shadow-none
+                                    - focus:shadow-none
+                                    - border-2
+                                    - border-white
+                                text: Log In to Install
+                                signals:
+                                  - signal: route/NAVIGATE
+                                    path: login
+                      - uesio/io.box:
+                          uesio.styleTokens:
+                            root:
+                              - p-6
+                              - md:col-span-2
+                          uesio.display:
+                            - type: hasValue
+                              value: ${splash}
+                          components:
+                            - uesio/io.image:
+                                uesio.styleTokens:
+                                  root:
+                                    - w-full
+                                src: $UserFile{splash}
+                      - uesio/io.box:
+                          uesio.styleTokens:
+                            root:
+                              - bg-[${app->color}]
+                              - p-6
+                              - rounded-xl
+                              - md:col-span-2
+                              - "[min-height:380px]"
+                              - grid
+                              - items-center
+                              - justify-center
+                          uesio.display:
+                            - type: hasNoValue
+                              value: ${splash}
+                          components:
+                            - uesio/io.text:
+                                uesio.styleTokens:
+                                  root:
+                                    - text-white
+                                    - text-8xl
+                                uesio.variant: uesio/io.icon
+                                text: ${app->icon}

--- a/libs/apps/uesio/studio/bundle/views/sitemanageappbundles.yaml
+++ b/libs/apps/uesio/studio/bundle/views/sitemanageappbundles.yaml
@@ -50,6 +50,7 @@ definition:
       collection: uesio/studio.bundlelisting
       fields:
         uesio/core.id:
+        uesio/studio.title:
         uesio/studio.description:
         uesio/studio.app:
           fields:
@@ -58,6 +59,7 @@ definition:
             uesio/studio.fullname:
         uesio/studio.status:
         uesio/studio.approved:
+        uesio/studio.splash:
         uesio/core.owner:
         uesio/core.createdat:
         uesio/core.createdby:
@@ -146,7 +148,7 @@ definition:
                 selected: managebundles
         content:
           - uesio/io.list:
-              uesio.id: bundleListingDeck
+              uesio.id: bundleListing
               wire: bundlelisting
               mode: READ
               components:
@@ -157,6 +159,37 @@ definition:
                     actions:
                       - uesio/io.group:
                           components:
+                            - uesio/io.button:
+                                uesio.variant: uesio/io.secondary
+                                text: Edit
+                                signals:
+                                  - signal: component/CALL
+                                    component: uesio/io.list
+                                    componentsignal: TOGGLE_MODE
+                                    targettype: specific
+                                    componentid: bundleListing
+                                uesio.display:
+                                  - type: wireHasNoChanges
+                                    wire: bundlelisting
+                            - uesio/io.button:
+                                uesio.variant: uesio/io.primary
+                                text: Save
+                                signals:
+                                  - signal: wire/SAVE
+                                    wires:
+                                      - bundlelisting
+                                uesio.display:
+                                  - type: wireHasChanges
+                                    wire: bundlelisting
+                            - uesio/io.button:
+                                uesio.variant: uesio/io.secondary
+                                text: Cancel
+                                signals:
+                                  - signal: wire/CANCEL
+                                    wire: bundlelisting
+                                uesio.display:
+                                  - type: wireHasChanges
+                                    wire: bundlelisting
                             - uesio/io.button:
                                 uesio.variant: uesio/io.secondary
                                 text: Start Review
@@ -228,11 +261,19 @@ definition:
                     components:
                       - uesio/io.grid:
                           uesio.variant: uesio/io.two_columns
+                          uesio.styleTokens:
+                            root:
+                              - gap-10
                           items:
                             - uesio/io.box:
                                 components:
                                   - uesio/io.field:
+                                      fieldId: uesio/studio.title
+                                  - uesio/io.field:
                                       fieldId: uesio/studio.description
+                                  - uesio/io.field:
+                                      fieldId: uesio/studio.splash
+                                      displayAs: IMAGE
                                   - uesio/io.field:
                                       fieldId: uesio/studio.status
                                   - uesio/io.field:
@@ -243,7 +284,8 @@ definition:
                                       color: ${uesio/studio.app->uesio/studio.color}
                                       icon: ${uesio/studio.app->uesio/studio.icon}
                                       title: ${uesio/studio.app->uesio/studio.fullname}
-                                      subtitle: ${uesio/studio.description}
+                                      subtitle: ${uesio/studio.title}
+                                      description: ${uesio/studio.description}
                                       verified: false
           - uesio/io.box:
               uesio.variant: uesio/io.section

--- a/libs/apps/uesio/studio/bundle/views/sitemanagebundles.yaml
+++ b/libs/apps/uesio/studio/bundle/views/sitemanagebundles.yaml
@@ -38,6 +38,7 @@ definition:
       collection: uesio/studio.bundlelisting
       fields:
         uesio/core.id:
+        uesio/studio.title:
         uesio/studio.description:
         uesio/studio.app:
           fields:
@@ -106,7 +107,7 @@ definition:
                               text: ${uesio/studio.app->uesio/studio.fullname}
                               icon: ${uesio/studio.app->uesio/studio.icon}
                               color: ${uesio/studio.app->uesio/studio.color}
-                      - field: uesio/studio.description
+                      - field: uesio/studio.title
                       - field: uesio/studio.status
                       - field: uesio/core.createdby
                         user:


### PR DESCRIPTION
Adds a public listing page for installable bundles.

With splash image
<img width="1428" alt="Screenshot 2024-06-12 at 3 30 43 PM" src="https://github.com/ues-io/uesio/assets/55447225/96274187-6b21-47a2-ab0d-fde62f9ca083">

Without splash image.
<img width="1428" alt="Screenshot 2024-06-12 at 3 31 09 PM" src="https://github.com/ues-io/uesio/assets/55447225/d203b272-9043-4bf2-9068-04df6111de62">
