### PR TITLE
chore: use hurl from npm

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -137,13 +137,6 @@ jobs:
         run: |
           ./scripts/seed-etc-hosts.sh
 
-          # install hurl for debian. Using the NPM package has SSL issues with node-keytar... really frustrating
-          # Make sure we're using the same Hurl version specified in package.json
-          hurlversion=$(bash ./scripts/get-hurl-version.sh)
-          echo "Installing hurl $hurlversion for Debian..."
-          curl -LO https://github.com/Orange-OpenSource/hurl/releases/download/${hurlversion}/hurl_${hurlversion}_amd64.deb
-          sudo apt update && sudo apt install ./hurl_${hurlversion}_amd64.deb
-
           # Start up the Uesio app, and dependencies, in Docker
           # then run all Integration and E2E tests against the app
           npm run tests-ci

--- a/README.md
+++ b/README.md
@@ -498,7 +498,7 @@ To run API integration tests locally against your running Uesio container, use `
 The easiest way to run a single Integration Test is to go into the `run-integration-tests.sh` file and comment out the lines where we run all tests, and uncomment the lines here:
 
 ```
-hurl --very-verbose -k --variable host=studio.uesio-dev.com --variable domain=uesio-dev.com --variable port=3000 hurl_specs/wire_collection_dependencies.hurl
+npx hurl --very-verbose -k --variable host=studio.uesio-dev.com --variable domain=uesio-dev.com --variable port=3000 hurl_specs/wire_collection_dependencies.hurl
 ```
 
 You could run this from the CLI, but you would have to make sure that you are (a) in the right directory (b) have the right environment variables set up. (See the top of this `run-integration-tests.sh` for a better understanding).

--- a/scripts/get-hurl-version.sh
+++ b/scripts/get-hurl-version.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-cat node_modules/@orangeopensource/hurl/package.json | jq -r '."hurlBinaryVersion"' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+'

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -26,15 +26,15 @@ cd apps/platform-integration-tests
 # sequential execution via --jobs flag but this should be investigated and, assuming possible depending on root cause, changed to not limit parallel execution.
 # See https://github.com/ues-io/uesio/issues/4457
 # Run specs
-hurl --jobs 1 --error-format long -k --variable host=studio.uesio-dev.com --variable domain=uesio-dev.com --variable port=3000 --test hurl_specs/*.hurl
+npx hurl --jobs 1 --error-format long -k --variable host=studio.uesio-dev.com --variable domain=uesio-dev.com --variable port=3000 --test hurl_specs/*.hurl
 # Run field condition tests
-hurl --jobs 1 --error-format long -k --variable host=studio.uesio-dev.com --variable domain=uesio-dev.com --variable port=3000 --test hurl_fields/*.hurl
+npx hurl --jobs 1 --error-format long -k --variable host=studio.uesio-dev.com --variable domain=uesio-dev.com --variable port=3000 --test hurl_fields/*.hurl
 
 # FYI if you want to view the output of the request made by a specific hurl spec,
 # you can comment out the assertions of the last hurl request made in a hurl file, and then run the spec
 # without the "--test" flag, like this
-# hurl --very-verbose -k --variable host=studio.uesio-dev.com --variable domain=uesio-dev.com --variable port=3000 hurl_specs/wire_collection_dependencies.hurl
+# npx hurl --very-verbose -k --variable host=studio.uesio-dev.com --variable domain=uesio-dev.com --variable port=3000 hurl_specs/wire_collection_dependencies.hurl
 
-hurl --very-verbose -k --variable host=studio.uesio-dev.com --variable domain=uesio-dev.com --variable port=3000 --test hurl_specs_single_run/perf_stats.hurl
+npx hurl --very-verbose -k --variable host=studio.uesio-dev.com --variable domain=uesio-dev.com --variable port=3000 --test hurl_specs_single_run/perf_stats.hurl
 
 cd - >> /dev/null

--- a/scripts/tests-cleanup.sh
+++ b/scripts/tests-cleanup.sh
@@ -28,7 +28,7 @@ echo "dev workspace should be clear"
 cd - >> /dev/null
 
 # Run specs
-hurl -k --variable host=studio.uesio-dev.com --variable port=3000 --test apps/platform-integration-tests/hurl_specs_single_run/truncate_tenant_data_cli.hurl
+npx hurl -k --variable host=studio.uesio-dev.com --variable port=3000 --test apps/platform-integration-tests/hurl_specs_single_run/truncate_tenant_data_cli.hurl
 
 # Delete the workspaces
 cd apps/platform-integration-tests

--- a/scripts/tests-init.sh
+++ b/scripts/tests-init.sh
@@ -19,7 +19,7 @@ uesio sethost
 uesio login
 
 echo "Deleting and recreating the tests app and dev workspace..."
-hurl -k --error-format long --no-output --variable host=studio.uesio-dev.com --variable port=3000 --variable domain=uesio-dev.com hurl_seeds/app_and_workspace.hurl
+npx hurl -k --error-format long --no-output --variable host=studio.uesio-dev.com --variable port=3000 --variable domain=uesio-dev.com hurl_seeds/app_and_workspace.hurl
 
 # truncatetests workspace
 echo "Changing to truncatetests workspace..."
@@ -43,12 +43,12 @@ uesio upsert -f seed_data/contacts.csv -s seed_data/contacts_import.spec.json
 uesio upsert -f seed_data/tools.csv -s seed_data/tools_import.spec.json
 
 # Populate secrets and config values for the dev workspace
-hurl -k --error-format long --no-output --variable host=studio.uesio-dev.com --variable port=3000 --variable domain=uesio-dev.com hurl_seeds/populate_secrets_and_config_values.hurl
+npx hurl -k --error-format long --no-output --variable host=studio.uesio-dev.com --variable port=3000 --variable domain=uesio-dev.com hurl_seeds/populate_secrets_and_config_values.hurl
 
 echo "Successfully upserted seed data into our workspace. Creating a test site, domain, and bundle..."
 
-# Now that we have deployed our site, we can create a bundle, site, and domain which uses its metadata
-hurl -k --error-format long --no-output --variable host=studio.uesio-dev.com --variable port=3000 --variable domain=uesio-dev.com hurl_seeds/site_domain_bundle.hurl
+# Now that we have deployed our metadata to the workspace, we can create a bundle, site, and domain which uses its metadata
+npx hurl -k --error-format long --no-output --variable host=studio.uesio-dev.com --variable port=3000 --variable domain=uesio-dev.com hurl_seeds/site_domain_bundle.hurl
 
 echo "Seeding data into our test site..."
 uesio siteadmin -n=testsite


### PR DESCRIPTION
# What does this PR do?

Hurl was recently updated to v6 and seems to work properly when npm version is used.  Eliminate separate apt install of hurl and use npm dep version.

# Testing

All pass locally, ci & e2e will cover.
