### PR TITLE
fix: generated package.json name format

### DIFF
--- a/libs/apps/uesio/core/bundle/bots/generator/init/bot.js
+++ b/libs/apps/uesio/core/bundle/bots/generator/init/bot.js
@@ -2,7 +2,7 @@ function init(bot) {
 	var name = bot.params.get("name")
 	var params = {
 		name,
-		pkgName: `${name?.includes('/') ? '@' : ''}${name}`
+		pkgName: `${name?.includes("/") ? "@" : ""}${name}`,
 	}
 	var templatePrefix = "templates/template."
 	bot.generateFile(".gitignore", params, `${templatePrefix}gitignore`)

--- a/libs/apps/uesio/core/bundle/bots/generator/init/bot.js
+++ b/libs/apps/uesio/core/bundle/bots/generator/init/bot.js
@@ -2,6 +2,7 @@ function init(bot) {
 	var name = bot.params.get("name")
 	var params = {
 		name,
+		pkgName: `${name?.includes('/') ? '@' : ''}${name}`
 	}
 	var templatePrefix = "templates/template."
 	bot.generateFile(".gitignore", params, `${templatePrefix}gitignore`)

--- a/libs/apps/uesio/core/bundle/bots/generator/init/templates/template.package.json
+++ b/libs/apps/uesio/core/bundle/bots/generator/init/templates/template.package.json
@@ -1,5 +1,5 @@
 {
-	"name": "${name}",
+	"name": "${pkgName}",
 	"version": "0.0.1",
 	"description": "",
 	"scripts": {


### PR DESCRIPTION
# What does this PR do?

Fix package.json name value

# Testing

All tests pass and confirmed a new app/clone name has a leading `@` in the package.json name value.

Resolves #4421 
