### PR TITLE
allow uesio to run without redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,96 @@ The following environment variables can optionally be configured in your Shell (
     <td>10</td>
     <td>Usage data (stored in Redis) will only be aggregated and committed to Postgres as often as this job is run by the worker process. Set to a lower window for more frequent checks.</td>
   </tr>
+  <tr>
+    <td>UESIO_WORKER_MODE</td>
+    <td>Determines whether the batch job worker will run as part of the serve command or as a separate process.</td>
+    <td>separate</td>
+    <td>separate: The worker will run as a separate process. combined: The worker will run as part of the serve command.</td>
+  </tr>
+  <tr>
+    <td>UESIO_USAGE_MODE</td>
+    <td>Determines whether to handle usage in memory on the web server, or to use redis for multiple web servers.</td>
+    <td>redis</td>
+    <td>redis, memory</td>
+  </tr>
+  <tr>
+    <td>UESIO_PLATFORM_CACHE</td>
+    <td>Determines whether to handle the platform cache in memory on the web server, or to use redis for multiple web servers.</td>
+    <td>redis</td>
+    <td>redis, memory</td>
+  </tr>
+  <tr>
+    <td>REDIS_HOST</td>
+    <td>The host to connect to Redis</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>REDIS_PORT</td>
+    <td>The port to connect to Redis</td>
+    <td>6739</td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>REDIS_USER</td>
+    <td>The Redis Username (If Necessary)</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>REDIS_PASSWORD</td>
+    <td>The Redis Password (If Necessary)</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>REDIS_TTL</td>
+    <td>Redis TTL Seconds</td>
+    <td>86400</td>
+    <td>Default is one day.</td>
+  </tr>
+  <tr>
+    <td>REDIS_TLS</td>
+    <td>Whether or not to use TLS Mode</td>
+    <td>false</td>
+    <td>true or false</td>
+  </tr>
+  <tr>
+    <td>UESIO_DB_USER</td>
+    <td></td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>UESIO_DB_PASSWORD</td>
+    <td></td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>UESIO_DB_DATABASE</td>
+    <td></td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>UESIO_DB_HOST</td>
+    <td></td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>UESIO_DB_PORT</td>
+    <td></td>
+    <td>5432</td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>UESIO_DB_SSLMODE</td>
+    <td></td>
+    <td>disable</td>
+    <td>disable, allow, prefer, require, etc.</td>
+  </tr>
 </table>
 
 In addition, all Uesio Secrets can have their default value set by setting a corresponding `UESIO_SECRET_<namespace>_<name>` environment variable. Any value set for these secrets in a Site/Workspace will override the environment variable default, but it can often be useful, especially for local development, to configure a default value, so that you don't have to populate these secrets in every site. (Note: there is no corresponding feature for Config Values, because you can define a Config Value's default directly in the metadata definition).

--- a/apps/platform/main.go
+++ b/apps/platform/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/thecloudmasters/uesio/pkg/bot"
+	"github.com/thecloudmasters/uesio/pkg/usage/usage_memory"
 	"github.com/thecloudmasters/uesio/pkg/usage/usage_redis"
 
 	"github.com/thecloudmasters/uesio/pkg/adapt"
@@ -84,6 +85,7 @@ func init() {
 
 	// Usage Handlers
 	usage.RegisterUsageHandler("redis", &usage_redis.RedisUsageHandler{})
+	usage.RegisterUsageHandler("memory", &usage_memory.MemoryUsageHandler{})
 
 }
 

