### PR TITLE
Remove tslint references

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,5 @@
 {
   "recommendations": [
-    "ms-vscode.vscode-typescript-tslint-plugin",
     "esbenp.prettier-vscode",
     "firsttris.vscode-jest-runner"
   ]

--- a/nx.json
+++ b/nx.json
@@ -43,7 +43,6 @@
 		"sharedGlobals": [
 			"{workspaceRoot}/workspace.json",
 			"{workspaceRoot}/tsconfig.base.json",
-			"{workspaceRoot}/tslint.json",
 			"{workspaceRoot}/nx.json"
 		],
 		"production": [


### PR DESCRIPTION
Removes all references to tslint in nx config and vscode config. We aren't using it anyway.