### PR TITLE
Chore/migrate to project service

### DIFF
--- a/apps/platform-e2e/eslint.config.mjs
+++ b/apps/platform-e2e/eslint.config.mjs
@@ -5,13 +5,4 @@ import baseConfig from "../../eslint.config.mjs"
 export default [
   cypress.configs["recommended"],
   ...baseConfig,
-  {
-    files: ["**/*.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"],
-    languageOptions: {
-      parserOptions: {
-        project: ["apps/platform-e2e/tsconfig.json"],
-      },
-    },
-    rules: {},
-  },
 ]

--- a/apps/platform-e2e/eslint.config.mjs
+++ b/apps/platform-e2e/eslint.config.mjs
@@ -2,7 +2,4 @@ import cypress from "eslint-plugin-cypress/flat"
 import baseConfig from "../../eslint.config.mjs"
 
 /** @type {import('@typescript-eslint/utils/ts-eslint').FlatConfig.Config[]} */
-export default [
-  cypress.configs["recommended"],
-  ...baseConfig,
-]
+export default [cypress.configs["recommended"], ...baseConfig]

--- a/apps/platform-integration-tests/eslint.config.mjs
+++ b/apps/platform-integration-tests/eslint.config.mjs
@@ -3,13 +3,4 @@ import baseConfig from "../../eslint.config.mjs"
 /** @type {import('@typescript-eslint/utils/ts-eslint').FlatConfig.Config[]} */
 export default [
   ...baseConfig,
-  {
-    files: ["**/*.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"],
-    languageOptions: {
-      parserOptions: {
-        project: ["apps/platform-integration-tests/tsconfig.*?.json"],
-      },
-    },
-    rules: {},
-  },
 ]

--- a/apps/platform-integration-tests/eslint.config.mjs
+++ b/apps/platform-integration-tests/eslint.config.mjs
@@ -1,6 +1,4 @@
 import baseConfig from "../../eslint.config.mjs"
 
 /** @type {import('@typescript-eslint/utils/ts-eslint').FlatConfig.Config[]} */
-export default [
-  ...baseConfig,
-]
+export default [...baseConfig]

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,7 +2,7 @@ import nx from "@nx/eslint-plugin"
 import reactPlugin from "eslint-plugin-react"
 import reactHooksPlugin from "eslint-plugin-react-hooks"
 import globals from "globals"
