### PR TITLE
fix: handle password param in createsite

### DIFF
--- a/apps/platform-integration-tests/bundle/bots/listener/tester_createlogin/bot.ts
+++ b/apps/platform-integration-tests/bundle/bots/listener/tester_createlogin/bot.ts
@@ -24,17 +24,17 @@ export default function tester_createlogin(bot: ListenerBotApi) {
 		</body>
 	</html>`
 
-  bot.asAdmin.save(`${namespace}/email_log`, [
+  bot.asAdmin.save(`${namespace}.email_log`, [
     {
-      [`${namespace}/to_emails`]: [email],
-      [`${namespace}/to_names`]: [username],
-      [`${namespace}/from_email`]: from,
-      [`${namespace}/from_name`]: fromName,
-      [`${namespace}/subject`]: subject,
-      [`${namespace}/html_body`]: body,
-      [`${namespace}/content_type`]: contentType,
-      [`${namespace}/verification_code`]: code,
-      [`${namespace}/link`]: link,
+      [`${namespace}.to_emails`]: [email],
+      [`${namespace}.to_names`]: [username],
+      [`${namespace}.from_email`]: from,
+      [`${namespace}.from_name`]: fromName,
+      [`${namespace}.subject`]: subject,
+      [`${namespace}.html_body`]: body,
+      [`${namespace}.content_type`]: contentType,
+      [`${namespace}.verification_code`]: code,
+      [`${namespace}.link`]: link,
     } as unknown as WireRecord,
   ])
 }

--- a/apps/platform-integration-tests/bundle/bots/listener/tester_resetpassword/bot.ts
+++ b/apps/platform-integration-tests/bundle/bots/listener/tester_resetpassword/bot.ts
@@ -25,17 +25,17 @@ export default function tester_forgotpassword(bot: ListenerBotApi) {
 		</body>
 	</html>`
 
-  bot.asAdmin.save(`${namespace}/email_log`, [
+  bot.asAdmin.save(`${namespace}.email_log`, [
     {
-      [`${namespace}/to_emails`]: [email],
-      [`${namespace}/to_names`]: [email],
-      [`${namespace}/from_email`]: from,
-      [`${namespace}/from_name`]: from,
-      [`${namespace}/subject`]: subject,
-      [`${namespace}/html_body`]: body,
-      [`${namespace}/content_type`]: contentType,
-      [`${namespace}/verification_code`]: code,
-      [`${namespace}/link`]: link,
+      [`${namespace}.to_emails`]: [email],
+      [`${namespace}.to_names`]: [email],
+      [`${namespace}.from_email`]: from,
+      [`${namespace}.from_name`]: from,
+      [`${namespace}.subject`]: subject,
+      [`${namespace}.html_body`]: body,
+      [`${namespace}.content_type`]: contentType,
+      [`${namespace}.verification_code`]: code,
+      [`${namespace}.link`]: link,
     } as unknown as WireRecord,
   ])
 }

--- a/apps/platform-integration-tests/hurl_specs/listener_bot_create_site.hurl
+++ b/apps/platform-integration-tests/hurl_specs/listener_bot_create_site.hurl
@@ -7,6 +7,7 @@ POST https://{{host}}:{{port}}/site/auth/uesio/core/mock/login
 {
     "token": "uesio"
 }
+HTTP 200
 
 # Should successfully create site when no password is specified
 POST https://{{host}}:{{port}}/site/bots/call/uesio/studio/createsite
@@ -28,6 +29,8 @@ jsonpath "$.success" == true
 
 # Should successfully create site when password is specified
 POST https://{{host}}:{{port}}/site/bots/call/uesio/studio/createsite
+[Options]
+variable: example_valid_password=aA$09999
 {
   		"firstname": "createsite",
 			"lastname": "user",
@@ -39,7 +42,7 @@ POST https://{{host}}:{{port}}/site/bots/call/uesio/studio/createsite
 			"profile": "uesio/tests.rep",
 			"username": "createsiteuser",
 			"signupmethod": "uesio/tests.tester",
-      "password": "aA$09999"
+      "password": "{{example_valid_password}}"
 }
 HTTP 200
 [Asserts]
@@ -53,6 +56,8 @@ HTTP 400
 
 # Should successfully create site when password does not meet min requirements
 POST https://{{host}}:{{port}}/site/bots/call/uesio/studio/createsite
+[Options]
+variable: example_weak_password=a
 {
   		"firstname": "createsite",
 			"lastname": "user",
@@ -64,7 +69,7 @@ POST https://{{host}}:{{port}}/site/bots/call/uesio/studio/createsite
 			"profile": "uesio/tests.rep",
 			"username": "createsiteuser",
 			"signupmethod": "uesio/tests.tester",
-      "password": "a"
+      "password": "{{example_weak_password}}"
 }
 HTTP 400
 [Asserts]

--- a/apps/platform-integration-tests/hurl_specs/listener_bot_create_site.hurl
+++ b/apps/platform-integration-tests/hurl_specs/listener_bot_create_site.hurl
@@ -1,0 +1,71 @@
+######################################################
+# Tests the crud apis for listener bots
+######################################################
+
+# Test as a logged-in user so that we don't get redirected to the login page
+POST https://{{host}}:{{port}}/site/auth/uesio/core/mock/login
+{
+    "token": "uesio"
+}
+
+# Should successfully create site when no password is specified
+POST https://{{host}}:{{port}}/site/bots/call/uesio/studio/createsite
+{
+  		"firstname": "createsite",
+			"lastname": "user",
+			"email": "createsiteuser@uesio.com",
+			"subdomain": "createsite-nopwd",
+			"site": "createsitenopwd",
+			"version": "v0.0.1",
+			"app": "uesio/tests",
+			"profile": "uesio/tests.rep",
+			"username": "createsiteuser",
+			"signupmethod": "uesio/tests.tester"
+}
+HTTP 200
+[Asserts]
+jsonpath "$.success" == true
+
+# Should successfully create site when password is specified
+POST https://{{host}}:{{port}}/site/bots/call/uesio/studio/createsite
+{
+  		"firstname": "createsite",
+			"lastname": "user",
+			"email": "createsiteuser@uesio.com",
+			"subdomain": "createsite-validpwd",
+			"site": "createsitevalidpwd",
+			"version": "v0.0.1",
+			"app": "uesio/tests",
+			"profile": "uesio/tests.rep",
+			"username": "createsiteuser",
+			"signupmethod": "uesio/tests.tester",
+      "password": "aA$09999"
+}
+HTTP 200
+[Asserts]
+jsonpath "$.success" == true
+
+# Should fail when payload empty
+POST https://{{host}}:{{port}}/site/bots/call/uesio/studio/createsite
+{
+}
+HTTP 400
+
+# Should successfully create site when password does not meet min requirements
+POST https://{{host}}:{{port}}/site/bots/call/uesio/studio/createsite
+{
+  		"firstname": "createsite",
+			"lastname": "user",
+			"email": "createsiteuser@uesio.com",
+			"subdomain": "createsite-invalidpwd",
+			"site": "createsiteinvalidpwd",
+			"version": "v0.0.1",
+			"app": "uesio/tests",
+			"profile": "uesio/tests.rep",
+			"username": "createsiteuser",
+			"signupmethod": "uesio/tests.tester",
+      "password": "a"
+}
+HTTP 400
+[Asserts]
+body contains "does not meet the password policy requirements"

--- a/apps/platform/pkg/auth/platform/platform.go
+++ b/apps/platform/pkg/auth/platform/platform.go
@@ -359,16 +359,22 @@ func (c *Connection) CreateLogin(signupMethod *meta.SignupMethod, payload map[st
 	}
 
 	// 1. If the payload includes a "password", go ahead and auto verify and set the password
-	password, hasPassword := payload["password"]
-	if hasPassword {
-		payload["hasPassword"] = true
+	var password string
+	if passwordValue, ok := payload["password"]; ok {
+		if passwordValue, ok := passwordValue.(string); !ok {
+			return exceptions.NewInvalidParamException("password must be a string", "password")
+		} else {
+			password = passwordValue
+		}
 	}
+	hasPassword := password != ""
+	payload["hasPassword"] = hasPassword
 
 	// 2. If the payload includes a "password" and a "setTemporary" flag, set the password into
 	//    the temporary password field as well.
 	setTemporary := param.GetBoolean(payload, "setTemporary")
 	if hasPassword && setTemporary {
-		loginMethod.TemporaryPassword = password.(string)
+		loginMethod.TemporaryPassword = password
 	}
 
 	// 3. If the payload includes a "password" and a "forceReset" flag, set the forceReset flag on

--- a/apps/platform/pkg/bot/jsdialect/generatorbot.go
+++ b/apps/platform/pkg/bot/jsdialect/generatorbot.go
@@ -187,6 +187,8 @@ func (gba *GeneratorBotAPI) CreateUser(options *deploy.CreateUserOptions) (map[s
 }
 
 func (gba *GeneratorBotAPI) GeneratePassword() (string, error) {
+	// TODO: Ensure generated password meets our current requirements - as written currently
+	// do not believe it will guarantee at least 1 lower & upper case characters
 	return passwordGenerator.Generate(10, 1, 1, false, false)
 }
 


### PR DESCRIPTION
# What does this PR do?

Ensures that `password` is correctly detected and handled when creating a site.

# Testing

Added integration tests to cover.
