### PR TITLE
chore: cache docker deps

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,6 +78,9 @@ jobs:
           npx nx run-many -t build --all
           echo "GITSHA=`echo $(echo ${{ steps.setNxSHAs.outputs.head }} | cut -c1-8).${{ github.run_number }}.${{ github.run_attempt }}`" >> "$GITHUB_OUTPUT"
 
+      - name: Set up docker buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
@@ -89,13 +92,29 @@ jobs:
           labels: |
             org.opencontainers.image.version=${{ steps.setDockerSHAs.outputs.gitsha }}
 
-      - name: Set up docker buildx
-        uses: docker/setup-buildx-action@v3
+      - name: Cache for docker
+        id: cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            go-build-cache
+          key: ${{ runner.os }}-docker-cache-${{ hashFiles('apps/**/go.sum') }}
+
+      - name: Inject cache into docker
+        uses: reproducible-containers/buildkit-cache-dance@v3
+        with:
+          cache-map: |
+            {
+              "go-build-cache": "/root/.cache/go-build"
+            }
+          skip-extraction: ${{ steps.cache.outputs.cache-hit }}
 
       - name: Build and export to docker
         uses: docker/build-push-action@v6
         with:
           context: .
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           load: true
           file: ./apps/platform/Dockerfile
           build-args: |

--- a/apps/platform/Dockerfile
+++ b/apps/platform/Dockerfile
@@ -1,8 +1,11 @@
 FROM golang:1.23-alpine AS multistage
 
 WORKDIR /src
+RUN go env -w GOMODCACHE=/root/.cache/go-build
+COPY ./apps/platform/go.mod ./apps/platform/go.sum ./
+RUN --mount=type=cache,target=/root/.cache/go-build go mod download
 COPY ./apps/platform .
-RUN go build
+RUN --mount=type=cache,target=/root/.cache/go-build go build
 
 ##
 

--- a/apps/platform/pkg/auth/platform/platform.go
+++ b/apps/platform/pkg/auth/platform/platform.go
@@ -25,6 +25,7 @@ import (
 type Auth struct{}
 
 func (a *Auth) GetAuthConnection(credentials *wire.Credentials, authSource *meta.AuthSource, connection wire.Connection, session *sess.Session) (auth.AuthConnection, error) {
+	fmt.Println("test a code change")
 	return &Connection{
 		credentials: credentials,
 		authSource:  authSource,

--- a/apps/platform/pkg/auth/platform/platform.go
+++ b/apps/platform/pkg/auth/platform/platform.go
@@ -25,7 +25,6 @@ import (
 type Auth struct{}
 
 func (a *Auth) GetAuthConnection(credentials *wire.Credentials, authSource *meta.AuthSource, connection wire.Connection, session *sess.Session) (auth.AuthConnection, error) {
-	fmt.Println("test a code change")
 	return &Connection{
 		credentials: credentials,
 		authSource:  authSource,


### PR DESCRIPTION
# What does this PR do?

Cache docker dependencies when building image and also across CI workflow runs.

# Testing

Local docker build times decreased significantly.  As an example, making a change in apps/platform and re-running `tests-ci` would take 35-40 secs to rebuild the image and it now takes < 10 seconds.

Instrumented github workflows to do the "cache dance" across CI runs which should result in the same benefit in our CI builds as well.

All tests pass locally, ci & e2e will verify rest.
