### PR TITLE
Rebrand studio splash page

### DIFF
--- a/libs/apps/uesio/appkit/bundle/components/splash.yaml
+++ b/libs/apps/uesio/appkit/bundle/components/splash.yaml
@@ -8,9 +8,7 @@ slots:
       - uesio/io.box:
           uesio.styleTokens:
             root:
-              - bg-[url($File{uesio/appkit.splash})]
-              - bg-cover
-              - bg-right
+              - bg-slate-100
 defaultVariant: uesio/appkit.default
 definition:
   - uesio/io.grid:

--- a/libs/apps/uesio/appkit/bundle/views/login.yaml
+++ b/libs/apps/uesio/appkit/bundle/views/login.yaml
@@ -15,9 +15,7 @@ definition:
         - uesio/io.box:
             uesio.styleTokens:
               root:
-                - bg-[url($File{uesio/appkit.splash})]
-                - bg-cover
-                - bg-right
+                - bg-slate-100
   components:
     - uesio/appkit.splash:
         content:

--- a/libs/apps/uesio/sitekit/bundle/components/testimonial.yaml
+++ b/libs/apps/uesio/sitekit/bundle/components/testimonial.yaml
@@ -61,11 +61,11 @@ definition:
         root:
           - $Region{root}
       components:
-        - uesio/io.box:
-            components:
-              - uesio/sitekit.testimonial_stars:
-                  wrapperVariant: $Prop{starsVariant}
-                  stars: $Prop{stars}
+        - uesio/sitekit.testimonial_stars:
+            uesio.styleTokens:
+              root: $Region{stars}
+            wrapperVariant: $Prop{starsVariant}
+            stars: $Prop{stars}
         - uesio/io.text:
             uesio.variant: $Prop{quoteVariant}
             uesio.styleTokens:
@@ -74,6 +74,9 @@ definition:
             text: $Prop{quote}
         - uesio/io.titlebar:
             uesio.variant: uesio/io.item
+            uesio.display:
+              - type: hasValue
+                value: $Prop{name}
             title: $Prop{name}
             subtitle: $Prop{title}
             avatar:
@@ -81,6 +84,9 @@ definition:
                   uesio.variant: $Prop{avatarVariant}
                   image: $File{$Prop{avatar}:$Prop{avatarPath}}
         - uesio/io.box:
+            uesio.display:
+              - type: hasValue
+                value: $Prop{extra}
             uesio.styleTokens:
               root:
                 - $Region{extra}

--- a/libs/apps/uesio/sitekit/bundle/components/testimonial_stars.yaml
+++ b/libs/apps/uesio/sitekit/bundle/components/testimonial_stars.yaml
@@ -12,6 +12,9 @@ properties:
 definition:
   - uesio/io.box:
       uesio.variant: $Prop{wrapperVariant}
+      uesio.styleTokens:
+        root:
+          - $Region{root}
       uesio.display:
         - type: group
           conjunction: OR

--- a/libs/apps/uesio/studio/bundle/components/splash.yaml
+++ b/libs/apps/uesio/studio/bundle/components/splash.yaml
@@ -1,0 +1,37 @@
+name: splash
+category: LAYOUT
+title: Secret Section
+type: DECLARATIVE
+discoverable: false
+description: The studio splash screen
+properties:
+sections:
+  - type: HOME
+  - type: DISPLAY
+definition:
+  - uesio/sitekit.testimonial:
+      quote: Develop apps in minutes, not months.
+      uesio.styleTokens:
+        root:
+          - grid
+          - bg-slate-100
+          - justify-center
+          - items-center
+          - text-center
+          - content-center
+          - font-bold
+          - xl:px-48
+          - lg:px-24
+          - md:px-12
+          - px-8
+          - py-24
+          - "[text-wrap:balance]"
+        quote:
+          - text-4xl
+          - font-light
+          - text-slate-700
+        stars:
+          - justify-center
+          - text-slate-700
+          - text-2xl
+          - order-last

--- a/libs/apps/uesio/studio/bundle/permissionsets/public.yaml
+++ b/libs/apps/uesio/studio/bundle/permissionsets/public.yaml
@@ -1,6 +1,7 @@
 name: public
 named:
 views:
+  uesio/studio.login: true
   uesio/studio.signup: true
   uesio/studio.signuplanding: true
   uesio/studio.publicbundlelisting: true

--- a/libs/apps/uesio/studio/bundle/routes/login.yaml
+++ b/libs/apps/uesio/studio/bundle/routes/login.yaml
@@ -1,5 +1,5 @@
 name: login
 path: login
-view: uesio/appkit.login
+view: uesio/studio.login
 theme: default
 title: Uesio - Login

--- a/libs/apps/uesio/studio/bundle/views/login.yaml
+++ b/libs/apps/uesio/studio/bundle/views/login.yaml
@@ -1,0 +1,10 @@
+name: login
+public: true
+definition:
+  components:
+    - uesio/core.view:
+        view: uesio/appkit.login
+        uesio.id: login
+        slots:
+          splash:
+            - uesio/studio.splash:

--- a/libs/apps/uesio/studio/bundle/views/signup.yaml
+++ b/libs/apps/uesio/studio/bundle/views/signup.yaml
@@ -267,3 +267,5 @@ definition:
                                     - text-blue-600
                             - uesio/io.text:
                                 text: "."
+        splash:
+          - uesio/studio.splash:


### PR DESCRIPTION
# What does this PR do?

Styling changes to the splash panel for login and signup in the studio. Removes the weird image, and adds a simple quote. We can have the splash area be more featureful later.