### PR TITLE
increase timeout for main Github action

### DIFF
--- a/.github/workflows/master_branch_build.yaml
+++ b/.github/workflows/master_branch_build.yaml
@@ -32,7 +32,7 @@ jobs:
     env:
       FULL_SHA: ${{ github.sha }}
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
# What does this PR do?

This PR increase timeout for main Github action, seems that after https://github.com/ues-io/uesio/pull/4332 the process of building the app slowed down a bit, I guess we can try to give it a few more minutes and see if it ends. Before in Github it took 6m 27s to finish the job, locally I don't feel any difference (It was a lot not building uesio anyway so don't trust me).

If this don't fix it then I guess we will have to look why that PR slows so much the build, after looking at the PR might be the size of the react imports but I guess @humandad you know more what is going on in the PR.
  

# Testing

Just merge this PR and the action should trigger.
