### PR TITLE
send email to admin when a new user signup using google

### DIFF
--- a/libs/apps/uesio/studio/bundle/bots/listener/signupgoogle/bot.ts
+++ b/libs/apps/uesio/studio/bundle/bots/listener/signupgoogle/bot.ts
@@ -1,0 +1,47 @@
+import { ListenerBotApi } from "@uesio/bots"
+
+export default function signupgoogle(bot: ListenerBotApi) {
+	const username = bot.params.get("username")
+	const email = bot.params.get("email")
+	const firstName = bot.params.get("firstname")
+	const lastName = bot.params.get("lastname")
+	const toName = firstName && lastName ? `${firstName} ${lastName}` : username
+	const contentType = "text/html"
+	const from = "info@ues.io"
+	const fromName = "the ues.io team"
+
+	const site = bot.getSession().getSite()
+
+	const signupNotifyEmail = bot.asAdmin.getConfigValue(
+		"uesio/studio.signup_notify_email"
+	)
+
+	if (signupNotifyEmail) {
+		const notifyBody = `
+		<!DOCTYPE html>
+		<html>
+			<body>
+				Hi ues.io Studio Administrator,<br/>
+				<br/>
+				A user signed up using Google for a studio account on site ${site.getName()} and domain ${site.getDomain()}.<br/>
+				<br/>
+				Name: ${toName}<br/>
+				Username: ${username}<br/>
+				Email: ${email}<br/><br/>
+				Cheers!<br/>
+				<br/>
+				The team at ues.io
+			</body>
+		</html>`
+
+		bot.runIntegrationAction("uesio/core.sendgrid", "sendemail", {
+			to: [signupNotifyEmail],
+			toNames: ["Studio Administrator"],
+			from,
+			fromName,
+			subject: `New signup in uesio studio: ${toName}`,
+			plainBody: notifyBody,
+			contentType,
+		})
+	}
+}

--- a/libs/apps/uesio/studio/bundle/bots/listener/signupgoogle/bot.yaml
+++ b/libs/apps/uesio/studio/bundle/bots/listener/signupgoogle/bot.yaml
@@ -1,0 +1,10 @@
+name: signupgoogle
+type: LISTENER
+dialect: TYPESCRIPT
+params:
+  - name: username
+    type: TEXT
+    required: true
+  - name: email
+    type: TEXT
+    required: true

--- a/libs/apps/uesio/studio/bundle/signupmethods/google.yaml
+++ b/libs/apps/uesio/studio/bundle/signupmethods/google.yaml
@@ -5,6 +5,7 @@ usernameTemplate: ${username}
 usernameRegex: "^[a-z0-9_]+$"
 usernameFormatExplanation: "lowercase a-z, 0-9, and underscore only"
 landingRoute: uesio/studio.login
+signupBot: uesio/studio.signupgoogle
 autoLogin: true
 enableSelfSignup: true
 public: true


### PR DESCRIPTION
# What does this PR do?

This emails the studio admin when a new user signs up using the Google method.

# Testing

You can test this locally, by adding the Google and SendGrid keys and ensuring that the config value signup_notify_email is set.

Then just create a new user using the Google method.
