### PR TITLE
fix: log message when `-d` option is not specified

### DIFF
--- a/apps/cli/pkg/command/workspace/deploy.go
+++ b/apps/cli/pkg/command/workspace/deploy.go
@@ -16,7 +16,7 @@ import (
 func Deploy(sourceDir string) error {
 
 	sourceDirDescription := sourceDir
-	if sourceDir == "." {
+	if sourceDir == "." || sourceDir == "" {
 		sourceDirDescription = "current directory"
 	}
 

--- a/apps/cli/pkg/command/workspace/retrieve.go
+++ b/apps/cli/pkg/command/workspace/retrieve.go
@@ -19,7 +19,7 @@ import (
 func Retrieve(targetDir string) error {
 
 	targetDirDescription := targetDir
-	if targetDir == "." {
+	if targetDir == "." || targetDir == "" {
 		targetDirDescription = "current directory"
 	}
 


### PR DESCRIPTION
# What does this PR do?

When `-d` is not specified for `retrieve` or `deploy` commands, ensure log message contains "current directory"

> [!NOTE]
> There are several issues with the way that paths are resolved when `-d` is specified.  For example, if `./` is specified, retrieve fails with `Error: illegal file path: bundle/views/community_detail.yaml` error.  This PR only addresses the specific case around not specifying `-d`.  Separately, the entire code base should be reviewed/adjusted to ensure proper handling of `-d` depending on the approach taken in #4393.

# Testing

No existing tests so manual testing performed to ensure proper message emitted.

Resolves #4402