### PR TITLE
improve panel build experience

### DIFF
--- a/libs/apps/uesio/builder/bundle/componentpacks/main/src/api/stateapi.ts
+++ b/libs/apps/uesio/builder/bundle/componentpacks/main/src/api/stateapi.ts
@@ -329,7 +329,7 @@ const setSelectedPath = (context: ctx.Context, path?: FullPath) => {
     }
   }
 
-  api.signal.runMany(signals, context)
+  api.signal.runMany(signals, context.removeAllThemeFrames())
 
   setBuilderState<string>(context, "selected", combinePath(path))
 }

--- a/libs/apps/uesio/builder/bundle/componentpacks/main/src/components/mainwrapper/mainwrapper.tsx
+++ b/libs/apps/uesio/builder/bundle/componentpacks/main/src/components/mainwrapper/mainwrapper.tsx
@@ -51,7 +51,7 @@ const MainWrapper: definition.UC<component.ViewComponentDefinition> = (
   hooks.useHotKeyCallback(
     "meta+u",
     () => {
-      toggleBuildMode(context, setBuildMode, !!buildMode)
+      toggleBuildMode(builderContext, setBuildMode, !!buildMode)
     },
     true,
     [buildMode, setBuildMode],

--- a/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/dialogplain/dialogplain.tsx
+++ b/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/dialogplain/dialogplain.tsx
@@ -1,12 +1,5 @@
 import { definition, styles } from "@uesio/ui"
-import {
-  FloatingPortal,
-  FloatingFocusManager,
-  FloatingOverlay,
-  useDismiss,
-  useFloating,
-  useInteractions,
-} from "@floating-ui/react"
+import PanelWrapper from "../panelwrapper/panelwrapper"
 
 interface DialogPlainUtilityProps {
   onClose?: () => void
@@ -20,12 +13,22 @@ interface DialogPlainUtilityProps {
 const DialogPlain: definition.UtilityComponent<DialogPlainUtilityProps> = (
   props,
 ) => {
+  const {
+    onClose,
+    width,
+    height,
+    initialFocus,
+    closeOnOutsideClick,
+    closed,
+    children,
+  } = props
+
   const classes = styles.useUtilityStyleTokens(
     {
       blocker: [],
       wrapper: [
-        ...(props.width ? [`w-[${props.width}]`] : ["w-1/2"]),
-        ...(props.height ? [`h-[${props.height}]`] : ["h-1/2"]),
+        ...(props.width ? [`w-[${width}]`] : ["w-1/2"]),
+        ...(props.height ? [`h-[${height}]`] : ["h-1/2"]),
       ],
       inner: [],
       blockerClosed: [],
@@ -36,57 +39,17 @@ const DialogPlain: definition.UtilityComponent<DialogPlainUtilityProps> = (
     "uesio/io.dialog",
   )
 
-  const floating = useFloating({
-    open: true,
-    onOpenChange: (open) => {
-      if (!open && props.onClose) props.onClose()
-    },
-  })
-
-  const closeOnOutsideClick =
-    props.closeOnOutsideClick === undefined ? true : !!props.closeOnOutsideClick
-
-  const dismiss = useDismiss(floating.context, {
-    outsidePress: closeOnOutsideClick,
-  })
-
-  const { getFloatingProps } = useInteractions([dismiss])
-
   return (
-    <FloatingPortal>
-      <FloatingOverlay
-        className={styles.cx(
-          classes.blocker,
-          props.closed && classes.blockerClosed,
-        )}
-        lockScroll
-        style={{ position: "absolute" }}
-      >
-        <FloatingFocusManager
-          context={floating.context}
-          initialFocus={props.initialFocus}
-          closeOnFocusOut={false}
-        >
-          <div
-            className={styles.cx(
-              classes.wrapper,
-              props.closed && classes.wrapperClosed,
-            )}
-            ref={floating.refs.setFloating}
-            {...getFloatingProps()}
-          >
-            <div
-              className={styles.cx(
-                classes.inner,
-                props.closed && classes.innerClosed,
-              )}
-            >
-              {props.children}
-            </div>
-          </div>
-        </FloatingFocusManager>
-      </FloatingOverlay>
-    </FloatingPortal>
+    <PanelWrapper
+      onClose={onClose}
+      initialFocus={initialFocus}
+      closeOnOutsideClick={closeOnOutsideClick}
+      closed={closed}
+      context={props.context}
+      classes={classes}
+    >
+      {children}
+    </PanelWrapper>
   )
 }
 

--- a/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/panelwrapper/panelwrapper.tsx
+++ b/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/panelwrapper/panelwrapper.tsx
@@ -1,0 +1,98 @@
+import { definition, styles } from "@uesio/ui"
+import {
+  FloatingPortal,
+  FloatingFocusManager,
+  FloatingOverlay,
+  useDismiss,
+  useFloating,
+  useInteractions,
+} from "@floating-ui/react"
+
+interface PanelWrapperUtilityProps {
+  onClose?: () => void
+  initialFocus?: number
+  closeOnOutsideClick?: boolean
+  closed?: boolean
+}
+
+const StyleDefaults = Object.freeze({
+  blocker: [],
+  wrapper: [],
+  inner: [],
+  blockerClosed: [],
+  wrapperClosed: [],
+  innerClosed: [],
+})
+
+const PanelWrapper: definition.UtilityComponent<PanelWrapperUtilityProps> = (
+  props,
+) => {
+  const classes = styles.useUtilityStyleTokens(
+    StyleDefaults,
+    props,
+    "uesio/io.panelwrapper",
+  )
+
+  const floating = useFloating({
+    open: true,
+    onOpenChange: (open) => {
+      if (!open && props.onClose) props.onClose()
+    },
+  })
+
+  const outsideClickFunc = (e: MouseEvent) => {
+    const target = e.target
+    if (!(target instanceof HTMLElement)) return false
+    return !!target.closest("#canvas-root")
+  }
+
+  const closeOnOutsideClick =
+    props.closeOnOutsideClick === undefined
+      ? outsideClickFunc
+      : !!props.closeOnOutsideClick
+
+  const dismiss = useDismiss(floating.context, {
+    outsidePress: closeOnOutsideClick,
+  })
+
+  const { getFloatingProps } = useInteractions([dismiss])
+
+  return (
+    <FloatingPortal id="canvas-root">
+      <FloatingOverlay
+        className={styles.cx(
+          classes.blocker,
+          props.closed && classes.blockerClosed,
+        )}
+        lockScroll
+        style={{ position: "absolute" }}
+      >
+        <FloatingFocusManager
+          context={floating.context}
+          initialFocus={props.initialFocus}
+          closeOnFocusOut={false}
+        >
+          <div
+            className={styles.cx(
+              classes.wrapper,
+              props.closed && classes.wrapperClosed,
+            )}
+            ref={floating.refs.setFloating}
+            {...getFloatingProps()}
+          >
+            <div
+              className={styles.cx(
+                classes.inner,
+                props.closed && classes.innerClosed,
+              )}
+            >
+              {props.children}
+            </div>
+          </div>
+        </FloatingFocusManager>
+      </FloatingOverlay>
+    </FloatingPortal>
+  )
+}
+
+export default PanelWrapper

--- a/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/sidepanelplain/sidepanelplain.tsx
+++ b/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/sidepanelplain/sidepanelplain.tsx
@@ -1,11 +1,5 @@
 import { definition, styles } from "@uesio/ui"
-import {
-  FloatingFocusManager,
-  FloatingOverlay,
-  useDismiss,
-  useFloating,
-  useInteractions,
-} from "@floating-ui/react"
+import PanelWrapper from "../panelwrapper/panelwrapper"
 
 interface SidePanelUtilityProps {
   onClose?: () => void
@@ -16,78 +10,34 @@ interface SidePanelUtilityProps {
 
 const StyleDefaults = Object.freeze({
   blocker: [],
-  root: [],
+  wrapper: [],
   inner: [],
   blockerClosed: [],
-  rootClosed: [],
+  wrapperClosed: [],
   innerClosed: [],
 })
 
 const SidePanelPlain: definition.UtilityComponent<SidePanelUtilityProps> = (
   props,
 ) => {
+  const { onClose, initialFocus, closeOnOutsideClick, closed, children } = props
   const classes = styles.useUtilityStyleTokens(
     StyleDefaults,
     props,
     "uesio/io.sidepanel",
   )
 
-  const floating = useFloating({
-    open: true,
-    onOpenChange: (open) => {
-      if (!open && props.onClose) props.onClose()
-    },
-  })
-
-  const closeOnOutsideClick =
-    props.closeOnOutsideClick === undefined ? true : !!props.closeOnOutsideClick
-
-  const dismiss = useDismiss(floating.context, {
-    outsidePress: false,
-    referencePress: closeOnOutsideClick,
-  })
-
-  const { getFloatingProps, getReferenceProps } = useInteractions([dismiss])
-
   return (
-    <FloatingOverlay
-      className={styles.cx(
-        classes.blocker,
-        props.closed && classes.blockerClosed,
-      )}
-      lockScroll
-      style={{ position: "absolute" }}
-      ref={floating.refs.setReference}
-      {...getReferenceProps()}
+    <PanelWrapper
+      onClose={onClose}
+      initialFocus={initialFocus}
+      closeOnOutsideClick={closeOnOutsideClick}
+      closed={closed}
+      context={props.context}
+      classes={classes}
     >
-      <FloatingFocusManager
-        context={floating.context}
-        initialFocus={props.initialFocus}
-        closeOnFocusOut={false}
-      >
-        <div
-          className={styles.cx(
-            classes.root,
-            props.closed && classes.rootClosed,
-          )}
-          ref={floating.refs.setFloating}
-          {...getFloatingProps({
-            onPointerDown(e) {
-              e.stopPropagation()
-            },
-          })}
-        >
-          <div
-            className={styles.cx(
-              classes.inner,
-              props.closed && classes.innerClosed,
-            )}
-          >
-            {props.children}
-          </div>
-        </div>
-      </FloatingFocusManager>
-    </FloatingOverlay>
+      {children}
+    </PanelWrapper>
   )
 }
 

--- a/libs/apps/uesio/io/bundle/componentvariants/uesio/io/sidepanel/base.yaml
+++ b/libs/apps/uesio/io/bundle/componentvariants/uesio/io/sidepanel/base.yaml
@@ -2,7 +2,7 @@ name: base
 label: Base
 definition:
   uesio.styleTokens:
-    root:
+    wrapper:
       - absolute
       - inset-0
       - pointer-events-none
@@ -14,7 +14,7 @@ definition:
       - ease-in-out
       - transition-all
       - duration-200
-    rootClosed:
+    wrapperClosed:
     blockerClosed:
       - backdrop-blur-none
       - backdrop-grayscale-0


### PR DESCRIPTION
1. Consolidates most of the floating-ui code for both `dialog` and `sidepanel` code into a single `panelwrapper` utility.
2. Keeps panels inside of the canvas in build mode.
3. Outside Press only dismisses the panel if the click is in the canvas, not in the builder toolbar area.