### PR TITLE
chore: apply run-name to CI build on workflow_dispatch event

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,5 @@
 name: CI
+run-name: ${{ (github.event_name == 'workflow_dispatch' && format('manual{0} {1}', ':', github.sha)) || '' }}
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
# What does this PR do?

The default run-name for workflows is the commit message, however for workflow_dispatch events (manual runs), there is no commit message.  

This PR will apply a name that includes the sha of the commit to the message when event is workflow_dispatch.

# Testing

ci, e2e and manual runs will confirm.
