### PR TITLE
login_changes_landing_page_addition

### DIFF
--- a/libs/apps/uesio/core/bundle/views/login.yaml
+++ b/libs/apps/uesio/core/bundle/views/login.yaml
@@ -24,7 +24,7 @@ definition:
                     text: "New to ues.io? "
                     uesio.styleTokens:
                       root:
-                        - text-xs
+                        - text-s
                         - font-light
                 - uesio/io.link:
                     text: "Create an account"
@@ -32,7 +32,7 @@ definition:
                     uesio.styleTokens:
                       root:
                         - text-blue-600
-                        - text-xs
+                        - text-s
                         - font-light
   params:
     expired:

--- a/libs/apps/uesio/core/bundle/views/signuplanding.yaml
+++ b/libs/apps/uesio/core/bundle/views/signuplanding.yaml
@@ -34,7 +34,7 @@ definition:
                   - text-xl
               element: div
           - uesio/io.text:
-              text: Please check your email and confirm your identity.
+              text: Please check your email and confirm your identity then head back over https://studio.ues.io/login to get started.
               uesio.styleTokens:
                 root:
                   - text-base


### PR DESCRIPTION
1. login.yaml - Replaced - text-xs with  -text-s to enlarge the 'New to ues.io? [Create an account]' text as some users do not see it at first glance.

2. signuplanding.yaml - adds the text ' then head back over https://studio.ues.io/login to get started.' so that users do not have to find the login link after verifying their email address.