### PR TITLE
improve currency merge

### DIFF
--- a/libs/apps/uesio/studio/bundle/views/file.yaml
+++ b/libs/apps/uesio/studio/bundle/views/file.yaml
@@ -150,7 +150,7 @@ definition:
                                                             root:
                                                               - bg-white
                                                           uesio.variant: uesio/appkit.badge
-                                                          text: $FileSize{filesize}
+                                                          text: $FileSize{${filesize}}
                                                           element: div
                                               content:
                                                 - uesio/io.image:
@@ -197,7 +197,7 @@ definition:
                                                           root:
                                                             - bg-white
                                                         uesio.variant: uesio/appkit.badge
-                                                        text: $FileSize{uesio/core.contentlength}
+                                                        text: $FileSize{${uesio/core.contentlength}}
                                                         element: div
                                             content:
                                               - uesio/io.fileattachment:


### PR DESCRIPTION
Allows pre-merging the expression inside of a `$Currency{}` merge. That way you can use the result of a `$Formula{}` merge as the expression.