### PR TITLE
Chore/improve nx graph deps

### DIFF
--- a/libs/apps/uesio/aikit/project.json
+++ b/libs/apps/uesio/aikit/project.json
@@ -7,10 +7,7 @@
   "targets": {
     "build": {
       "executor": "nx:run-commands",
-      "inputs": [
-        "default",
-        "^production"
-      ],
+      "inputs": ["default", "^production"],
       "outputs": ["{projectRoot}/bundle/componentpacks/main/dist"],
       "options": {
         "commands": ["../../../../dist/cli/uesio pack"],
@@ -20,10 +17,7 @@
     },
     "typecheck": {
       "executor": "nx:run-commands",
-      "inputs": [
-        "default",
-        "^production"
-      ],
+      "inputs": ["default", "^production"],
       "outputs": ["{workspaceRoot}/dist/out-tsc/libs/apps/uesio/aikit"],
       "options": {
         "commands": [

--- a/libs/apps/uesio/aikit/project.json
+++ b/libs/apps/uesio/aikit/project.json
@@ -7,6 +7,10 @@
   "targets": {
     "build": {
       "executor": "nx:run-commands",
+      "inputs": [
+        "default",
+        "^production"
+      ],
       "outputs": ["{projectRoot}/bundle/componentpacks/main/dist"],
       "options": {
         "commands": ["../../../../dist/cli/uesio pack"],
@@ -16,6 +20,10 @@
     },
     "typecheck": {
       "executor": "nx:run-commands",
+      "inputs": [
+        "default",
+        "^production"
+      ],
       "outputs": ["{workspaceRoot}/dist/out-tsc/libs/apps/uesio/aikit"],
       "options": {
         "commands": [

--- a/libs/apps/uesio/appkit/project.json
+++ b/libs/apps/uesio/appkit/project.json
@@ -7,10 +7,7 @@
   "targets": {
     "build": {
       "executor": "nx:run-commands",
-      "inputs": [
-        "default",
-        "^production"
-      ],
+      "inputs": ["default", "^production"],
       "outputs": ["{projectRoot}/bundle/componentpacks/main/dist"],
       "options": {
         "commands": ["../../../../dist/cli/uesio pack"],
@@ -20,10 +17,7 @@
     },
     "typecheck": {
       "executor": "nx:run-commands",
-      "inputs": [
-        "default",
-        "^production"
-      ],
+      "inputs": ["default", "^production"],
       "outputs": ["{workspaceRoot}/dist/out-tsc/libs/apps/uesio/appkit"],
       "options": {
         "commands": [

--- a/libs/apps/uesio/appkit/project.json
+++ b/libs/apps/uesio/appkit/project.json
@@ -7,6 +7,10 @@
   "targets": {
     "build": {
       "executor": "nx:run-commands",
+      "inputs": [
+        "default",
+        "^production"
+      ],
       "outputs": ["{projectRoot}/bundle/componentpacks/main/dist"],
       "options": {
         "commands": ["../../../../dist/cli/uesio pack"],
@@ -16,6 +20,10 @@
     },
     "typecheck": {
       "executor": "nx:run-commands",
+      "inputs": [
+        "default",
+        "^production"
+      ],
       "outputs": ["{workspaceRoot}/dist/out-tsc/libs/apps/uesio/appkit"],
       "options": {
         "commands": [

--- a/libs/apps/uesio/core/project.json
+++ b/libs/apps/uesio/core/project.json
@@ -7,10 +7,7 @@
   "targets": {
     "build": {
       "executor": "nx:run-commands",
-      "inputs": [
-        "default",
-        "^production"
-      ],
+      "inputs": ["default", "^production"],
       "outputs": ["{projectRoot}/bundle/componentpacks/app/dist"],
       "options": {
         "commands": ["../../../../dist/cli/uesio pack"],
@@ -20,10 +17,7 @@
     },
     "typecheck": {
       "executor": "nx:run-commands",
-      "inputs": [
-        "default",
-        "^production"
-      ],
+      "inputs": ["default", "^production"],
       "outputs": ["{workspaceRoot}/dist/out-tsc/libs/apps/uesio/core"],
       "options": {
         "commands": [

--- a/libs/apps/uesio/core/project.json
+++ b/libs/apps/uesio/core/project.json
@@ -7,6 +7,10 @@
   "targets": {
     "build": {
       "executor": "nx:run-commands",
+      "inputs": [
+        "default",
+        "^production"
+      ],
       "outputs": ["{projectRoot}/bundle/componentpacks/app/dist"],
       "options": {
         "commands": ["../../../../dist/cli/uesio pack"],
@@ -16,6 +20,10 @@
     },
     "typecheck": {
       "executor": "nx:run-commands",
+      "inputs": [
+        "default",
+        "^production"
+      ],
       "outputs": ["{workspaceRoot}/dist/out-tsc/libs/apps/uesio/core"],
       "options": {
         "commands": [

--- a/libs/apps/uesio/io/project.json
+++ b/libs/apps/uesio/io/project.json
@@ -7,10 +7,7 @@
   "targets": {
     "build": {
       "executor": "nx:run-commands",
-      "inputs": [
-        "default",
-        "^production"
-      ],
+      "inputs": ["default", "^production"],
       "outputs": ["{projectRoot}/bundle/componentpacks/main/dist"],
       "options": {
         "commands": ["../../../../dist/cli/uesio pack"],
@@ -20,10 +17,7 @@
     },
     "typecheck": {
       "executor": "nx:run-commands",
-      "inputs": [
-        "default",
-        "^production"
-      ],
+      "inputs": ["default", "^production"],
       "outputs": ["{workspaceRoot}/dist/out-tsc/libs/apps/uesio/io"],
       "options": {
         "commands": [

--- a/libs/apps/uesio/io/project.json
+++ b/libs/apps/uesio/io/project.json
@@ -7,6 +7,10 @@
   "targets": {
     "build": {
       "executor": "nx:run-commands",
+      "inputs": [
+        "default",
+        "^production"
+      ],
       "outputs": ["{projectRoot}/bundle/componentpacks/main/dist"],
       "options": {
         "commands": ["../../../../dist/cli/uesio pack"],
@@ -16,6 +20,10 @@
     },
     "typecheck": {
       "executor": "nx:run-commands",
+      "inputs": [
+        "default",
+        "^production"
+      ],
       "outputs": ["{workspaceRoot}/dist/out-tsc/libs/apps/uesio/io"],
       "options": {
         "commands": [

--- a/libs/apps/uesio/sitekit/project.json
+++ b/libs/apps/uesio/sitekit/project.json
@@ -7,10 +7,7 @@
   "targets": {
     "build": {
       "executor": "nx:run-commands",
-      "inputs": [
-        "default",
-        "^production"
-      ],
+      "inputs": ["default", "^production"],
       "outputs": ["{projectRoot}/bundle/componentpacks/main/dist"],
       "options": {
         "commands": ["../../../../dist/cli/uesio pack"],
@@ -20,10 +17,7 @@
     },
     "typecheck": {
       "executor": "nx:run-commands",
-      "inputs": [
-        "default",
-        "^production"
-      ],
+      "inputs": ["default", "^production"],
       "outputs": ["{workspaceRoot}/dist/out-tsc/libs/apps/uesio/sitekit"],
       "options": {
         "commands": [

--- a/libs/apps/uesio/sitekit/project.json
+++ b/libs/apps/uesio/sitekit/project.json
@@ -7,6 +7,10 @@
   "targets": {
     "build": {
       "executor": "nx:run-commands",
+      "inputs": [
+        "default",
+        "^production"
+      ],
       "outputs": ["{projectRoot}/bundle/componentpacks/main/dist"],
       "options": {
         "commands": ["../../../../dist/cli/uesio pack"],
@@ -16,6 +20,10 @@
     },
     "typecheck": {
       "executor": "nx:run-commands",
+      "inputs": [
+        "default",
+        "^production"
+      ],
       "outputs": ["{workspaceRoot}/dist/out-tsc/libs/apps/uesio/sitekit"],
       "options": {
         "commands": [

--- a/libs/apps/uesio/studio/project.json
+++ b/libs/apps/uesio/studio/project.json
@@ -7,10 +7,7 @@
   "targets": {
     "build": {
       "executor": "nx:run-commands",
-      "inputs": [
-        "default",
-        "^production"
-      ],
+      "inputs": ["default", "^production"],
       "outputs": ["{projectRoot}/bundle/componentpacks/main/dist"],
       "options": {
         "commands": ["../../../../dist/cli/uesio pack"],
@@ -20,10 +17,7 @@
     },
     "typecheck": {
       "executor": "nx:run-commands",
-      "inputs": [
-        "default",
-        "^production"
-      ],
+      "inputs": ["default", "^production"],
       "outputs": ["{workspaceRoot}/dist/out-tsc/libs/apps/uesio/studio"],
       "options": {
         "commands": [

--- a/libs/apps/uesio/studio/project.json
+++ b/libs/apps/uesio/studio/project.json
@@ -7,6 +7,10 @@
   "targets": {
     "build": {
       "executor": "nx:run-commands",
+      "inputs": [
+        "default",
+        "^production"
+      ],
       "outputs": ["{projectRoot}/bundle/componentpacks/main/dist"],
       "options": {
         "commands": ["../../../../dist/cli/uesio pack"],
@@ -16,6 +20,10 @@
     },
     "typecheck": {
       "executor": "nx:run-commands",
+      "inputs": [
+        "default",
+        "^production"
+      ],
       "outputs": ["{workspaceRoot}/dist/out-tsc/libs/apps/uesio/studio"],
       "options": {
         "commands": [

--- a/libs/ui/project.json
+++ b/libs/ui/project.json
@@ -7,10 +7,7 @@
   "targets": {
     "build": {
       "executor": "nx:run-commands",
-      "inputs": [
-        "default",
-        "^production"
-      ],
+      "inputs": ["default", "^production"],
       "outputs": ["{workspaceRoot}/dist/ui"],
       "options": {
         "commands": ["bash build.sh"],
@@ -20,10 +17,7 @@
     },
     "typecheck": {
       "executor": "nx:run-commands",
-      "inputs": [
-        "default",
-        "^production"
-      ],
+      "inputs": ["default", "^production"],
       "outputs": ["{workspaceRoot}/dist/out-tsc/libs/ui"],
       "options": {
         "commands": [

--- a/libs/ui/project.json
+++ b/libs/ui/project.json
@@ -7,6 +7,10 @@
   "targets": {
     "build": {
       "executor": "nx:run-commands",
+      "inputs": [
+        "default",
+        "^production"
+      ],
       "outputs": ["{workspaceRoot}/dist/ui"],
       "options": {
         "commands": ["bash build.sh"],
@@ -16,6 +20,10 @@
     },
     "typecheck": {
       "executor": "nx:run-commands",
+      "inputs": [
+        "default",
+        "^production"
+      ],
       "outputs": ["{workspaceRoot}/dist/out-tsc/libs/ui"],
       "options": {
         "commands": [
@@ -26,7 +34,6 @@
     },
     "watch": {
       "executor": "nx:run-commands",
-      "outputs": ["{workspaceRoot}/dist/ui"],
       "options": {
         "command": "../../dist/cli/uesio packui --watch",
         "cwd": "libs/ui"

--- a/libs/vendor/project.json
+++ b/libs/vendor/project.json
@@ -7,6 +7,10 @@
   "targets": {
     "build": {
       "executor": "nx:run-commands",
+      "inputs": [
+        "default",
+        "^production"
+      ],
       "outputs": ["{workspaceRoot}/dist/vendor"],
       "options": {
         "commands": ["gulp -f libs/vendor/gulpfile.js"]
@@ -14,6 +18,10 @@
     },
     "typecheck": {
       "executor": "nx:run-commands",
+      "inputs": [
+        "default",
+        "^production"
+      ],
       "outputs": ["{workspaceRoot}/dist/out-tsc/libs/vendor"],
       "options": {
         "commands": [

--- a/libs/vendor/project.json
+++ b/libs/vendor/project.json
@@ -7,10 +7,7 @@
   "targets": {
     "build": {
       "executor": "nx:run-commands",
-      "inputs": [
-        "default",
-        "^production"
-      ],
+      "inputs": ["default", "^production"],
       "outputs": ["{workspaceRoot}/dist/vendor"],
       "options": {
         "commands": ["gulp -f libs/vendor/gulpfile.js"]
@@ -18,10 +15,7 @@
     },
     "typecheck": {
       "executor": "nx:run-commands",
-      "inputs": [
-        "default",
-        "^production"
-      ],
+      "inputs": ["default", "^production"],
       "outputs": ["{workspaceRoot}/dist/out-tsc/libs/vendor"],
       "options": {
         "commands": [

--- a/nx.json
+++ b/nx.json
@@ -14,9 +14,7 @@
       "!{projectRoot}/tsconfig.spec.json",
       "!{projectRoot}/jest.config.[jt]s"
     ],
-    "sharedGlobals": [
-      "{workspaceRoot}/.github/workflows/ci.yaml"
-    ],
+    "sharedGlobals": ["{workspaceRoot}/.github/workflows/ci.yaml"],
     "golang": [
       "{projectRoot}/go.mod",
       "{projectRoot}/go.sum",
@@ -42,28 +40,14 @@
       "cache": true
     },
     "@nx-go/nx-go:build": {
-      "inputs": [
-        "golang",
-        "^production",
-        "sharedGlobals"
-      ],
-      "outputs": [
-        "{options.outputPath}"
-      ]
+      "inputs": ["golang", "^production", "sharedGlobals"],
+      "outputs": ["{options.outputPath}"]
     },
     "@nx-go/nx-go:test": {
-      "inputs": [
-        "golang",
-        "^production",
-        "sharedGlobals"
-      ]
+      "inputs": ["golang", "^production", "sharedGlobals"]
     },
     "@nx-go/nx-go:lint": {
-      "inputs": [
-        "golang",
-        "^production",
-        "sharedGlobals"
-      ]
+      "inputs": ["golang", "^production", "sharedGlobals"]
     }
   },
   "plugins": [

--- a/nx.json
+++ b/nx.json
@@ -15,8 +15,14 @@
       "!{projectRoot}/jest.config.[jt]s"
     ],
     "sharedGlobals": [
-      "{workspaceRoot}/.github/workflows/ci.yaml",
-      "{workspaceRoot}/go.work"
+      "{workspaceRoot}/.github/workflows/ci.yaml"
+    ],
+    "golang": [
+      "{projectRoot}/go.mod",
+      "{projectRoot}/go.sum",
+      "{projectRoot}/**/*.go",
+      "{workspaceRoot}/go.work",
+      "{workspaceRoot}/go.work.sum"
     ]
   },
   "targetDefaults": {
@@ -34,6 +40,30 @@
     },
     "typecheck": {
       "cache": true
+    },
+    "@nx-go/nx-go:build": {
+      "inputs": [
+        "golang",
+        "^production",
+        "sharedGlobals"
+      ],
+      "outputs": [
+        "{options.outputPath}"
+      ]
+    },
+    "@nx-go/nx-go:test": {
+      "inputs": [
+        "golang",
+        "^production",
+        "sharedGlobals"
+      ]
+    },
+    "@nx-go/nx-go:lint": {
+      "inputs": [
+        "golang",
+        "^production",
+        "sharedGlobals"
+      ]
     }
   },
   "plugins": [


### PR DESCRIPTION
# What does this PR do?

Improves/Fixes inputs/outputs with nx targets.

1. Go Projects - By default, @nx-go does not include `sharedGlobals`.  Adjustments made to ensure cacheable go targets have inputs/outputs required to ensure proper cacheability.
2. Non-Go Projects - For projects in `libs/**` custom build/lint/typecheck targets are defined using `@nx:run-commands` executor.  Because these tasks are not inferred (unlike `test` & `eslint` targets), the inputs/outputs are not inferred resulting in only the most basic of defaults (e.g., `{projectRoot}/**`, not including sharedGlobals, etc.).  Ensure that these targets have required inputs/outputs for cacheability.

# Testing

Tested various changes locally with `nx affected` and all works as expected.  ci & e2 will cover rest.
