### PR TITLE
fix: identify correct hurl version for test runners

### DIFF
--- a/scripts/get-hurl-version.sh
+++ b/scripts/get-hurl-version.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-cat package.json | jq -r '."devDependencies"."@orangeopensource/hurl"' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+'
+cat node_modules/@orangeopensource/hurl/package.json | jq -r '."hurlBinaryVersion"' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+'


### PR DESCRIPTION
# What does this PR do?

PR #4448 updated the hurl dependency to 4.3.3 from 4.2.0.  This causesd the e2e tests to fail when installing hurl.

The reason for this is that the scripts used to prepare for test running uses the version in package.json of this package to download and install hurl.  However, the npm package version does not always match the actual hurl binary version.  In this case, the npm package is 4.3.3 but the hurl binary is 4.3.0.  

This PR addresses the issue by obtaining the hurl binary version from the npm packages package.json via the `hurlBinaryVersion` property it contains.

# Testing

e2e should cover.
