### PR TITLE
chore: improve performance of zipping files

### DIFF
--- a/apps/cli/pkg/zip/zip.go
+++ b/apps/cli/pkg/zip/zip.go
@@ -4,6 +4,7 @@ import (
 	"archive/zip"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -22,7 +23,7 @@ func ZipDir(localPath string) io.Reader {
 		// Zip the current directory
 		w := zip.NewWriter(pw)
 
-		walker := func(path string, info os.FileInfo, err error) error {
+		walker := func(path string, info fs.DirEntry, err error) error {
 			if err != nil {
 				return err
 			}
@@ -50,7 +51,7 @@ func ZipDir(localPath string) io.Reader {
 
 			return nil
 		}
-		err := filepath.Walk(localPath, walker)
+		err := filepath.WalkDir(localPath, walker)
 		if err != nil {
 			fmt.Println("Error Zipping Bundle Dir: " + err.Error())
 		}


### PR DESCRIPTION
# What does this PR do?

Switches from `filepath.Walk` to `filepath.WalkDir` to improve performance of zipping files.

This is an intermediate solution as the final solution should migrate to using [fs.WalkDir](https://pkg.go.dev/io/fs#example-WalkDir) to improve testability.  Making the change to `fs.WalkDir` requires a more invasive set of changes so for now, just picking up perf improvements of `filepath.WalkDir` vs. `filepath.Walk`.  Migrating to `fs.WalkDir` should be completed as part of a larger effort required to improve overall testability of the codebase.

# Testing

No current tests so manual deploy performed via CLI.
