### PR TITLE
chore: update ci workflow paths-ignore

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,9 +3,11 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
+    paths-ignore: [".vscode/**", "**/*.md"] # TODO: Verify no md files are used in bundles, etc.
   merge_group:
   pull_request:
     branches: [main]
+    # Note - Ignore is not commit specific, if any file in the PR is outside of this list, workflow will run, see https://github.com/orgs/community/discussions/25161#discussioncomment-3246673
     paths-ignore: [".vscode/**", "**/*.md"] # TODO: Verify no md files are used in bundles, etc.
 
 # Automatically cancel in-progress actions on the same branch except for main


### PR DESCRIPTION
# What does this PR do?

update workflow paths-ignore

# Testing

Manual testing of PR to ensure WF does not trigger in expected scenarios.
