### PR TITLE
fix: remove "dir" flag from retrieve & deploy commands

### DIFF
--- a/apps/cli/pkg/cmd/workspace.go
+++ b/apps/cli/pkg/cmd/workspace.go
@@ -26,7 +26,6 @@ func init() {
 		Long:  "Retrieves all metadata from a remote workspace to the local directory",
 		Run:   workspaceRetrieve,
 	}
-	workspaceRetrieveCmd.Flags().StringVarP(&targetDir, "dir", "d", "", "Directory to retrieve into. Defaults to current directory")
 
 	workspaceDeployCmd := &cobra.Command{
 		Use:   "deploy",
@@ -34,7 +33,6 @@ func init() {
 		Long:  "Deploys all local metadata to a remote workspace",
 		Run:   workspaceDeploy,
 	}
-	workspaceDeployCmd.Flags().StringVarP(&targetDir, "dir", "d", "", "Directory to deploy from. Defaults to current directory")
 
 	workspaceCreateCmd := &cobra.Command{
 		Use:   "create",
@@ -69,20 +67,18 @@ func init() {
 		Short: "uesio deploy",
 		Run:   workspaceDeploy,
 	}
-	oldDeployCommand.Flags().StringVarP(&targetDir, "dir", "d", "", "Directory to deploy from. Defaults to current directory")
 	oldRetrieveCommand := &cobra.Command{
 		Use:   "retrieve",
 		Short: "uesio retrieve",
 		Run:   workspaceRetrieve,
 	}
-	oldRetrieveCommand.Flags().StringVarP(&targetDir, "dir", "d", "", "Directory to retrieve into. Defaults to current directory")
 
 	rootCmd.AddCommand(workspaceCommand, oldDeployCommand, oldRetrieveCommand)
 
 }
 
 func workspaceRetrieve(cmd *cobra.Command, args []string) {
-	err := workspace.Retrieve(targetDir)
+	err := workspace.Retrieve()
 	if err != nil {
 		fmt.Println("Error: " + err.Error())
 		os.Exit(1)
@@ -91,7 +87,7 @@ func workspaceRetrieve(cmd *cobra.Command, args []string) {
 }
 
 func workspaceDeploy(cmd *cobra.Command, args []string) {
-	err := workspace.Deploy(targetDir)
+	err := workspace.Deploy()
 	if err != nil {
 		fmt.Println("Error: " + err.Error())
 		os.Exit(1)

--- a/apps/cli/pkg/command/workspace/deploy.go
+++ b/apps/cli/pkg/command/workspace/deploy.go
@@ -3,7 +3,6 @@ package workspace
 import (
 	"errors"
 	"fmt"
-	"path/filepath"
 
 	"github.com/thecloudmasters/cli/pkg/auth"
 	"github.com/thecloudmasters/cli/pkg/call"
@@ -13,14 +12,7 @@ import (
 	"github.com/thecloudmasters/cli/pkg/zip"
 )
 
-func Deploy(sourceDir string) error {
-
-	sourceDirDescription := sourceDir
-	if sourceDir == "." || sourceDir == "" {
-		sourceDirDescription = "current directory"
-	}
-
-	fmt.Printf("Deploying metadata to studio from %s ... \n", sourceDirDescription)
+func Deploy() error {
 
 	_, err := auth.Login()
 	if err != nil {
@@ -46,7 +38,7 @@ func Deploy(sourceDir string) error {
 		return err
 	}
 
-	payload := zip.ZipDir(filepath.Join(sourceDir, "bundle"))
+	payload := zip.ZipDir("bundle")
 
 	url := fmt.Sprintf("workspace/%s/%s/metadata/deploy", app, workspace)
 

--- a/apps/cli/pkg/command/workspace/retrieve.go
+++ b/apps/cli/pkg/command/workspace/retrieve.go
@@ -16,14 +16,7 @@ import (
 	"github.com/thecloudmasters/uesio/pkg/meta"
 )
 
-func Retrieve(targetDir string) error {
-
-	targetDirDescription := targetDir
-	if targetDir == "." || targetDir == "" {
-		targetDirDescription = "current directory"
-	}
-
-	fmt.Printf("Retrieving metadata from studio into %s ... \n", targetDirDescription)
+func Retrieve() error {
 
 	_, err := auth.Login()
 	if err != nil {
@@ -44,7 +37,7 @@ func Retrieve(targetDir string) error {
 		return errors.New("No active workspace is set. Use \"uesio work\" to set one.")
 	}
 
-	err = RetrieveBundleForAppWorkspace(appName, workspace, targetDir)
+	err = RetrieveBundleForAppWorkspace(appName, workspace, "")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# What does this PR do?

As described in #4393, there are some issues when using the `-d` flag with `retrieve` & `deploy`.  Upon review, a couple of things stand-out:

1. The existing logic of `retrieve` and `deploy` look for a `bundle/bundle.yaml` file and do not respect `-d` when doing so which is what leads to the errors mentioned in #4393.  
2. All other commands (except `app clone`) operate on cwd and do not offer a `-d` flag

Given the way that all commands current operate (except `app clone`) expecting there to be a `./bundle/bundle.yaml`, the options are to modify all commands to have a `-d` and then locate `bundle.yaml` appropriately or remove `-d` from `retrieve` & `deploy` to make them consistent with the way all the other commands behave.

For now, eliminating `-d` from `retrieve` and `deploy` so that the CLI always works on `cwd` (except for `app clone` which accepts a `-d`).  This is consistent with the way many other CLIs operate.  If/When the requirement presents itself that the CLI support targeted directory paths, a `-d` can be added but it must support the shared/common logic of locating `bundle/bundle.yaml` along with anything the command itself is doing.

# Testing

No current tests so built and tested retrieve and deploy manually.

Resolves #4393 