### PR TITLE
Suppress window scrollTo warnings

### DIFF
--- a/libs/ui/jest-test-setup.js
+++ b/libs/ui/jest-test-setup.js
@@ -1,0 +1,3 @@
+// https://stackoverflow.com/a/57312218
+const noop = () => {}
+Object.defineProperty(window, "scrollTo", { value: noop, writable: true })

--- a/libs/ui/jest-test-setup.js
+++ b/libs/ui/jest-test-setup.js
@@ -1,4 +1,2 @@
-// https://stackoverflow.com/a/57312218
-// eslint-disable-next-line @typescript-eslint/no-empty-function
-const noop = () => {}
-Object.defineProperty(window, "scrollTo", { value: noop, writable: true })
+// jsdom does not implement scrollTo - See https://stackoverflow.com/a/57312218 & https://github.com/jsdom/jsdom/blob/b1c0072e306e4e9ad83a5e1ddf0e356ba044bd25/lib/jsdom/browser/Window.js#L904
+Object.defineProperty(window, "scrollTo", { value: jest.fn(), writable: true })

--- a/libs/ui/jest-test-setup.js
+++ b/libs/ui/jest-test-setup.js
@@ -1,3 +1,4 @@
 // https://stackoverflow.com/a/57312218
+// eslint-disable-next-line @typescript-eslint/no-empty-function
 const noop = () => {}
 Object.defineProperty(window, "scrollTo", { value: noop, writable: true })

--- a/libs/ui/jest.config.js
+++ b/libs/ui/jest.config.js
@@ -7,5 +7,5 @@ module.exports = {
   },
   moduleFileExtensions: ["ts", "tsx", "js", "jsx"],
   coverageDirectory: "../../coverage/libs/ui",
-  setupFiles: ["./jest-test-setup.js"],
+  setupFilesAfterEnv: ["./jest-test-setup.js"],
 }

--- a/libs/ui/jest.config.js
+++ b/libs/ui/jest.config.js
@@ -7,4 +7,5 @@ module.exports = {
   },
   moduleFileExtensions: ["ts", "tsx", "js", "jsx"],
   coverageDirectory: "../../coverage/libs/ui",
+  setupFiles: ["./jest-test-setup.js"],
 }


### PR DESCRIPTION
# What does this PR do?

Just an idea for suppressing the window.scrollTo warnings in jest.

Based on this stackoverflow post.
https://stackoverflow.com/a/57312218

@techfg feel free to merge if you like this idea or close.

Thanks!