### PR TITLE
fix: display slot name when label not provided

### DIFF
--- a/libs/apps/uesio/builder/bundle/componentpacks/main/src/components/mainwrapper/indexslot.tsx
+++ b/libs/apps/uesio/builder/bundle/componentpacks/main/src/components/mainwrapper/indexslot.tsx
@@ -82,7 +82,7 @@ const IndexSlot: definition.UtilityComponent<IndexSlotProps> = (props) => {
 		parentSelected,
 	} = props
 	const listName = slot.name
-	const label = slot.label || "Slot"
+	const label = slot.label || listName || "Slot"
 
 	const listPath = path ? `${path}["${listName}"]` : `["${listName}"]`
 	const classes = styles.useUtilityStyleTokens(SlotStyleDefaults, props)


### PR DESCRIPTION
# What does this PR do?

If a slot does not specify a `label` property, display the `name` of the slot so that the component index contains something meaningful rather than `Slot` so that the user knows which slot is which.

# Testing

No current test coverage so manual testing of the builder on a component that does not contain labels for slots (e.g., Card).

Resolves #4409 
