### PR TITLE
chore: update ci workflow for docker & int/e2e tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -135,6 +135,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     timeout-minutes: 3
+    permissions:
+      id-token: write # This is required for requesting a OIDC JWT for AWS
     steps:
       - name: Checkout TheCloudMasters/uesio-infra
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,6 +69,8 @@ jobs:
 
       - name: Prep for docker image
         id: setDockerSHAs
+        env:
+          UESIO_DEV: "true"
         run: |
           # We lint/test/build affected but in order to build image, we need to ensure everything
           # is built.  Build anything that hasn't been built yet (takes advantage of nx cache

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,8 +76,7 @@ jobs:
           # is built.  Build anything that hasn't been built yet (takes advantage of nx cache
           # for anything already built from above)
           npx nx run-many -t build --all
-          #echo "GITSHA=`echo $(echo ${{ steps.setNxSHAs.outputs.head }} | cut -c1-8)-${{ github.run_number }}-${{ github.run_attempt }}`" >> "$GITHUB_OUTPUT"
-          echo "GITSHA=`echo $(echo ${{ steps.setNxSHAs.outputs.head }} | cut -c1-8)`" >> "$GITHUB_OUTPUT"
+          echo "GITSHA=`echo $(echo ${{ steps.setNxSHAs.outputs.head }} | cut -c1-8).${{ github.run_number }}.${{ github.run_attempt }}`" >> "$GITHUB_OUTPUT"
 
       - name: Docker meta
         id: meta
@@ -132,7 +131,7 @@ jobs:
 
   update-dev-branch:
     name: Update Dev environment to latest image
-    if: github.ref_name == 'main' && github.event_name == 'push'
+    if: github.ref_name == 'main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     needs: build
     timeout-minutes: 3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -86,6 +86,8 @@ jobs:
             type=raw,value=${{ steps.setDockerSHAs.outputs.gitsha }}
             type=ref,event=branch
             type=ref,event=pr
+          labels: |
+            org.opencontainers.image.version=${{ steps.setDockerSHAs.outputs.gitsha }}
 
       - name: Set up docker buildx
         uses: docker/setup-buildx-action@v3