--- a/apps/platform/pkg/auth/auth.go
+++ b/apps/platform/pkg/auth/auth.go
@@ -31,7 +31,7 @@ func init() {
 		store = NewFSSessionStore()
 	} else if storageType == "redis" {
 		store = NewRedisSessionStore()
-	} else if storageType == "" {
+	} else if storageType == "" || storageType == "memory" {
 		store = session.NewInMemStore()
 	} else {
 		panic("UESIO_SESSION_STORE is an unrecognized value: " + storageType)

--- a/apps/platform/pkg/auth/cache.go
+++ b/apps/platform/pkg/auth/cache.go
@@ -13,8 +13,8 @@ var userCache cache.Cache[*meta.User]
 var hostCache cache.Cache[*meta.Site]
 
 func init() {
-	userCache = cache.NewRedisCache[*meta.User]("user")
-	hostCache = cache.NewRedisCache[*meta.Site]("host")
+	userCache = cache.NewPlatformCache[*meta.User]("user", 0)
+	hostCache = cache.NewPlatformCache[*meta.Site]("host", 0)
 }
 
 func GetUserCacheKey(userid string, site *meta.Site) string {

--- a/apps/platform/pkg/cache/memory.go
+++ b/apps/platform/pkg/cache/memory.go
@@ -9,18 +9,18 @@ import (
 	gocache "github.com/patrickmn/go-cache"
 )
 
-type memoryCache[T any] struct {
+type MemoryCache[T any] struct {
 	c *gocache.Cache
 }
 
-func NewMemoryCache[T any](expirationTime, purgeTime time.Duration) Cache[T] {
+func NewMemoryCache[T any](expirationTime, purgeTime time.Duration) *MemoryCache[T] {
 	c := gocache.New(expirationTime, purgeTime)
-	return &memoryCache[T]{
+	return &MemoryCache[T]{
 		c,
 	}
 }
 
-func (mc *memoryCache[T]) Get(key string) (T, error) {
+func (mc *MemoryCache[T]) Get(key string) (T, error) {
 	var result T
 	val, hasVal := mc.c.Get(key)
 	if hasVal {
@@ -29,14 +29,27 @@ func (mc *memoryCache[T]) Get(key string) (T, error) {
 	return result, errors.New("key " + key + " not found")
 }
 
-func (mc *memoryCache[T]) Set(key string, value T) error {
+func (mc *MemoryCache[T]) Set(key string, value T) error {
 	mc.c.Set(key, value, 0) // 0 duration = use default expiration
 	return nil
 }
 
-func (mc *memoryCache[T]) Del(key ...string) error {
+func (mc *MemoryCache[T]) Del(key ...string) error {
 	for _, k := range key {
 		mc.c.Delete(k)
 	}
 	return nil
+}
+
+func (mc *MemoryCache[T]) GetAll() map[string]T {
+	items := mc.c.Items()
+	result := map[string]T{}
+	for key, item := range items {
+		result[key] = item.Object.(T)
+	}
+	return result
+}
+
+func (mc *MemoryCache[T]) DeleteAll() {
+	mc.c.Flush()
 }

--- a/apps/platform/pkg/cache/platform.go
+++ b/apps/platform/pkg/cache/platform.go
@@ -1,0 +1,28 @@
+package cache
+
+import (
+	"os"
+	"time"
+)
+
+// This cache can be switched between memory or redis depending on the setup.
+
+type platformCache[T any] struct {
+	c       Cache[T]
+	options *CacheOptions[T]
+}
+
+func getDefaultExpiration() time.Duration {
+	return time.Duration(redisTTLSeconds) * time.Second
+}
+
+func NewPlatformCache[T any](namespace string, expiration time.Duration) Cache[T] {
+	if expiration == 0 {
+		expiration = getDefaultExpiration()
+	}
+	cacheType := os.Getenv("UESIO_PLATFORM_CACHE")
+	if cacheType == "memory" {
+		return NewMemoryCache[T](expiration, expiration*2)
+	}
+	return NewRedisCache[T](namespace).WithExpiration(expiration)
+}

--- a/apps/platform/pkg/cache/redis.go
+++ b/apps/platform/pkg/cache/redis.go
@@ -98,6 +98,20 @@ func NewRedisCache[T any](namespace string) *RedisCache[T] {
 // TODO: Switch to using go-redis instead of Redigo to get a cleaner, type-safe API
 // where we don't have to do manual connection management
 func init() {
+
+	sessionStorageMethod := os.Getenv("UESIO_SESSION_STORE")
+	platformCache := os.Getenv("UESIO_PLATFORM_CACHE")
+	usageHandler := os.Getenv("UESIO_USAGE_HANDLER")
+
+	needRedisForSessions := sessionStorageMethod == "redis"
+	needRedisForPlatformCache := platformCache != "memory"
+	needRedisForUsage := usageHandler == "redis"
+
+	if !needRedisForSessions && !needRedisForPlatformCache && !needRedisForUsage {
+		slog.Info("Skipping up Redis Connection: Not Needed")
+		return
+	}
+
 	redisHost := os.Getenv("REDIS_HOST")
 	redisPort := os.Getenv("REDIS_PORT")
 	redisUser := os.Getenv("REDIS_USER")
@@ -115,6 +129,8 @@ func init() {
 	}
 
 	redisAddr := fmt.Sprintf("%s:%s", redisHost, redisPort)
+
+	slog.Info("Setting up Redis Connection: " + redisAddr)
 
 	options := []redis.DialOption{}
 

--- a/apps/platform/pkg/cmd/serve.go
+++ b/apps/platform/pkg/cmd/serve.go
@@ -10,6 +10,7 @@ import (
 	"github.com/thecloudmasters/uesio/pkg/controller/oauth"
 	"github.com/thecloudmasters/uesio/pkg/env"
 	"github.com/thecloudmasters/uesio/pkg/tls"
+	"github.com/thecloudmasters/uesio/pkg/worker"
 
 	"github.com/gorilla/mux"
 	"github.com/spf13/cobra"
@@ -457,6 +458,13 @@ func serve(cmd *cobra.Command, args []string) {
 		}
 		done <- true
 	}()
+
+	if os.Getenv("UESIO_WORKER_MODE") == "combined" {
+		slog.Info("Running worker combined with web server")
+		go func() {
+			worker.ScheduleJobs()
+		}()
+	}
 
 	// wait for graceful shutdown to complete
 	server.WaitShutdown()

--- a/apps/platform/pkg/datasource/fetchreferences.go
+++ b/apps/platform/pkg/datasource/fetchreferences.go
@@ -159,14 +159,16 @@ func FetchReferences(
 	}
 
 	err = HandleReferences(connection, referencedIDCollections, metadata, session, &ReferenceOptions{
-		MergeItems: true,
+		MergeItems:         true,
+		RemoveMissingItems: op.Options != nil && op.Options.IgnoreMissingReferences,
 	})
 	if err != nil {
 		return err
 	}
 
 	return HandleReferences(connection, referencedUniqueKeyCollections, metadata, session, &ReferenceOptions{
-		MergeItems: true,
+		MergeItems:         true,
+		RemoveMissingItems: op.Options != nil && op.Options.IgnoreMissingReferences,
 	})
 
 }

--- a/apps/platform/pkg/datasource/licensing.go
+++ b/apps/platform/pkg/datasource/licensing.go
@@ -15,7 +15,7 @@ type LicenseMap map[string]*meta.License
 var licenseCache cache.Cache[LicenseMap]
 
 func init() {
-	licenseCache = cache.NewRedisCache[LicenseMap]("license")
+	licenseCache = cache.NewPlatformCache[LicenseMap]("license", 0)
 }
 
 func InvalidateLicenseCaches(namespaces []string) error {

--- a/apps/platform/pkg/datasource/references.go
+++ b/apps/platform/pkg/datasource/references.go
@@ -90,8 +90,9 @@ func LoadLooper(
 }
 
 type ReferenceOptions struct {
-	AllowMissingItems bool
-	MergeItems        bool
+	AllowMissingItems  bool
+	RemoveMissingItems bool
+	MergeItems         bool
 }
 
 func HandleReferences(
@@ -151,6 +152,17 @@ func HandleReferences(
 
 			// This means we tried to load some references, but they don't exist.
 			if refItem == nil {
+				if options.RemoveMissingItems {
+					// Loop over all matchIndexes and copy the data from the refItem
+					for _, locator := range matchIndexes {
+						concreteItem := locator.Item.(meta.Item)
+						err = concreteItem.SetField(locator.Field.GetFullName(), nil)
+						if err != nil {
+							return err
+						}
+					}
+					return nil
+				}
 				if options.AllowMissingItems {
 					return nil
 				}

--- a/apps/platform/pkg/middleware/dev_logger.go
+++ b/apps/platform/pkg/middleware/dev_logger.go
@@ -55,7 +55,7 @@ func (h *DevLogHandler) Handle(ctx context.Context, r slog.Record) error {
 		return true
 	})
 
-	timeStr := r.Time.Format("[15:05:05.000]")
+	timeStr := r.Time.Format("[15:04:05.000]")
 	var siteKey, user string
 	if fields["app"] != nil {
 		app := fields["app"].(string)

--- a/apps/platform/pkg/oauth2/authorizationcode.go
+++ b/apps/platform/pkg/oauth2/authorizationcode.go
@@ -27,7 +27,7 @@ func setCacheImpl(cacheImpl cache.Cache[string]) {
 func resetCacheImpl() {
 	// This Redis cache can have a very short expiration, to prevent replay attacks,
 	// but should be long enough to allow for 2FA exchanges initiated by the auth server
-	oauthExchangeCache = cache.NewRedisCache[string]("oauthExchange").WithExpiration(time.Minute * 5)
+	oauthExchangeCache = cache.NewPlatformCache[string]("oauthExchange", time.Minute*5)
 }
 
 type RedirectMetadata struct {

--- a/apps/platform/pkg/reflecttool/set.go
+++ b/apps/platform/pkg/reflecttool/set.go
@@ -148,6 +148,7 @@ func setPrimative(to reflect.Value, from reflect.Value) error {
 
 func setFieldReflect(to reflect.Value, from reflect.Value) error {
 	if !from.IsValid() {
+		to.Set(reflect.Zero(to.Type()))
 		return nil
 	}
 

--- a/apps/platform/pkg/types/wire/save.go
+++ b/apps/platform/pkg/types/wire/save.go
@@ -344,8 +344,15 @@ func (ci *ChangeItem) GetUpdatedByID() (string, error) {
 }
 
 type SaveOptions struct {
-	Upsert               bool `json:"upsert" bot:"upsert"`
+	// Convert inserts to upserts if the unique key matches an existing record
+	Upsert bool `json:"upsert" bot:"upsert"`
+	// Ignore issues where we can't find old data for an update or delete. This
+	// is usually used to prevent issues in cascade delete where records have already been deleted.
 	IgnoreMissingRecords bool `json:"ignoreMissingRecords"`
+	// Ignore issues where we can't find references, just remove them from the save.
+	IgnoreMissingReferences bool `json:"ignoreMissingReferences"`
+	// If we encounter a validation error, just remove that change and keep going with the other ones.
+	IgnoreValidationErrors bool `json:""`
 }
 
 func GetValueInt(value interface{}) (int64, error) {

--- a/apps/platform/pkg/usage/usage.go
+++ b/apps/platform/pkg/usage/usage.go
@@ -2,6 +2,7 @@ package usage
 
 import (
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/thecloudmasters/uesio/pkg/sess"
@@ -13,7 +14,16 @@ type UsageHandler interface {
 }
 
 var usageHandlerMap = map[string]UsageHandler{}
-var activeHandler = "redis"
+var activeHandler string
+
+func init() {
+	usageHandler := os.Getenv("UESIO_USAGE_HANDLER")
+	if usageHandler == "memory" {
+		activeHandler = "memory"
+	} else {
+		activeHandler = "redis"
+	}
+}
 
 func RegisterUsageHandler(name string, handler UsageHandler) {
 	usageHandlerMap[name] = handler

--- a/apps/platform/pkg/usage/usage_common/usage_common.go
+++ b/apps/platform/pkg/usage/usage_common/usage_common.go
@@ -22,7 +22,11 @@ func SaveBatch(usage meta.UsageCollection, session *sess.Session) error {
 			Collection: "uesio/studio.usage",
 			Wire:       "CoolWireName",
 			Changes:    &usage,
-			Options:    &wire.SaveOptions{Upsert: true},
+			Options: &wire.SaveOptions{
+				Upsert:                  true,
+				IgnoreMissingReferences: true,
+				IgnoreValidationErrors:  true,
+			},
 		},
 	}
 

--- a/apps/platform/pkg/usage/usage_common/usage_common.go
+++ b/apps/platform/pkg/usage/usage_common/usage_common.go
@@ -3,7 +3,6 @@ package usage_common
 import (
 	"fmt"
 	"log/slog"
-	"strconv"
 	"strings"
 
 	"github.com/thecloudmasters/uesio/pkg/datasource"
@@ -37,7 +36,7 @@ func SaveBatch(usage meta.UsageCollection, session *sess.Session) error {
 
 }
 
-func GetUsageItem(key, value string) *meta.Usage {
+func GetUsageItem(key string, value int64) *meta.Usage {
 	// Make sure the value was actually there
 	if key == "nil" {
 		return nil
@@ -74,7 +73,6 @@ func GetUsageItem(key, value string) *meta.Usage {
 		},
 	}
 
-	total, _ := strconv.ParseInt(value, 10, 64)
-	usageItem.SetField("uesio/studio.total", total)
+	usageItem.SetField("uesio/studio.total", value)
 	return usageItem
 }

--- a/apps/platform/pkg/usage/usage_memory/usage_memory.go
+++ b/apps/platform/pkg/usage/usage_memory/usage_memory.go
@@ -1,0 +1,63 @@
+package usage_memory
+
+import (
+	"time"
+
+	"github.com/thecloudmasters/uesio/pkg/cache"
+	"github.com/thecloudmasters/uesio/pkg/meta"
+	"github.com/thecloudmasters/uesio/pkg/sess"
+	"github.com/thecloudmasters/uesio/pkg/usage/usage_common"
+)
+
+const MAX_USAGE_PER_RUN = 1000
+const KEYS_SET_NAME = "USAGE_KEYS"
+
+var usageCache *cache.MemoryCache[int64]
+
+func init() {
+	usageCache = cache.NewMemoryCache[int64](-1, 5*time.Minute)
+}
+
+type MemoryUsageHandler struct{}
+
+func (pcuh *MemoryUsageHandler) ApplyBatch(session *sess.Session) error {
+
+	items := usageCache.GetAll()
+
+	changes := meta.UsageCollection{}
+
+	for key, value := range items {
+		usageItem := usage_common.GetUsageItem(key, value)
+		if usageItem == nil {
+			continue
+		}
+		changes = append(changes, usageItem)
+	}
+
+	err := usage_common.SaveBatch(changes, session)
+	if err != nil {
+		return err
+	}
+
+	// Remove Keys
+	usageCache.DeleteAll()
+
+	return nil
+
+}
+
+func (pcuh *MemoryUsageHandler) Set(key string, size int64) error {
+	value, err := usageCache.Get(key)
+	if err != nil {
+		value = 0
+	}
+
+	if size == 0 {
+		value = value + 1
+	} else {
+		value = value + size
+	}
+
+	return usageCache.Set(key, value)
+
+}

--- a/apps/platform/pkg/usage/usage_redis/usage_redis.go
+++ b/apps/platform/pkg/usage/usage_redis/usage_redis.go
@@ -3,6 +3,7 @@ package usage_redis
 import (
 	"fmt"
 	"log/slog"
+	"strconv"
 
 	"github.com/gomodule/redigo/redis"
 	"github.com/thecloudmasters/uesio/pkg/cache"
@@ -49,7 +50,8 @@ func (ruh *RedisUsageHandler) ApplyBatch(session *sess.Session) error {
 	changes := meta.UsageCollection{}
 
 	for i, key := range keys {
-		usageItem := usage_common.GetUsageItem(key, values[i])
+		total, _ := strconv.ParseInt(values[i], 10, 64)
+		usageItem := usage_common.GetUsageItem(key, total)
 		if usageItem == nil {
 			continue
 		}

--- a/cypress/e2e/builder.cy.ts
+++ b/cypress/e2e/builder.cy.ts
@@ -381,6 +381,8 @@ describe("Uesio Builder Tests", () => {
 			// Verify that the URL and title has changed
 			cy.url().should("contain", `/edit`)
 			cy.title().should("eq", `Edit: ${viewName}`)
+			// Wait for the schema definitions to load
+			cy.wait(1000)
 		})
 	})
 

--- a/libs/apps/uesio/builder/bundle/componentpacks/main/src/components/mainwrapper/canvas.tsx
+++ b/libs/apps/uesio/builder/bundle/componentpacks/main/src/components/mainwrapper/canvas.tsx
@@ -82,8 +82,19 @@ const Canvas: FunctionComponent<definition.UtilityProps> = (props) => {
 	const onClickCapture = (e: MouseEvent) => {
 		e.stopPropagation()
 		e.preventDefault()
-		// Step 1: Find the closest slot that is accepting the current dragpath.
-		let target = document.elementFromPoint(e.clientX, e.clientY)
+
+		// Check for invisible target -- this is so that cypress testing can
+		// trigger click events on zero width elements
+		const eventTarget = e.target as Element
+		let target: Element | null
+
+		if (eventTarget.clientWidth === 0 || eventTarget.clientHeight === 0) {
+			target = e.target as Element | null
+		} else {
+			// Step 1: Find the closest slot that is accepting the current dragpath.
+			target = document.elementFromPoint(e.clientX, e.clientY)
+		}
+
 		if (!target) return
 		let validPath = ""
 		while (target !== null && target !== e.currentTarget) {

--- a/libs/apps/uesio/tests/hurl_specs/wire_save.hurl
+++ b/libs/apps/uesio/tests/hurl_specs/wire_save.hurl
@@ -181,3 +181,29 @@ HTTP 200
 jsonpath "$.wires[0].data[0]['uesio/tests.genus']" == "Kupker"
 jsonpath "$.wires[0].data[0]['uesio/tests.species']" == "Alain"
 jsonpath "$.wires[0].data[0]['uesio/core.uniquekey']" == "Kupker:Alain"
+
+# Test a simple insert with missing required field
+POST https://{{host}}:{{port}}/workspace/uesio/tests/dev/wires/save
+Accept: application/json
+{
+    "wires": [
+        {
+            "collection":"uesio/tests.animal",
+            "deletes":{},
+            "changes":{
+                "temp1":{
+                    "uesio/tests.species": "Flavious"
+                }
+            },
+            "wire":"mywire"
+        }
+    ]
+}
+HTTP 200
+[Asserts]
+jsonpath "$.wires[0].changes['temp1']['uesio/tests.species']" == "Flavious"
+jsonpath "$.wires[0].changes['temp1']['uesio/tests.genus']" not exists
+jsonpath "$.wires[0].errors[0]['recordid']" == "temp1"
+jsonpath "$.wires[0].errors[0]['fieldid']" == "uesio/tests.genus"
+jsonpath "$.wires[0].errors[0]['message']" == "Field: Genus is required"
+


### PR DESCRIPTION
1. Added environment variable documentation for REDIS and UESIO_DB settings.
2. Created an in-memory usage handler that does not need Redis.
3. Added a `UESIO_WORKER_MODE` setting to allow the worker to run on the same process as the webserver.

These changes allow uesio to run with full functionality on a single server without Redis.
