### PR TITLE
Chore/improve invalid yaml file error msg

### DIFF
--- a/apps/platform/pkg/bundlestore/filebundlestore/filebundlestore.go
+++ b/apps/platform/pkg/bundlestore/filebundlestore/filebundlestore.go
@@ -106,7 +106,7 @@ func (b *FileBundleStoreConnection) GetItem(item meta.BundleableItem, options *b
 
 	err = bundlestore.DecodeYAML(item, buf)
 	if err != nil {
-		return err
+		return fmt.Errorf("Error decoding metadata item: %s from file: %s : %w", key, fileMetadata.Path(), err)
 	}
 
 	if !b.AllowPrivate && !item.IsPublic() {

--- a/libs/apps/uesio/io/bundle/components/card.yaml
+++ b/libs/apps/uesio/io/bundle/components/card.yaml
@@ -77,3 +77,5 @@ definition:
               - $Slot{content}
             footer:
               - $Slot{footer}
+defaultDefinition:
+  uesio.variant: uesio/io.default

--- a/libs/apps/uesio/io/bundle/components/card.yaml
+++ b/libs/apps/uesio/io/bundle/components/card.yaml
@@ -9,6 +9,7 @@ slots:
   - name: avatar
 description: A Card component
 discoverable: true
+defaultVariant: uesio/io.default
 properties:
   - name: title
     label: Title
@@ -23,7 +24,7 @@ properties:
       type: COMPONENTVARIANT
       grouping: uesio/io.tile
   - name: scrollpanelVariant
-    label: Scrollpanel Variant
+    label: Scroll Panel Variant
     type: METADATA
     metadata:
       type: COMPONENTVARIANT
@@ -40,7 +41,11 @@ sections:
     properties:
       - title
       - subtitle
+  - type: STYLES
+    properties:
+      - tileVariant
       - scrollpanelVariant
+      - titlebarVariant
   - type: DISPLAY
 definition:
   - uesio/io.tile:

--- a/libs/apps/uesio/io/bundle/componentvariants/uesio/io/card/default.yaml
+++ b/libs/apps/uesio/io/bundle/componentvariants/uesio/io/card/default.yaml
@@ -1,0 +1,7 @@
+name: default
+label: Default
+definition:
+  tileVariant: uesio/io.default
+  scrollpanelVariant: uesio/io.default
+  titlebarVariant: uesio/io.default
+public: true


### PR DESCRIPTION
# What does this PR do?

Include the metadata item name/key and the filename being read when encountering a file that contains invalid yaml.

# Testing

Manual by placing a tab character instead of a space in the beginning of an indented line.

@humandad - I didn't see a common pattern for error messages throughout the code base but tried to follow the approach/format within the same file.  If you'd like to see a different format and/or information in the message itself, just let me know.