-import { workspaceRoot } from '@nx/devkit';
+import { workspaceRoot } from "@nx/devkit"
 
 /** @type {import('@typescript-eslint/utils/ts-eslint').FlatConfig.Config[]} */
 export default [
@@ -16,11 +16,11 @@ export default [
     languageOptions: {
       parserOptions: {
         projectService: {
-          allowDefaultProject: ["eslint.config.mjs", "eslint.config.cjs"]
+          allowDefaultProject: ["eslint.config.mjs", "eslint.config.cjs"],
         },
         tsconfigRootDir: workspaceRoot,
-      }
-    }
+      },
+    },
   },
   {
     files: ["**/*.spec.{ts,tsx,js,jsx}"],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,6 +2,7 @@ import nx from "@nx/eslint-plugin"
 import reactPlugin from "eslint-plugin-react"
 import reactHooksPlugin from "eslint-plugin-react-hooks"
 import globals from "globals"
+import { workspaceRoot } from '@nx/devkit';
 
 /** @type {import('@typescript-eslint/utils/ts-eslint').FlatConfig.Config[]} */
 export default [
@@ -10,6 +11,16 @@ export default [
   ...nx.configs["flat/javascript"],
   {
     ignores: ["**/dist"],
+  },
+  {
+    languageOptions: {
+      parserOptions: {
+        projectService: {
+          allowDefaultProject: ["eslint.config.mjs", "eslint.config.cjs"]
+        },
+        tsconfigRootDir: workspaceRoot,
+      }
+    }
   },
   {
     files: ["**/*.spec.{ts,tsx,js,jsx}"],

--- a/libs/apps/uesio/aikit/eslint.config.mjs
+++ b/libs/apps/uesio/aikit/eslint.config.mjs
@@ -3,13 +3,4 @@ import baseConfig from "../../../../eslint.config.mjs"
 /** @type {import('@typescript-eslint/utils/ts-eslint').FlatConfig.Config[]} */
 export default [
   ...baseConfig,
-  {
-    files: ["**/*.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"],
-    languageOptions: {
-      parserOptions: {
-        project: ["libs/apps/uesio/aikit/tsconfig.*?.json"],
-      },
-    },
-    rules: {},
-  },
 ]

--- a/libs/apps/uesio/aikit/eslint.config.mjs
+++ b/libs/apps/uesio/aikit/eslint.config.mjs
@@ -1,6 +1,4 @@
 import baseConfig from "../../../../eslint.config.mjs"
 
 /** @type {import('@typescript-eslint/utils/ts-eslint').FlatConfig.Config[]} */
-export default [
-  ...baseConfig,
-]
+export default [...baseConfig]

--- a/libs/apps/uesio/appkit/eslint.config.mjs
+++ b/libs/apps/uesio/appkit/eslint.config.mjs
@@ -4,15 +4,6 @@ import baseConfig from "../../../../eslint.config.mjs"
 export default [
   ...baseConfig,
   {
-    files: ["**/*.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"],
-    languageOptions: {
-      parserOptions: {
-        project: ["libs/apps/uesio/appkit/tsconfig.*?.json"],
-      },
-    },
-    rules: {},
-  },
-  {
     files: ["**/generator/**/bot.js"],
     rules: {
       "@typescript-eslint/no-unused-vars": [

--- a/libs/apps/uesio/builder/eslint.config.mjs
+++ b/libs/apps/uesio/builder/eslint.config.mjs
@@ -3,13 +3,4 @@ import baseConfig from "../../../../eslint.config.mjs"
 /** @type {import('@typescript-eslint/utils/ts-eslint').FlatConfig.Config[]} */
 export default [
   ...baseConfig,
-  {
-    files: ["**/*.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"],
-    languageOptions: {
-      parserOptions: {
-        project: ["libs/apps/uesio/builder/tsconfig.*?.json"],
-      },
-    },
-    rules: {},
-  },
 ]

--- a/libs/apps/uesio/builder/eslint.config.mjs
+++ b/libs/apps/uesio/builder/eslint.config.mjs
@@ -1,6 +1,4 @@
 import baseConfig from "../../../../eslint.config.mjs"
 
 /** @type {import('@typescript-eslint/utils/ts-eslint').FlatConfig.Config[]} */
-export default [
-  ...baseConfig,
-]
+export default [...baseConfig]

--- a/libs/apps/uesio/core/eslint.config.mjs
+++ b/libs/apps/uesio/core/eslint.config.mjs
@@ -7,15 +7,6 @@ export default [
     ignores: ["**/generator/**/templates/**/*.{ts,tsx,mts,cts,js,jsx,mjs,cjs}"],
   },
   {
-    files: ["**/*.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"],
-    languageOptions: {
-      parserOptions: {
-        project: ["libs/apps/uesio/core/tsconfig.*?.json"],
-      },
-    },
-    rules: {},
-  },
-  {
     files: ["**/generator/**/bot.js"],
     rules: {
       "@typescript-eslint/no-unused-vars": [

--- a/libs/apps/uesio/io/eslint.config.mjs
+++ b/libs/apps/uesio/io/eslint.config.mjs
@@ -3,13 +3,4 @@ import baseConfig from "../../../../eslint.config.mjs"
 /** @type {import('@typescript-eslint/utils/ts-eslint').FlatConfig.Config[]} */
 export default [
   ...baseConfig,
-  {
-    files: ["**/*.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"],
-    languageOptions: {
-      parserOptions: {
-        project: ["libs/apps/uesio/io/tsconfig.*?.json"],
-      },
-    },
-    rules: {},
-  },
 ]

--- a/libs/apps/uesio/io/eslint.config.mjs
+++ b/libs/apps/uesio/io/eslint.config.mjs
@@ -1,6 +1,4 @@
 import baseConfig from "../../../../eslint.config.mjs"
 
 /** @type {import('@typescript-eslint/utils/ts-eslint').FlatConfig.Config[]} */
-export default [
-  ...baseConfig,
-]
+export default [...baseConfig]

--- a/libs/apps/uesio/sitekit/eslint.config.mjs
+++ b/libs/apps/uesio/sitekit/eslint.config.mjs
@@ -4,15 +4,6 @@ import baseConfig from "../../../../eslint.config.mjs"
 export default [
   ...baseConfig,
   {
-    files: ["**/*.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"],
-    languageOptions: {
-      parserOptions: {
-        project: ["libs/apps/uesio/sitekit/tsconfig.*?.json"],
-      },
-    },
-    rules: {},
-  },
-  {
     files: ["**/generator/**/bot.js"],
     rules: {
       "@typescript-eslint/no-unused-vars": [

--- a/libs/apps/uesio/studio/eslint.config.mjs
+++ b/libs/apps/uesio/studio/eslint.config.mjs
@@ -1,6 +1,4 @@
 import baseConfig from "../../../../eslint.config.mjs"
 
 /** @type {import('@typescript-eslint/utils/ts-eslint').FlatConfig.Config[]} */
-export default [
-  ...baseConfig,
-]
+export default [...baseConfig]

--- a/libs/apps/uesio/studio/eslint.config.mjs
+++ b/libs/apps/uesio/studio/eslint.config.mjs
@@ -3,13 +3,4 @@ import baseConfig from "../../../../eslint.config.mjs"
 /** @type {import('@typescript-eslint/utils/ts-eslint').FlatConfig.Config[]} */
 export default [
   ...baseConfig,
-  {
-    files: ["**/*.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"],
-    languageOptions: {
-      parserOptions: {
-        project: ["libs/apps/uesio/studio/tsconfig.*?.json"],
-      },
-    },
-    rules: {},
-  },
 ]

--- a/libs/ui/eslint.config.mjs
+++ b/libs/ui/eslint.config.mjs
@@ -3,13 +3,4 @@ import baseConfig from "../../eslint.config.mjs"
 /** @type {import('@typescript-eslint/utils/ts-eslint').FlatConfig.Config[]} */
 export default [
   ...baseConfig,
-  {
-    files: ["**/*.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"],
-    languageOptions: {
-      parserOptions: {
-        project: ["libs/ui/tsconfig.*?.json"],
-      },
-    },
-    rules: {},
-  },
 ]

--- a/libs/ui/eslint.config.mjs
+++ b/libs/ui/eslint.config.mjs
@@ -1,6 +1,4 @@
 import baseConfig from "../../eslint.config.mjs"
 
 /** @type {import('@typescript-eslint/utils/ts-eslint').FlatConfig.Config[]} */
-export default [
-  ...baseConfig,
-]
+export default [...baseConfig]


### PR DESCRIPTION
# What does this PR do?

Migrates from typescript-eslint `project` to `projectService` parser option.

# Testing

ci & e2e will cover.
