### PR TITLE
chore: clean-up public types

### DIFF
--- a/apps/platform-integration-tests/generated/@types/@uesio/package.json
+++ b/apps/platform-integration-tests/generated/@types/@uesio/package.json
@@ -1,3 +1,0 @@
-{
-	"types": "index.d.ts"
-}

--- a/apps/platform-integration-tests/tsconfig.json
+++ b/apps/platform-integration-tests/tsconfig.json
@@ -7,7 +7,6 @@
       "path": "./tsconfig.lib.json"
     }
   ],
-  "typeRoots": ["node_modules/@types", "./generated/@types"],
   "compilerOptions": {
     "sourceMap": true
   }

--- a/libs/apps/uesio/core/bundle/bots/generator/init/templates/template.tsconfig.json
+++ b/libs/apps/uesio/core/bundle/bots/generator/init/templates/template.tsconfig.json
@@ -15,7 +15,6 @@
     "noUnusedLocals": true,
     "target": "es6",
     "module": "esnext",
-    "typeRoots": ["node_modules/@types", "generated/@types"],
     "lib": ["es2019", "dom"],
     "skipLibCheck": true,
     "skipDefaultLibCheck": true,

--- a/libs/ui/build.sh
+++ b/libs/ui/build.sh
@@ -12,7 +12,6 @@ echo -e "declare module \"@uesio/bots\" {\n$(cat src/public_types/server/index.d
 echo -e "declare module \"@uesio/bots\" {\n$(cat src/public_types/server/index.d.ts)\n}" > ../../dist/ui/types/client/index.d.ts
 # @uesio/ui API
 echo -e "declare module \"@uesio/ui\" {\n$(cat src/public_types/client/index.d.ts)\n}" >> ../../dist/ui/types/client/index.d.ts
-cp src/public_types/client/package.json ../../dist/ui/types/client/package.json
 
 npx tsc --noEmit --project ./tsconfig.lib.json
 

--- a/libs/ui/src/public_types/client/package.json
+++ b/libs/ui/src/public_types/client/package.json
@@ -1,3 +1,0 @@
-{
-	"types": "index.d.ts"
-}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -17,7 +17,6 @@
     "noUnusedLocals": true,
     "target": "es2023",
     "module": "esnext",
-    "typeRoots": ["node_modules/@types"],
     "lib": ["esnext", "dom", "dom.iterable"],
     "skipLibCheck": true,
     "skipDefaultLibCheck": true,


### PR DESCRIPTION
# What does this PR do?

1. Removes `package.json` from `generated` types folders as its unnecessary.  The contents of the folder is not a package and the types in the files within the folder are included via tsconfig references (e.g., `paths` and/or `include`)
2. Removes specifying `typeRoots` conforming to above

# Testing

Tested generating an app with bots & component packs and all types are properly resolved.  ci & e2e will cover everything else.
