### PR TITLE
feat: display column name in studio collection view

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -158,7 +158,7 @@ Cypress.Commands.add(
 			.should(($div) => {
 				// should have found 1 element
 				expect($div).to.have.length(1)
-				expect($div.children("p").eq(0)).to.contain(expectLabel)
+				expect($div.children("p").eq(0)).to.contain(expectName)
 				expect($div.children("p").eq(1)).to.contain(expectNamespace)
 			})
 		cy.get(tableRowSelector)

--- a/libs/apps/uesio/studio/bundle/views/collection.yaml
+++ b/libs/apps/uesio/studio/bundle/views/collection.yaml
@@ -417,7 +417,7 @@ definition:
                               components:
                                 - uesio/io.iconlabel:
                                     uesio.variant: uesio/io.namespacefield
-                                    text: ${uesio/studio.label}
+                                    text: ${uesio/studio.name}
                                     subtitle: ${uesio/studio.namespace}
                                     icon: ${uesio/studio.appicon}
                                     color: ${uesio/studio.appcolor}
@@ -511,7 +511,7 @@ definition:
                               components:
                                 - uesio/io.iconlabel:
                                     uesio.variant: uesio/io.namespacefield
-                                    text: ${uesio/studio.label}
+                                    text: ${uesio/studio.name}
                                     subtitle: ${uesio/studio.namespace}
                                     icon: ${uesio/studio.appicon}
                                     color: ${uesio/studio.appcolor}
@@ -711,7 +711,7 @@ definition:
                                                 components:
                                                   - uesio/io.iconlabel:
                                                       uesio.variant: uesio/io.namespacefield
-                                                      text: ${uesio/studio.label}
+                                                      text: ${uesio/studio.name}
                                                       subtitle: ${uesio/studio.namespace}
                                                       icon: ${uesio/studio.appicon}
                                                       color: ${uesio/studio.appcolor}


### PR DESCRIPTION
# What does this PR do?

Displays the collection field name instead of the label in the first column of tables within the collection view.

# Testing

Manual testing of Web UI.

Closes #4418 
