### PR TITLE
chore: needs permission to delete cache items

### DIFF
--- a/.github/workflows/cleanup-cache.yaml
+++ b/.github/workflows/cleanup-cache.yaml
@@ -13,6 +13,8 @@ on:
 jobs:
   cleanup:
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
     steps:
       - name: Check out code
         uses: actions/checkout@v4


### PR DESCRIPTION
# What does this PR do?

Default token permission is READ so need to explicitly request permission to delete cached items.

# Testing

workflow itself will test.
