### PR TITLE
use .nvmrc for node version in workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,9 +16,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request_target' && github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
-env:
-  NODE_VERSION: 22.13.0
-
 jobs:
   build:
     name: Check, build and test
@@ -44,7 +41,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version-file: ".nvmrc"
           cache: "npm"
 
       - name: Setup go


### PR DESCRIPTION
# What does this PR do?

Reduces maintenance points by using `.nvmrc` for node version in workflows.

Note that if/when move to matrix build/test, this will have to change but for now, reduces the number of places we need to change things when we change to different version.  This is similar to recent change of using `go.work` to detect the go version instead of hardcoding the version in the CI workflow.

# Testing

ci & e2e will cover.
