### PR TITLE
chore: update to go 1.23.5

### DIFF
--- a/apps/cli/go.mod
+++ b/apps/cli/go.mod
@@ -1,6 +1,6 @@
 module github.com/thecloudmasters/cli
 
-go 1.23.4
+go 1.23.5
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7

--- a/apps/platform/go.mod
+++ b/apps/platform/go.mod
@@ -1,6 +1,6 @@
 module github.com/thecloudmasters/uesio
 
-go 1.23.4
+go 1.23.5
 
 require (
 	github.com/NYTimes/gziphandler v1.1.1
@@ -70,7 +70,7 @@ require (
 	github.com/go-openapi/swag v0.23.0 // indirect
 	github.com/go-sourcemap/sourcemap v2.1.4+incompatible // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.1 // indirect
-	github.com/google/pprof v0.0.0-20250128161936-077ca0a936bf // indirect
+	github.com/google/pprof v0.0.0-20250202011525-fc3143867406 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.4 // indirect
 	github.com/googleapis/gax-go/v2 v2.14.1 // indirect

--- a/apps/platform/go.sum
+++ b/apps/platform/go.sum
@@ -154,8 +154,8 @@ github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+u
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
-github.com/google/pprof v0.0.0-20250128161936-077ca0a936bf h1:BvBLUD2hkvLI3dJTJMiopAq8/wp43AAZKTP7qdpptbU=
-github.com/google/pprof v0.0.0-20250128161936-077ca0a936bf/go.mod h1:vavhavw2zAxS5dIdcRluK6cSGGPlZynqzFM8NdvU144=
+github.com/google/pprof v0.0.0-20250202011525-fc3143867406 h1:wlQI2cYY0BsWmmPPAnxfQ8SDW0S3Jasn+4B8kXFxprg=
+github.com/google/pprof v0.0.0-20250202011525-fc3143867406/go.mod h1:vavhavw2zAxS5dIdcRluK6cSGGPlZynqzFM8NdvU144=
 github.com/google/s2a-go v0.1.9 h1:LGD7gtMgezd8a/Xak7mEWL0PjoTQFvpRudN895yqKW0=
 github.com/google/s2a-go v0.1.9/go.mod h1:YA0Ei2ZQL3acow2O62kdp9UlnvMmU7kA6Eutn0dXayM=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=

--- a/go.work
+++ b/go.work
@@ -3,7 +3,7 @@
 // externally.  The general guidance on this, although unofficial, is that is is OK to commit these files
 // to version control.  See https://github.com/golang/go/issues/53502
 
-go 1.23.4
+go 1.23.5
 
 
 use (


### PR DESCRIPTION
# What does this PR do?

update to go 1.23.5

# Testing

ci & e2e will cover.
