### PR TITLE
fix scrolling on navigate

### DIFF
--- a/libs/ui/jest-test-setup.js
+++ b/libs/ui/jest-test-setup.js
@@ -1,2 +1,0 @@
-// jsdom does not implement scrollTo - See https://stackoverflow.com/a/57312218 & https://github.com/jsdom/jsdom/blob/b1c0072e306e4e9ad83a5e1ddf0e356ba044bd25/lib/jsdom/browser/Window.js#L904
-Object.defineProperty(window, "scrollTo", { value: jest.fn(), writable: true })

--- a/libs/ui/jest.config.js
+++ b/libs/ui/jest.config.js
@@ -7,5 +7,4 @@ module.exports = {
   },
   moduleFileExtensions: ["ts", "tsx", "js", "jsx"],
   coverageDirectory: "../../coverage/libs/ui",
-  setupFilesAfterEnv: ["./jest-test-setup.js"],
 }

--- a/libs/ui/src/bands/route/operations.ts
+++ b/libs/ui/src/bands/route/operations.ts
@@ -180,7 +180,7 @@ const handleNavigateResponse = async (
   dispatchRouteDeps(deps)
 
   // Always scroll to top of view after doing a route navigate
-  window.scrollTo(0, 0)
+  document.getElementById("root")?.scrollTo(0, 0)
 
   return context
 }


### PR DESCRIPTION
# What does this PR do?

The actual root dom element of of uesio pages is the element with the "root" id. We need to scroll that element to the top, since it's inside the body tag and overflow auto and h-screen, it acts as the viewport. This also lets us delete the special setup file we needed for jest to handle the `window.scrollTo()` call.

# Testing

Navigate to a route and then scroll down. Then navigate to another route. That route should start scrolled all the way to the top.
