### PR TITLE
Fix eslint unexpected use of self

### DIFF
--- a/libs/ui/src/bands/route/operations.ts
+++ b/libs/ui/src/bands/route/operations.ts
@@ -12,11 +12,6 @@ import { dispatch } from "../../store/store"
 import { RouteState } from "./types"
 import { nanoid } from "@reduxjs/toolkit"
 
-// Check if we are in a real browser (vs in JSDom)
-const isRealBrowser = Object.getOwnPropertyDescriptor(self, "window")
-  ?.get?.toString()
-  .includes("[native code]")
-
 const redirect = (context: Context, path: string, newTab?: boolean) => {
   const mergedPath = context.mergeString(path)
   if (newTab) {
@@ -185,9 +180,7 @@ const handleNavigateResponse = async (
   dispatchRouteDeps(deps)
 
   // Always scroll to top of view after doing a route navigate
-  if (isRealBrowser) {
-    window.scrollTo(0, 0)
-  }
+  window.scrollTo(0, 0)
 
   return context
 }


### PR DESCRIPTION
# What does this PR do?

This PR removes some code that is no longer necessary and was causing an eslint warning. I ran the unit tests that would use JSDom and the pass just fine without this code. Improvements in dependencies may have made this no longer necessary.
