### PR TITLE
Fix component panel dependency issue

### DIFF
--- a/libs/apps/uesio/builder/bundle/components/mainwrapper.yaml
+++ b/libs/apps/uesio/builder/bundle/components/mainwrapper.yaml
@@ -5,6 +5,7 @@ components:
   - uesio/appkit.icontile
 variants:
   - uesio/io.tile:uesio/appkit.breadcrumb
+  - uesio/io.tile:uesio/appkit.item
   - uesio/io.group:uesio/appkit.breadcrumbs
   - uesio/io.button:uesio/builder.actionbutton
   - uesio/io.button:uesio/builder.buildtitle
@@ -25,6 +26,7 @@ variants:
   - uesio/io.selectfield:uesio/builder.propfield
   - uesio/io.tablabels:uesio/builder.mainsection
   - uesio/io.text:uesio/builder.infobadge
+  - uesio/io.text:uesio/appkit.avataricon
   - uesio/io.tile:uesio/appkit.apptag
   - uesio/io.tile:uesio/builder.indextag
   - uesio/io.tile:uesio/builder.propnodetag


### PR DESCRIPTION
# What does this PR do?

Fixes an issue where appkit variants were not getting loaded into the builder

![image](https://github.com/user-attachments/assets/7e1f0538-02d1-4580-9b7b-712af3bd44ea)