### PR TITLE
Fix annoying component not found bug

### DIFF
--- a/apps/cli/pkg/command/pack.go
+++ b/apps/cli/pkg/command/pack.go
@@ -58,6 +58,9 @@ func Pack(options *PackOptions) error {
 			MinifySyntax:      true,
 			Metafile:          true,
 			Sourcemap:         api.SourceMapLinked,
+			// This fixes a bug where the monaco amd loader was polluting
+			// the global define object, causing papaparse to not load correctly.
+			Define: map[string]string{"define.amd": "undefined"},
 		}
 
 		basePath := fmt.Sprintf("bundle/componentpacks/%s/", packName)

--- a/libs/apps/uesio/studio/bundle/componentpacks/main/src/components/dataimport/importbutton.tsx
+++ b/libs/apps/uesio/studio/bundle/componentpacks/main/src/components/dataimport/importbutton.tsx
@@ -1,5 +1,5 @@
 import { definition, api, component, styles } from "@uesio/ui"
-import Papa, { ParseResult } from "papaparse"
+import { parse, ParseResult } from "papaparse"
 
 interface Props {
 	changeUploaded: (success: boolean, csvFields: string[], file: File) => void
@@ -18,7 +18,7 @@ const getHeaderFields = async (files: FileList | null): Promise<string[]> => {
 
 const readCSV = async (file: File): Promise<string[][]> =>
 	new Promise<string[][]>((resolve) => {
-		Papa.parse(file, {
+		parse(file, {
 			header: false, //If false, will omit the header row. If data is an array of arrays this option is ignored. If data is an array of objects the keys of the first object are the header row. If data is an object with the keys fields and data the fields are the header row.
 			skipEmptyLines: true, //If true, lines that are completely empty (those which evaluate to an empty string) will be skipped. If set to 'greedy', lines that don't have any content (those which have only whitespace after parsing) will also be skipped.
 			complete: (results: ParseResult<string[]>) => {

--- a/libs/vendor/gulpfile.js
+++ b/libs/vendor/gulpfile.js
@@ -79,7 +79,7 @@ const scriptTasks = modules.map(({ src, dest, path, name: module }) => {
 		.filter((x) => !!x)
 		.join("/")
 	return function () {
-		return gulp.src(gulpSrc).pipe(gulp.dest(gulpDest))
+		return gulp.src(gulpSrc, { encoding: false }).pipe(gulp.dest(gulpDest))
 	}
 })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
 				"jest": "^29.7.0",
 				"jest-environment-jsdom": "^29.7.0",
 				"lodash": "4.17.21",
-				"monaco-editor": "^0.47.0",
+				"monaco-editor": "^0.50.0",
 				"nx": "18.3.5",
 				"papaparse": "^5.4.1",
 				"prettier": "3.2.5",
@@ -14305,9 +14305,9 @@
 			}
 		},
 		"node_modules/monaco-editor": {
-			"version": "0.47.0",
-			"resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.47.0.tgz",
-			"integrity": "sha512-VabVvHvQ9QmMwXu4du008ZDuyLnHs9j7ThVFsiJoXSOQk18+LF89N4ADzPbFenm0W4V2bGHnFBztIRQTgBfxzw==",
+			"version": "0.50.0",
+			"resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.50.0.tgz",
+			"integrity": "sha512-8CclLCmrRRh+sul7C08BmPBP3P8wVWfBHomsTcndxg5NRCEPfu/mc2AGU8k37ajjDVXcXFc12ORAMUkmk+lkFA==",
 			"dev": true
 		},
 		"node_modules/mri": {

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
 		"jest": "^29.7.0",
 		"jest-environment-jsdom": "^29.7.0",
 		"lodash": "4.17.21",
-		"monaco-editor": "^0.47.0",
+		"monaco-editor": "^0.50.0",
 		"nx": "18.3.5",
 		"papaparse": "^5.4.1",
 		"prettier": "3.2.5",


### PR DESCRIPTION
This finally fixes the bug where the studio component pack was occasionally failing to load.

Monaco pollutes the global `define` object.
https://github.com/microsoft/monaco-editor/issues/3083

Then papaparse tries to check for a global define object. Papaparse ends up using the monaco loader somehow.