### PR TITLE
Fix dragging into bottom of canvas bug

### DIFF
--- a/libs/apps/uesio/builder/bundle/componentpacks/main/src/components/mainwrapper/canvas.tsx
+++ b/libs/apps/uesio/builder/bundle/componentpacks/main/src/components/mainwrapper/canvas.tsx
@@ -137,15 +137,14 @@ const Canvas: FunctionComponent<definition.UtilityProps> = (props) => {
         <div className={classes.outerwrapper} id="canvas-root">
           <div
             ref={contentRef}
-            className={classes.contentwrapper}
+            className={"uesio-theme " + classes.contentwrapper}
             onDragOver={getDragOverHandler(context, dragPath, dropPath)}
             onDragLeave={onDragLeave}
             onDrop={onDrop}
             onClickCapture={onClickCapture}
             onChangeCapture={onChangeCapture}
           >
-            {/* This cancels the theme scope for the builder */}
-            <div className="uesio-theme">{props.children}</div>
+            {props.children}
           </div>
           <SelectBorder viewdef={viewDef} context={context} />
         </div>

--- a/libs/apps/uesio/builder/bundle/componentpacks/main/src/components/mainwrapper/mainwrapper.tsx
+++ b/libs/apps/uesio/builder/bundle/componentpacks/main/src/components/mainwrapper/mainwrapper.tsx
@@ -8,6 +8,7 @@ import { SlotBuilderComponentId } from "../../utilities/slotbuilder/slotbuilder"
 import CodePanel from "./codepanel"
 import { toggleBuildMode } from "../../helpers/buildmode"
 import BuildBar from "./buildbar/buildbar"
+import { ReactNode } from "react"
 
 const StyleDefaults = Object.freeze({
   root: ["h-full", "grid-cols-[1fr]", "auto-cols-auto", "grid-rows-[100%]"],
@@ -23,6 +24,22 @@ const StyleDefaults = Object.freeze({
   canvaswrap: ["grid-rows-1", "auto-rows-auto", "col-end-[-1]"],
   canvaswrapinner: ["relative", "grid", "grid-rows-1", "grid-cols-1"],
 })
+
+type ThemeWrapperProps = {
+  themeClass: string
+  children?: ReactNode
+}
+
+const ThemeWrapper = (props: ThemeWrapperProps) => (
+  <div
+    className={props.themeClass}
+    style={{
+      display: "contents",
+    }}
+  >
+    {props.children}
+  </div>
+)
 
 const MainWrapper: definition.UC<component.ViewComponentDefinition> = (
   props,
@@ -115,15 +132,15 @@ const MainWrapper: definition.UC<component.ViewComponentDefinition> = (
           definition={definition}
           path={path}
         />
-        <div className={themeClass}>
+        <ThemeWrapper themeClass={themeClass}>
           <BuildBar context={builderContext} />
-        </div>
+        </ThemeWrapper>
       </>
     )
   }
 
   return (
-    <div className={themeClass}>
+    <ThemeWrapper themeClass={themeClass}>
       <Grid className={classes.root} context={context} id="builder-root">
         <Grid context={context} className={classes.leftpanel}>
           <PropertiesPanel context={builderContext} />
@@ -148,7 +165,7 @@ const MainWrapper: definition.UC<component.ViewComponentDefinition> = (
           {showCode && <CodePanel context={builderContext} />}
         </Grid>
       </Grid>
-    </div>
+    </ThemeWrapper>
   )
 }
 

--- a/libs/ui/src/styles/styles.ts
+++ b/libs/ui/src/styles/styles.ts
@@ -193,9 +193,6 @@ const setupStyles = (context: Context) => {
         html: {
           "container-type": "inline-size",
         },
-        [".uesio-theme"]: {
-          display: "contents",
-        },
       },
     }),
   )


### PR DESCRIPTION
# What does this PR do?

Fixes the regression where you could no long drag components into the empty area of the canvas on a new view.