@@ -100,7 +102,9 @@ jobs:
             GITSHA=${{ steps.setDockerSHAs.outputs.gitsha }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=docker,dest=${{ runner.temp }}/uesio-image.tar
+          outputs: |
+            type=docker
+            type=docker,dest=${{ runner.temp }}/uesio-image.tar
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,12 +3,12 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
-    paths-ignore: [".vscode/**", "**/*.md"] # TODO: Verify no md files are used in bundles, etc.
+    paths-ignore: [".vscode/**", "docs/**", "**/README.md", "LICENSE.md", ".github/**.md"]
   merge_group:
   pull_request:
     branches: [main]
     # Note - Ignore is not commit specific, if any file in the PR is outside of this list, workflow will run, see https://github.com/orgs/community/discussions/25161#discussioncomment-3246673
-    paths-ignore: [".vscode/**", "**/*.md"] # TODO: Verify no md files are used in bundles, etc.
+    paths-ignore: [".vscode/**", "docs/**", "**/README.md", "LICENSE.md", ".github/**.md"]
 
 # Automatically cancel in-progress actions on the same branch except for main
 concurrency:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -94,6 +94,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           load: true
+          file: ./apps/platform/Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -107,7 +107,7 @@ jobs:
             type=docker
             type=docker,dest=${{ runner.temp }}/uesio-image.tar
 
-      - name: Upload artifact
+      - name: Upload docker image artifact
         uses: actions/upload-artifact@v4
         with:
           name: uesio-image
@@ -129,3 +129,64 @@ jobs:
           # Start up the Uesio app, and dependencies, in Docker
           # then run all Integration and E2E tests against the app
           npm run tests-ci
+
+  update-dev-branch:
+    name: Update Dev environment to latest image
+    if: github.ref_name == 'main' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    needs: build
+    timeout-minutes: 3
+    steps:
+      - name: Checkout TheCloudMasters/uesio-infra
+        uses: actions/checkout@v4
+        with:
+          repository: TheCloudMasters/uesio-infra
+          token: ${{ secrets.GH_PAT }} # `GH_PAT` is a secret that contains your personal Github access token
+          fetch-depth: 1
+
+      - name: Download docker image artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: uesio-image
+          path: ${{ runner.temp }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ECR_ROLE_DEV }}
+          role-session-name: ecrpush
+          aws-region: ${{ secrets.AWS_REGION_DEV }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Push image to ECR
+        id: pushImageToECR
+        env:
+          LOCAL_IMAGE_TAG: ${{ needs.build.outputs.gitsha }}
+          REGISTRY_IMAGE_TAG: ${{ steps.login-ecr.outputs.registry }}/uesio:${{ needs.build.outputs.gitsha }}
+        run: |
+          echo "LOCAL_IMAGE_TAG=${LOCAL_IMAGE_TAG}" >> "$GITHUB_OUTPUT"
+          echo "REGISTRY_IMAGE_TAG=${REGISTRY_IMAGE_TAG}" >> "$GITHUB_OUTPUT"
+          docker load --input ${{ runner.temp }}/uesio-image.tar
+          docker tag $LOCAL_IMAGE_TAG $REGISTRY_IMAGE_TAG
+          docker image push $REGISTRY_IMAGE_TAG
+
+      - name: Update docker container image tag for dev
+        env:
+          LOCAL_IMAGE_TAG: ${{ steps.pushImageToECR.outputs.LOCAL_IMAGE_TAG }}
+          REGISTRY_IMAGE_TAG: ${{ steps.pushImageToECR.outputs.REGISTRY_IMAGE_TAG }}
+          appTaskDefPath: ./aws/dev/ecs/task_definitions/uesio_web.json
+          workerTaskDefPath: ./aws/dev/ecs/task_definitions/uesio_worker.json
+        run: |
+          echo "Docker image SHA updated to $LOCAL_IMAGE_TAG"
+          jq --arg img "$REGISTRY_IMAGE_TAG" '.containerDefinitions[0].image = $img' $appTaskDefPath > tmp1.json
+          jq --arg img "$REGISTRY_IMAGE_TAG" '.containerDefinitions[0].image = $img' $workerTaskDefPath > tmp2.json
+          mv tmp1.json $appTaskDefPath
+          mv tmp2.json $workerTaskDefPath
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add $appTaskDefPath $workerTaskDefPath
+          git commit -m "ci: Auto-update dev image to $LOCAL_IMAGE_TAG"
+          git push

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,23 +20,32 @@ env:
 
 jobs:
   build:
+    name: Check, build and test
     runs-on: ubuntu-latest
+    outputs:
+      gitsha: ${{ steps.setDockerSHAs.outputs.gitsha }}
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
           # We need to fetch all branches and commits so that Nx affected has a base to compare against.
           fetch-depth: 0
+
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
+        id: setNxSHAs
         uses: nrwl/nx-set-shas@v4
+
       - name: Ensure tracking against main
         run: git branch --track main origin/main
         if: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
+
       - name: Setup node
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "npm"
+
       - name: Setup go
         uses: actions/setup-go@v5
         with:
@@ -44,13 +53,61 @@ jobs:
           cache-dependency-path: |
             apps/*/go.sum
             go.work.sum
+
       - name: Install NPM dependencies
         run: npm ci
+
       - name: Check formatting
         env:
           UESIO_DEV: "true"
         run: npx nx format:check --verbose
+
       - name: Lint, test, build
         env:
           UESIO_DEV: "true"
         run: npx nx affected -t lint test build typecheck --configuration=ci --parallel=5
+
+      - name: Prep for docker image
+        id: setDockerSHAs
+        run: |
+          # We lint/test/build affected but in order to build image, we need to ensure everything
+          # is built.  Build anything that hasn't been built yet (takes advantage of nx cache
+          # for anything already built from above)
+          npx nx run-many -t build --all
+          echo "GITSHA=`echo $(echo ${{ steps.setNxSHAs.outputs.head }} | cut -c1-8)-${{ github.run_number }}-${{ github.run_attempt }}`" >> "$GITHUB_OUTPUT"
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          tags: |
+            type=raw,value=${{ steps.setDockerSHAs.outputs.gitsha }}
+            type=ref,event=branch
+            type=ref,event=pr
+
+      - name: Set up docker buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and export to docker
+        uses: docker/build-push-action@v6
+        with:
+          load: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Integration and e2e tests
+        env:
+          GITSHA: ${{ steps.setDockerSHAs.outputs.gitsha }}
+        run: |
+          ./scripts/seed-etc-hosts.sh
+
+          # install hurl for debian. Using the NPM package has SSL issues with node-keytar... really frustrating
+          # Make sure we're using the same Hurl version specified in package.json
+          hurlversion=$(bash ./scripts/get-hurl-version.sh)
+          echo "Installing hurl $hurlversion for Debian..."
+          curl -LO https://github.com/Orange-OpenSource/hurl/releases/download/${hurlversion}/hurl_${hurlversion}_amd64.deb
+          sudo apt update && sudo apt install ./hurl_${hurlversion}_amd64.deb
+
+          # Start up the Uesio app, and dependencies, in Docker
+          # then run all Integration and E2E tests against the app
+          npm run tests-ci

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,7 +76,8 @@ jobs:
           # is built.  Build anything that hasn't been built yet (takes advantage of nx cache
           # for anything already built from above)
           npx nx run-many -t build --all
-          echo "GITSHA=`echo $(echo ${{ steps.setNxSHAs.outputs.head }} | cut -c1-8)-${{ github.run_number }}-${{ github.run_attempt }}`" >> "$GITHUB_OUTPUT"
+          #echo "GITSHA=`echo $(echo ${{ steps.setNxSHAs.outputs.head }} | cut -c1-8)-${{ github.run_number }}-${{ github.run_attempt }}`" >> "$GITHUB_OUTPUT"
+          echo "GITSHA=`echo $(echo ${{ steps.setNxSHAs.outputs.head }} | cut -c1-8)`" >> "$GITHUB_OUTPUT"
 
       - name: Docker meta
         id: meta

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -100,6 +100,13 @@ jobs:
             GITSHA=${{ steps.setDockerSHAs.outputs.gitsha }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=docker,dest=${{ runner.temp }}/uesio-image.tar
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: uesio-image
+          path: ${{ runner.temp }}/uesio-image.tar
 
       - name: Integration and e2e tests
         env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -93,8 +93,11 @@ jobs:
       - name: Build and export to docker
         uses: docker/build-push-action@v6
         with:
+          context: .
           load: true
           file: ./apps/platform/Dockerfile
+          build-args: |
+            GITSHA=${{ steps.setDockerSHAs.outputs.gitsha }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 

--- a/apps/platform/Dockerfile
+++ b/apps/platform/Dockerfile
@@ -17,7 +17,7 @@ COPY ./dist/vendor ./dist/vendor
 
 ARG GITSHA
 ENV GITSHA=${GITSHA}
-LABEL version=${GITSHA}
+LABEL build_version=${GITSHA}
 
 EXPOSE 3000
 

--- a/apps/platform/Dockerfile
+++ b/apps/platform/Dockerfile
@@ -16,7 +16,8 @@ COPY ./dist/ui ./dist/ui
 COPY ./dist/vendor ./dist/vendor
 
 ARG GITSHA
-ENV GITSHA ${GITSHA}
+ENV GITSHA=${GITSHA}
+LABEL version=${GITSHA}
 
 EXPOSE 3000
 

--- a/apps/platform/pkg/cmd/serve.go
+++ b/apps/platform/pkg/cmd/serve.go
@@ -51,10 +51,11 @@ var appParam = getNSParam("app")
 var nsParam = getNSParam("namespace")
 var nameParam = getMetadataItemParam("name")
 var itemParam = fmt.Sprintf("%s/%s", nsParam, nameParam)
-var versionParam = "{version:(?:v[0-9]+\\.[0-9]+\\.[0-9]+)|(?:[a-z0-9]{8,})}"
+var versionParam = "{version:(?:v[0-9]+\\.[0-9]+\\.[0-9]+)|(?:[a-z0-9]{8,}(?:\\.[0-9]+\\.[0-9]+)?)}"
 
 // Version will either be a Uesio bundle version string, e.g. v1.2.3,
-// Or an 8-character short Git sha, e.g. abcd1234
+// an 8-character short Git sha, e.g. abcd1234 or an 8-character short
+// Git sha followed by runnumber.runattempt, e.g. abcd1234.13.3
 var versionedItemParam = fmt.Sprintf("%s/%s/%s", nsParam, versionParam, nameParam)
 
 // Grouping values can either be full Uesio items (e.g. <user>/<app>.<name>) or simple values, e.g. "LISTENER",

--- a/nx.json
+++ b/nx.json
@@ -16,7 +16,7 @@
       "!{projectRoot}/jest.config.[jt]s"
     ],
     "sharedGlobals": [
-      "{workspaceRoot}/.github/workflows/branch_build.yaml",
+      "{workspaceRoot}/.github/workflows/ci.yaml",
       "{workspaceRoot}/go.work"
     ]
   },

--- a/scripts/tests-setup.sh
+++ b/scripts/tests-setup.sh
@@ -6,7 +6,7 @@ set -e
 CERT_FILE="./apps/platform/ssl/certificate.crt"
 if [ -f "$CERT_FILE" ]; then
     echo "SSL certificate already exists."
-else 
+else
     echo "SSL certificate does not exist, creating..."
     cd apps/platform/ssl
     bash ./create.sh
@@ -22,10 +22,9 @@ fi
 # In CI, we should have the image built already, but locally we may not
 if [[ -z "${GITSHA}" ]]; then
     export GITSHA=$(git rev-parse --short HEAD)
-    if [[ "$(docker images -q $GITSHA 2> /dev/null)" == "" ]]; then
-        docker build --tag "$GITSHA" -f ./apps/platform/Dockerfile .
-        export APP_IMAGE="$GITSHA"
-    fi
+    # force a (re)build to ensure we use current filesystem (e.g., uncommitted changes)
+    docker build --tag "$GITSHA" -f ./apps/platform/Dockerfile .
+    export APP_IMAGE="$GITSHA"
 fi
 if [[ -z "${APP_IMAGE}" ]]; then
     export APP_IMAGE="$GITSHA"


### PR DESCRIPTION
# What does this PR do?

Consolidates the previous "Non-master branch build" and "Master/Release Branch Build" workflows in to a "CI" workflow. 

The new workflow will occur as follows:

1. PRs - lint, unit tests, build, typecheck, integration tests, e2e tests
2. Main Push - all the above plus deploy latest image to dev environment

## Details
1. Single ci.yaml file that covers all required steps/tasks - this can be split out to separate files if needed/desired
2. Only pushes to ECR after all checks (unit tests, e2e, integration, etc.) have passed
3. Fixes issue that would have resulted in not building a new image during the workflow when one should have been (due to checking for existence of the image in ECR by sha only)
4. Ensures that building images locally (when GITSHA is not defined) will update image named with GITSHA with the files on the local filesystem at the time.  Previously, when running `npm run tests-ci`, the "current code" on the file system would not be used
5. Applies informative labels & tags to all docker images

# Testing

The workflow itself will be the test
