### PR TITLE
Improve route error handling

### DIFF
--- a/apps/platform/pkg/bundle/bundles.go
+++ b/apps/platform/pkg/bundle/bundles.go
@@ -166,7 +166,7 @@ func LoadMany(items []meta.BundleableItem, options *bundlestore.GetManyItemsOpti
 func Load(item meta.BundleableItem, options *bundlestore.GetItemOptions, session *sess.Session, connection wire.Connection) error {
 	bs, err := GetBundleStoreConnection(item.GetNamespace(), session, connection)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to load item: %s of type: %s with error: %w", item.GetKey(), item.GetBundleFolderName(), err)
 	}
 	return bs.GetItem(item, options)
 }

--- a/apps/platform/pkg/bundlestore/filebundlestore/filebundlestore.go
+++ b/apps/platform/pkg/bundlestore/filebundlestore/filebundlestore.go
@@ -89,7 +89,7 @@ func (b *FileBundleStoreConnection) GetItem(item meta.BundleableItem, options *b
 	buf := &bytes.Buffer{}
 	fileMetadata, err := b.download(buf, filepath.Join(b.PathFunc(b.Namespace, b.Version), collectionName, item.GetPath()))
 	if err != nil {
-		return exceptions.NewNotFoundException("Metadata item: " + key + " does not exist")
+		return exceptions.NewNotFoundException(fmt.Sprintf("Metadata item: %s of type: %s does not exist", key, collectionName))
 	}
 	fakeNamespaceUser := &meta.User{
 		BuiltIn: meta.BuiltIn{

--- a/apps/platform/pkg/preload/mergetypes.go
+++ b/apps/platform/pkg/preload/mergetypes.go
@@ -90,7 +90,9 @@ type MergeData struct {
 // look pretty in the html source.
 func (md MergeData) String() string {
 	// Remove the component pack dep info because we don't need it on the client
-	md.ComponentPack = nil
+	if md.PreloadMetadata != nil {
+		md.ComponentPack = nil
+	}
 
 	serialized, err := json.MarshalIndent(md, "        ", "  ")
 	//json, err := json.Marshal(md)


### PR DESCRIPTION
# What does this PR do?

1. Improves error messages coming from bundlestore loads.
2. Enter a version context when displaying an Error route so that we're sure to have access to all error route dependencies.
3. Prevent panic when rendering the index template with nil dependencies.
4. Actually handle errors when getting metadata for the standard error routes.
