### PR TITLE
run cli from dist directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,8 @@ Uesio is a **low-code** application development platform.
     -   `jq` (for JSON manipulation in Shell): `brew install jq`
     -   `wget` (for fetching URLs): `brew install wget`
 -   Start dependencies [here](#dependencies).
--   Create a symlink for the Uesio CLI into your bin (NOT an alias, which won't work with `nx`):
-    -   Mac OS: `sudo ln -s ~/git/uesio/dist/cli/uesio /usr/local/bin`
-    -   Windows: `mklink C:\bin\uesio C:\Users\<USERNAME>\git\uesio\dist\cli\uesio`, and ensure `bin` is on path: `setx PATH "C:\bin;%PATH%`
--   Build and run [here](#run).
+-   [Build](#build)
+-   [Run](#run).
 
 ## Optional
 
@@ -93,6 +91,14 @@ While developing you may want the entire monorepo to rebuild changed files. You 
 ```
 npm run watch-all
 ```
+
+## (Optional) Using Uesio CLI globally
+
+If you'd like to use the Uesio CLI that you have built elsewhere on your machine without having to explicitly reference the binary in `dist/cli`:
+
+- Mac OS/Linux: create a symlink for the Uesio CLI into your bin (NOT an alias, which won't work with `nx`): `sudo ln -s <absolute project root path>/dist/cli/uesio /usr/local/bin`
+- Windows: add `<absolute project root path>/dist/cli` to your PATH
+
 
 # <a id="dependencies"></a>Start dependencies
 

--- a/libs/apps/uesio/aikit/project.json
+++ b/libs/apps/uesio/aikit/project.json
@@ -10,7 +10,7 @@
 			"outputs": ["{projectRoot}/bundle/componentpacks/main/dist"],
 			"options": {
 				"commands": [
-					"uesio pack",
+					"../../../../dist/cli/uesio pack",
 					"npx tsc --noEmit --project ./tsconfig.lib.json"
 				],
 				"cwd": "libs/apps/uesio/aikit"
@@ -19,7 +19,7 @@
 		"watch": {
 			"executor": "nx:run-commands",
 			"options": {
-				"command": "uesio pack -w",
+				"command": "../../../../dist/cli/uesio pack -w",
 				"cwd": "libs/apps/uesio/aikit"
 			}
 		},

--- a/libs/apps/uesio/appkit/project.json
+++ b/libs/apps/uesio/appkit/project.json
@@ -10,7 +10,7 @@
 			"outputs": ["{projectRoot}/bundle/componentpacks/main/dist"],
 			"options": {
 				"commands": [
-					"uesio pack",
+					"../../../../dist/cli/uesio pack",
 					"npx tsc --noEmit --project ./tsconfig.lib.json"
 				],
 				"cwd": "libs/apps/uesio/appkit"
@@ -19,7 +19,7 @@
 		"watch": {
 			"executor": "nx:run-commands",
 			"options": {
-				"command": "uesio pack -w",
+				"command": "../../../../dist/cli/uesio pack -w",
 				"cwd": "libs/apps/uesio/appkit"
 			}
 		},

--- a/libs/apps/uesio/builder/project.json
+++ b/libs/apps/uesio/builder/project.json
@@ -10,7 +10,7 @@
 			"outputs": ["{projectRoot}/bundle/componentpacks/main/dist"],
 			"options": {
 				"commands": [
-					"uesio pack",
+					"../../../../dist/cli/uesio pack",
 					"npx tsc --noEmit --project ./tsconfig.lib.json",
 					"node ./build/generate-tailwind-classes-index.js"
 				],
@@ -20,7 +20,7 @@
 		"watch": {
 			"executor": "nx:run-commands",
 			"options": {
-				"command": "uesio pack -w",
+				"command": "../../../../dist/cli/uesio pack -w",
 				"cwd": "libs/apps/uesio/builder"
 			}
 		},

--- a/libs/apps/uesio/core/project.json
+++ b/libs/apps/uesio/core/project.json
@@ -10,7 +10,7 @@
 			"outputs": ["{projectRoot}/bundle/componentpacks/app/dist"],
 			"options": {
 				"commands": [
-					"uesio pack",
+					"../../../../dist/cli/uesio pack",
 					"npx tsc --noEmit --project ./tsconfig.lib.json"
 				],
 				"cwd": "libs/apps/uesio/core"
@@ -19,7 +19,7 @@
 		"watch": {
 			"executor": "nx:run-commands",
 			"options": {
-				"command": "uesio pack -w",
+				"command": "../../../../dist/cli/uesio pack -w",
 				"cwd": "libs/apps/uesio/core"
 			}
 		},

--- a/libs/apps/uesio/io/project.json
+++ b/libs/apps/uesio/io/project.json
@@ -10,7 +10,7 @@
 			"outputs": ["{projectRoot}/bundle/componentpacks/main/dist"],
 			"options": {
 				"commands": [
-					"uesio pack",
+					"../../../../dist/cli/uesio pack",
 					"npx tsc --noEmit --project ./tsconfig.lib.json"
 				],
 				"cwd": "libs/apps/uesio/io"
@@ -19,7 +19,7 @@
 		"watch": {
 			"executor": "nx:run-commands",
 			"options": {
-				"command": "uesio pack -w",
+				"command": "../../../../dist/cli/uesio pack -w",
 				"cwd": "libs/apps/uesio/io"
 			}
 		},

--- a/libs/apps/uesio/sitekit/project.json
+++ b/libs/apps/uesio/sitekit/project.json
@@ -10,7 +10,7 @@
 			"outputs": ["{projectRoot}/bundle/componentpacks/main/dist"],
 			"options": {
 				"commands": [
-					"uesio pack",
+					"../../../../dist/cli/uesio pack",
 					"npx tsc --noEmit --project ./tsconfig.lib.json"
 				],
 				"cwd": "libs/apps/uesio/sitekit"
@@ -19,7 +19,7 @@
 		"watch": {
 			"executor": "nx:run-commands",
 			"options": {
-				"command": "uesio pack -w",
+				"command": "../../../../dist/cli/uesio pack -w",
 				"cwd": "libs/apps/uesio/sitekit"
 			}
 		},

--- a/libs/apps/uesio/studio/project.json
+++ b/libs/apps/uesio/studio/project.json
@@ -10,7 +10,7 @@
 			"outputs": ["{projectRoot}/bundle/componentpacks/main/dist"],
 			"options": {
 				"commands": [
-					"uesio pack",
+					"../../../../dist/cli/uesio pack",
 					"npx tsc --noEmit --project ./tsconfig.lib.json"
 				],
 				"cwd": "libs/apps/uesio/studio"
@@ -19,7 +19,7 @@
 		"watch": {
 			"executor": "nx:run-commands",
 			"options": {
-				"command": "uesio pack -w",
+				"command": "../../../../dist/cli/uesio pack -w",
 				"cwd": "libs/apps/uesio/studio"
 			}
 		},

--- a/libs/ui/build.sh
+++ b/libs/ui/build.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-uesio packui
+../../dist/cli/uesio packui
 mkdir -p ../../dist/ui/types/client
 mkdir -p ../../dist/ui/types/server
 # For editing TypeScript bots in Studio output a file which JUST contains Bot types

--- a/libs/ui/project.json
+++ b/libs/ui/project.json
@@ -17,7 +17,7 @@
 			"executor": "nx:run-commands",
 			"outputs": ["{workspaceRoot}/dist/ui"],
 			"options": {
-				"command": "uesio packui --watch",
+				"command": "../../dist/cli/uesio packui --watch",
 				"cwd": "libs/ui"
 			}
 		},


### PR DESCRIPTION
# What does this PR do?

Ensures that build scripts use `dist/cli/uesio` consistently.

I believe I located all places that non-relative references existed but a thorough review of the build process should be performed to ensure I didn't miss anything 😄 

Resolves #4353

# Testing

`npm run build-all` works as expected without requiring symlink.
