### PR TITLE
fix: view component not loading correctly

### DIFF
--- a/libs/apps/uesio/builder/bundle/componentpacks/main/src/components/paramsfield/paramsfield.tsx
+++ b/libs/apps/uesio/builder/bundle/componentpacks/main/src/components/paramsfield/paramsfield.tsx
@@ -51,14 +51,12 @@ const ParamsField: definition.UC<ParamsFieldDefinition> = (props) => {
 		}
 	}
 
-	if (!view) return null
-
 	const paramsDef = api.view.useViewDef(view)?.params as Record<
 		string,
 		Record<"type", string>
 	>
 
-	if (!paramsDef) return null
+	if (!view || !paramsDef) return null
 
 	const params = record.getFieldValue(fieldId)
 

--- a/libs/ui/src/bands/view/operations/load.ts
+++ b/libs/ui/src/bands/view/operations/load.ts
@@ -23,7 +23,7 @@ const runEvents = async (
 	}
 }
 
-const useLoadWires = (
+const useLoadWiresAndEvents = (
 	context: Context,
 	viewDef: ViewDefinition | undefined
 ) => {
@@ -137,4 +137,4 @@ const doesConditionHaveParamDependency = (
 	return false
 }
 
-export { useLoadWires }
+export { useLoadWiresAndEvents }

--- a/libs/ui/src/components/wires.tsx
+++ b/libs/ui/src/components/wires.tsx
@@ -1,0 +1,16 @@
+import { FunctionComponent } from "react"
+import { useLoadWires } from "../bands/view/operations/load"
+import { Context } from "../context/context"
+import { ViewDefinition } from "../definition/definition"
+
+type WiresProps = { context: Context; viewDef: ViewDefinition }
+
+const Wires: FunctionComponent<WiresProps> = ({ context, viewDef }) => {
+	useLoadWires(context, viewDef)
+	return null
+}
+
+Wires.displayName = "Wires"
+
+export { type WiresProps }
+export default Wires

--- a/libs/ui/src/components/wires.tsx
+++ b/libs/ui/src/components/wires.tsx
@@ -1,16 +1,19 @@
 import { FunctionComponent } from "react"
-import { useLoadWires } from "../bands/view/operations/load"
+import { useLoadWiresAndEvents } from "../bands/view/operations/load"
 import { Context } from "../context/context"
 import { ViewDefinition } from "../definition/definition"
 
-type WiresProps = { context: Context; viewDef: ViewDefinition }
+type WiresAndEventsProps = { context: Context; viewDef: ViewDefinition }
 
-const Wires: FunctionComponent<WiresProps> = ({ context, viewDef }) => {
-	useLoadWires(context, viewDef)
+const WiresAndEvents: FunctionComponent<WiresAndEventsProps> = ({
+	context,
+	viewDef,
+}) => {
+	useLoadWiresAndEvents(context, viewDef)
 	return null
 }
 
-Wires.displayName = "Wires"
+WiresAndEvents.displayName = "WiresAndEvents"
 
-export { type WiresProps }
-export default Wires
+export { type WiresAndEventsProps }
+export default WiresAndEvents


### PR DESCRIPTION
# What does this PR do?

Ensures that a view component does not display an error when no view is selected and properly displays when selected.

Resolves #4369

# Testing

Manual testing of scenarios described in #4369 including monitoring for number of network calls resulting from memoized result.

@humandad - Couple of things specifically for review beyond general:

1. If the network call fails, error displays in console due to unhandled rejection occuring in useEffect which isn't ideal.  LIkely better to have the component itself display an error possibly.  Not sure what the standard is in the codebase for these types of situations.  Thoughts?
2. Regarding the Wires component, I tried to find & identify how FunctionComponents are defined in other areas and follow similar/same pattern.  It's a little overkill since Wires will only ever be used by View but have a look and let me know if it's what your expecting.
3. Plan on adding tests after we talk about approaches but, as discussed, getting that done shouldn't hold-up review & merge of this.

Thanks again for all your help in getting this fixed!!
