### PR TITLE
fix: add footer/actions area to dialog by default

### DIFF
--- a/libs/apps/uesio/builder/bundle/componentpacks/main/src/components/mainwrapper/viewinfopanel/viewinfopanel.tsx
+++ b/libs/apps/uesio/builder/bundle/componentpacks/main/src/components/mainwrapper/viewinfopanel/viewinfopanel.tsx
@@ -81,7 +81,6 @@ const ViewInfoPanel: definition.UtilityComponent = (props) => {
 			content: SimpleTagContent,
 			defaultDefinition: {
 				"uesio.type": defaultPanelComponentType,
-				components: [],
 				...getComponentDef(defaultPanelComponentType)
 					?.defaultDefinition,
 			},

--- a/libs/apps/uesio/io/bundle/components/dialog.yaml
+++ b/libs/apps/uesio/io/bundle/components/dialog.yaml
@@ -13,6 +13,8 @@ defaultDefinition:
   height: "60%"
   title: "New Panel"
   uesio.variant: uesio/io.default
+  components: []
+  actions: []
 properties:
   - name: panelid
     label: Panel Id


### PR DESCRIPTION
# What does this PR do?

There are a number of issues with Panels as described in #4392.

This PR helps to address one of them by adding an empty `actions` area to the dialog by default.  This was done for two reasons:

1. The component index is not currently visible for panels so there is no way for a user to know that an `actions` area even exists.  By having it exist by default, when dropping components on the dialog canvas, the footer/actions area will highlight so they will see that its there and a valid dropzone.  If the user does not want the area, they can remove it from yaml but this at least gives a visual indication that there is a footer/actions area until the component index problem is resolved.
2. Having the area by default seems like a more reasonable default since it's probably more common then not that a user would want a footer/actions area.  Making this the default provides that while still allowing it to be removed if the user does not want the area visible at all.

# Testing

Manual testing via web ui.
