### PR TITLE
chore: add cleanup-cache workflow

### DIFF
--- a/.github/workflows/cleanup-cache.yaml
+++ b/.github/workflows/cleanup-cache.yaml
@@ -1,0 +1,47 @@
+# GH will purge cache items when full to make room but keep things tidy
+# when cached assets are (likely) no longer required
+name: Cleanup cache
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 11 * * *"
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Cleanup caches older than 5 days
+        if: github.event_name == 'schedule'
+        uses: MyAlbum/purge-cache@v2
+        with:
+          max-age: 432000
+
+      # https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#force-deleting-cache-entries
+      - name: Cleanup on PR close
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh extension install actions/gh-actions-cache
+
+          REPO=${{ github.repository }}
+          BRANCH="refs/pull/${{ github.event.pull_request.number }}/merge"
+
+          echo "Fetching list of cache key"
+          cacheKeysForPR=$(gh actions-cache list -R $REPO -B $BRANCH -L 100 | cut -f 1 )
+
+          ## Setting this to not fail the workflow while deleting cache keys.
+          set +e
+          echo "Deleting caches..."
+          for cacheKey in $cacheKeysForPR
+          do
+              gh actions-cache delete $cacheKey -R $REPO -B $BRANCH --confirm
+          done
+          echo "Done"


### PR DESCRIPTION
# What does this PR do?

GH will automatically purge cache when its full, however no need to keep artifacts around that are (likely) no longer needed.

This workflow will:

1. Purge any cached item that hasn't been accessed in 5 days
2. Purge any cached item from closed PRs

# Testing

the workflow itself will be the test.
