### PR TITLE
use alias instead of path

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,5 @@
-const { getJestProjectsAsync } = require("@nx/jest")
+const { getJestProjects } = require("@nx/jest")
 
 module.exports = {
-	projects: [...getJestProjectsAsync()],
+	projects: [...getJestProjects()],
 }

--- a/scripts/tests-cleanup.sh
+++ b/scripts/tests-cleanup.sh
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
 
 set -e
+shopt -s expand_aliases
 
 export UESIO_CLI_LOGIN_METHOD=uesio/core.mock
 export UESIO_CLI_USERNAME=uesio
 export UESIO_CLI_HOST="https://studio.uesio-dev.com:3000"
 
-export PATH="$PATH:$(pwd)/dist/cli"
+SCRIPT_DIR=$(dirname "$(realpath "$0")")
+alias uesio="$SCRIPT_DIR/../dist/cli/uesio"
 
 #Navigate
 cd libs/apps/uesio/tests

--- a/scripts/tests-init.sh
+++ b/scripts/tests-init.sh
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
 
 set -e
+shopt -s expand_aliases
 
 export UESIO_CLI_LOGIN_METHOD=uesio/core.mock
 export UESIO_CLI_USERNAME=uesio
 export UESIO_CLI_HOST="https://studio.uesio-dev.com:3000"
 
-export PATH="$PATH:$(pwd)/dist/cli"
+SCRIPT_DIR=$(dirname "$(realpath "$0")")
+alias uesio="$SCRIPT_DIR/../dist/cli/uesio"
 
 # Deploy the sample app using Uesio
 cd libs/apps/uesio/tests


### PR DESCRIPTION
# What does this PR do?

1. Switches back to the deprecated `getJestProjects()` function. This is so that the jest extension in vscode will work. We could switch back to the `getJestProjectsAsync()` function at some point, but that would take some more work getting the config files to handle `async/await`

2. Uses an alias instead of the `PATH` environment variable in scripts.

