### PR TITLE
Fix/fetch depth

### DIFF
--- a/.github/workflows/branch_build.yaml
+++ b/.github/workflows/branch_build.yaml
@@ -20,15 +20,10 @@ jobs:
     env:
       FULL_SHA: ${{ github.sha }}
     steps:
-      # Checkout master (so we can use nx:affected)
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 1
-          ref: master
-      # Checkout the current branch
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
+          # We need to fetch all branches and commits so that Nx affected has a base to compare against.
+          fetch-depth: 0
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
         uses: nrwl/nx-set-shas@v4
         with:

--- a/.github/workflows/master_branch_build.yaml
+++ b/.github/workflows/master_branch_build.yaml
@@ -36,7 +36,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          # We need to fetch all branches and commits so that Nx affected has a base to compare against.
+          fetch-depth: 0
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
         uses: nrwl/nx-set-shas@v4
         with:

--- a/apps/platform/project.json
+++ b/apps/platform/project.json
@@ -55,7 +55,8 @@
       "dependsOn": [{ "projects": "tag:type:platform-dep", "target": "build" }]
     },
     "test": {
-      "executor": "@nx-go/nx-go:test"
+      "executor": "@nx-go/nx-go:test",
+      "dependsOn": ["vendor:build", "ui:build"]
     },
     "tidy": {
       "executor": "@nx-go/nx-go:tidy"

--- a/libs/ui/src/context/context.ts
+++ b/libs/ui/src/context/context.ts
@@ -347,6 +347,8 @@ class Context {
   siteadmin?: SiteAdminState
   slotLoader?: MetadataKey
 
+  testSHA = () => 1
+
   // returns the context app name, using workspace/site admin context if present
   // or otherwise defaulting to the site context app name
   getApp = () =>

--- a/libs/ui/src/context/context.ts
+++ b/libs/ui/src/context/context.ts
@@ -347,8 +347,6 @@ class Context {
   siteadmin?: SiteAdminState
   slotLoader?: MetadataKey
 
-  testSHA = () => 1
-
   // returns the context app name, using workspace/site admin context if present
   // or otherwise defaulting to the site context app name
   getApp = () =>


### PR DESCRIPTION
# What does this PR do?

1. Checkout `fetch-depth=0` to ensure that nx affected can find the last successful commit
2. Adds `vendor:build` and `ui:build` to dependencies for go platform tests

TODO: Need to go tests to either always run (via -count=1) or find alternate solution for coordination between go test cache and vendor/ui being re-built.  In the case of go tests, it's not just the go code that may have changed that the tests rely on.

# Testing

ci & e2e will cover.
