### PR TITLE
chore: split lint/test/build/typecheck in to separate jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   build:
-    name: Check, build and test
+    name: Build and test
     runs-on: ubuntu-latest
     outputs:
       gitsha: ${{ steps.setDockerSHAs.outputs.gitsha }}
@@ -55,15 +55,10 @@ jobs:
       - name: Install NPM dependencies
         run: npm ci
 
-      - name: Check formatting
+      - name: Build and test
         env:
           UESIO_DEV: "true"
-        run: npx nx format:check --verbose
-
-      - name: Lint, test, build
-        env:
-          UESIO_DEV: "true"
-        run: npx nx affected -t lint test build typecheck --configuration=ci --parallel=5
+        run: npx nx affected -t build test --configuration=ci --parallel=5
 
       - name: Prep for docker image
         id: setDockerSHAs
@@ -139,11 +134,90 @@ jobs:
           # then run all Integration and E2E tests against the app
           npm run tests-ci
 
+  check:
+    name: Check format and lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # We need to fetch all branches and commits so that Nx affected has a base to compare against.
+          fetch-depth: 0
+
+      - name: Derive appropriate SHAs for base and head for `nx affected` commands
+        id: setNxSHAs
+        uses: nrwl/nx-set-shas@v4
+
+      - name: Ensure tracking against main
+        run: git branch --track main origin/main
+        if: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
+
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+          cache: "npm"
+
+      - name: Setup go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.work
+          cache-dependency-path: |
+            apps/*/go.sum
+            go.work.sum
+
+      - name: Install NPM dependencies
+        run: npm ci
+
+      - name: Check formatting
+        env:
+          UESIO_DEV: "true"
+        run: npx nx format:check --verbose
+
+      - name: Lint
+        env:
+          UESIO_DEV: "true"
+        run: npx nx affected -t lint --configuration=ci --parallel=5
+
+  typecheck:
+    name: Check types
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # We need to fetch all branches and commits so that Nx affected has a base to compare against.
+          fetch-depth: 0
+
+      - name: Derive appropriate SHAs for base and head for `nx affected` commands
+        id: setNxSHAs
+        uses: nrwl/nx-set-shas@v4
+
+      - name: Ensure tracking against main
+        run: git branch --track main origin/main
+        if: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
+
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+          cache: "npm"
+
+      - name: Install NPM dependencies
+        run: npm ci
+
+      - name: Typecheck
+        env:
+          UESIO_DEV: "true"
+        run: npx nx affected -t typecheck --configuration=ci --parallel=5
+
   update-dev-branch:
     name: Update Dev environment to latest image
     if: github.ref_name == 'main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
-    needs: build
+    needs: [build, check, typecheck]
     timeout-minutes: 3
     permissions:
       id-token: write # This is required for requesting a OIDC JWT for AWS


### PR DESCRIPTION
# What does this PR do?

Splits lint/test/build/typecheck in to separate jobs in CI workflow to improve overall performance.

Reduces total time by ~45secs - now under 4 mins for full CI build (not including `update-dev-branch` job which only runs on push/workflow_dispatch to main).  Prior to this and other recent changes, full CI would take ~6-8mins.

build: build & test
check: format & lint
typecheck: typecheck

# Testing

workflow itself will be the test.
