### PR TITLE
fix: dialog dismiss handling

### DIFF
--- a/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/dialogplain/dialogplain.tsx
+++ b/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/dialogplain/dialogplain.tsx
@@ -1,5 +1,6 @@
 import { definition, styles } from "@uesio/ui"
 import {
+	FloatingPortal,
 	FloatingFocusManager,
 	FloatingOverlay,
 	useDismiss,
@@ -43,56 +44,49 @@ const DialogPlain: definition.UtilityComponent<DialogPlainUtilityProps> = (
 	})
 
 	const closeOnOutsideClick =
-		props.closeOnOutsideClick === undefined
-			? true
-			: !!props.closeOnOutsideClick
+		props.closeOnOutsideClick === undefined ? true : !!props.closeOnOutsideClick
 
 	const dismiss = useDismiss(floating.context, {
-		outsidePress: false,
-		referencePress: closeOnOutsideClick,
+		outsidePress: closeOnOutsideClick,
 	})
 
-	const { getFloatingProps, getReferenceProps } = useInteractions([dismiss])
+	const { getFloatingProps } = useInteractions([dismiss])
 
 	return (
-		<FloatingOverlay
-			className={styles.cx(
-				classes.blocker,
-				props.closed && classes.blockerClosed
-			)}
-			lockScroll
-			style={{ position: "absolute" }}
-			ref={floating.refs.setReference}
-			{...getReferenceProps()}
-		>
-			<FloatingFocusManager
-				context={floating.context}
-				initialFocus={props.initialFocus}
-				closeOnFocusOut={false}
+		<FloatingPortal>
+			<FloatingOverlay
+				className={styles.cx(
+					classes.blocker,
+					props.closed && classes.blockerClosed
+				)}
+				lockScroll
+				style={{ position: "absolute" }}
 			>
-				<div
-					className={styles.cx(
-						classes.wrapper,
-						props.closed && classes.wrapperClosed
-					)}
-					ref={floating.refs.setFloating}
-					{...getFloatingProps({
-						onPointerDown(e) {
-							e.stopPropagation()
-						},
-					})}
+				<FloatingFocusManager
+					context={floating.context}
+					initialFocus={props.initialFocus}
+					closeOnFocusOut={false}
 				>
 					<div
 						className={styles.cx(
-							classes.inner,
-							props.closed && classes.innerClosed
+							classes.wrapper,
+							props.closed && classes.wrapperClosed
 						)}
+						ref={floating.refs.setFloating}
+						{...getFloatingProps()}
 					>
-						{props.children}
+						<div
+							className={styles.cx(
+								classes.inner,
+								props.closed && classes.innerClosed
+							)}
+						>
+							{props.children}
+						</div>
 					</div>
-				</div>
-			</FloatingFocusManager>
-		</FloatingOverlay>
+				</FloatingFocusManager>
+			</FloatingOverlay>
+		</FloatingPortal>
 	)
 }
 

--- a/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/dialogplain/dialogplain.tsx
+++ b/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/dialogplain/dialogplain.tsx
@@ -44,7 +44,9 @@ const DialogPlain: definition.UtilityComponent<DialogPlainUtilityProps> = (
 	})
 
 	const closeOnOutsideClick =
-		props.closeOnOutsideClick === undefined ? true : !!props.closeOnOutsideClick
+		props.closeOnOutsideClick === undefined
+			? true
+			: !!props.closeOnOutsideClick
 
 	const dismiss = useDismiss(floating.context, {
 		outsidePress: closeOnOutsideClick,


### PR DESCRIPTION
# What does this PR do?

Updating to `@floating-ui/react@0.27.3` in PR #4449 exposed an issue with the way that dismissing a dialog was being handled.  In v0.27.3, new functionality was added to [referencePress](https://github.com/floating-ui/floating-ui/releases/tag/%40floating-ui%2Freact%400.27.0) to handle native clicks.  This meant that click events would be processed and close the dialog when not intended.  For example, when clicking anywhere within the dialog "whitespace", on a "select" field, etc.

This behavior was reproduceable with v0.26.8 if the [e.stopPropogation()](https://github.com/ues-io/uesio/compare/fix/dialog-dismiss-handling?expand=1#diff-f433cef287b5d099ddc5915d2009b888830aa517f6984d6a630255fabbed99d2L81) was removed since essentially stopping propagation was solving the underlying issues with the way the floating elements were configured.

In short, this PR resolves the following issues:

1. Eliminates the "reference element" within the dialog itself - Previously, the reference element was being assigned to the FloatingOverlay.  However, reference elements are intended to be assigned to the element that "triggers" the floating element to appear (e.g., a button that you click to launch the dialog).  Reference elements are how the library ties aria-labels, roles, etc. together between the element that triggers the floating element and vice-versa.  In short, by assigning the overlay as the reference element itself it was behaving like the triggering element and the overlay which is why stop propogation was required.  As a separate issue (see #4432), a proper solution needs to be implemented to associated triggering elements to dialogs for accessibility purposes - this could possibly be done via a prop to Dialog.
2. Assigns the prop `closeOnOutsideClick` to `outsidePress` to ensure clicking outside of the dialog itself (e.g., on the overlay) will dismiss the dialog based on the value of the prop.
3. Adds a FloatingPortal - While not directly associated with the problem, wrapping the floating elements in a portal ensures that the elements are placed outside of app root to ensure any container clipping (e.g. overflow-hidden), etc. does not impact the dialog itself.  This may help with some of the display issues of the dialog in the builder but either way, is the recommended approach per the docs.

# Testing

`tests-all` passes locally and ci & e2e should cover as well.
