### PR TITLE
fix: do not ignore dotfiles when zipping local files

### DIFF
--- a/apps/cli/pkg/zip/zip.go
+++ b/apps/cli/pkg/zip/zip.go
@@ -28,9 +28,6 @@ func ZipDir(localPath string) io.Reader {
 				return nil
 			}
 			file, err := os.Open(path)
-			if strings.HasPrefix(file.Name(), ".") || strings.Contains(file.Name(), "/.") {
-				return nil
-			}
 			if err != nil {
 				return err
 			}

--- a/apps/cli/pkg/zip/zip.go
+++ b/apps/cli/pkg/zip/zip.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/thecloudmasters/uesio/pkg/fileadapt/localfiles"
 )
 
 func ZipDir(localPath string) io.Reader {
@@ -25,6 +27,9 @@ func ZipDir(localPath string) io.Reader {
 				return err
 			}
 			if info.IsDir() {
+				return nil
+			}
+			if localfiles.ShouldIgnoreFile(info.Name()) {
 				return nil
 			}
 			file, err := os.Open(path)

--- a/apps/platform/pkg/fileadapt/localfiles/localfiles.go
+++ b/apps/platform/pkg/fileadapt/localfiles/localfiles.go
@@ -7,11 +7,22 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/thecloudmasters/uesio/pkg/types/file"
 	"github.com/thecloudmasters/uesio/pkg/types/wire"
 )
+
+// Skip .DS_Store files
+var LocalFileIgnore = []string{".DS_Store"}
+
+// For local files, returns true if the file should be ignored during processing, false otherwise
+func ShouldIgnoreFile(fileName string) bool {
+	return slices.ContainsFunc(LocalFileIgnore, func(name string) bool {
+		return strings.EqualFold(name, fileName)
+	})
+}
 
 type FileAdapter struct {
 }
@@ -54,8 +65,7 @@ func (c *Connection) List(dirPath string) ([]file.Metadata, error) {
 		if path == basePath {
 			return nil
 		}
-		// Skip .DS_Store files
-		if info.Name() == ".DS_Store" {
+		if ShouldIgnoreFile(info.Name()) {
 			return nil
 		}
 


### PR DESCRIPTION
# What does this PR do?

Changes behavior from ignoring all dotfiles (files that start with `.`) to not ignoring.  There are certain meta data types that allow files that start with `.` (e.g., Files).  If a file gets zipped and is invalid for a given metadata type, server side validation when processing the zip should detect and fail the operation.

# Testing

No current tests for any portions of the CLI in this area so manually tested to ensure that files that start with `.` are zipped and sent to server and changes reflected.

Resolves #4400 
