### PR TITLE
chore: surface card sub component variants in builder

### DIFF
--- a/libs/apps/uesio/io/bundle/components/card.yaml
+++ b/libs/apps/uesio/io/bundle/components/card.yaml
@@ -9,6 +9,7 @@ slots:
   - name: avatar
 description: A Card component
 discoverable: true
+defaultVariant: uesio/io.default
 properties:
   - name: title
     label: Title
@@ -23,7 +24,7 @@ properties:
       type: COMPONENTVARIANT
       grouping: uesio/io.tile
   - name: scrollpanelVariant
-    label: Scrollpanel Variant
+    label: Scroll Panel Variant
     type: METADATA
     metadata:
       type: COMPONENTVARIANT
@@ -40,7 +41,11 @@ sections:
     properties:
       - title
       - subtitle
+  - type: STYLES
+    properties:
+      - tileVariant
       - scrollpanelVariant
+      - titlebarVariant
   - type: DISPLAY
 definition:
   - uesio/io.tile:

--- a/libs/apps/uesio/io/bundle/componentvariants/uesio/io/card/default.yaml
+++ b/libs/apps/uesio/io/bundle/componentvariants/uesio/io/card/default.yaml
@@ -1,0 +1,7 @@
+name: default
+label: Default
+definition:
+  tileVariant: uesio/io.default
+  scrollpanelVariant: uesio/io.default
+  titlebarVariant: uesio/io.default
+public: true


### PR DESCRIPTION
# What does this PR do?

Add a default variant for `Card` component and surface sub-component variants in `Styles` panel.

# Testing

Manual testing via Builder UI.
