### PR TITLE
chore: separate go cache per job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request_target' && github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
+env:
+  GO_CACHE_INFO_FILE: wf-go-cache-info.txt
+
 jobs:
   build:
     name: Build and test
@@ -44,6 +47,13 @@ jobs:
           node-version-file: ".nvmrc"
           cache: "npm"
 
+      # https://github.com/actions/setup-go/issues/358 - cache is shared across jobs by default since the dependency
+      # graph is the same, however each job results in different dependencies being downloaded and the first one
+      # to finish wins with regards to saving the cache.  To workaround, we create a file to include in the graph
+      # that contains information specified to the workflow & job so that each job gets a separate go cache.
+      - name: Create go cache info file
+        run: echo "go-cache-${{ github.workflow }}-${{ github.job }}-${{ runner.os }}" > ${GO_CACHE_INFO_FILE}
+
       - name: Setup go
         uses: actions/setup-go@v5
         with:
@@ -51,6 +61,7 @@ jobs:
           cache-dependency-path: |
             apps/*/go.sum
             go.work.sum
+            ${{ env.GO_CACHE_INFO_FILE }}
 
       - name: Install NPM dependencies
         run: npm ci
@@ -159,6 +170,13 @@ jobs:
           node-version-file: ".nvmrc"
           cache: "npm"
 
+      # https://github.com/actions/setup-go/issues/358 - cache is shared across jobs by default since the dependency
+      # graph is the same, however each job results in different dependencies being downloaded and the first one
+      # to finish wins with regards to saving the cache.  To workaround, we create a file to include in the graph
+      # that contains information specified to the workflow & job so that each job gets a separate go cache.
+      - name: Create go cache info file
+        run: echo "go-cache-${{ github.workflow }}-${{ github.job }}-${{ runner.os }}" > ${GO_CACHE_INFO_FILE}
+
       - name: Setup go
         uses: actions/setup-go@v5
         with:
@@ -166,6 +184,7 @@ jobs:
           cache-dependency-path: |
             apps/*/go.sum
             go.work.sum
+            ${{ env.GO_CACHE_INFO_FILE }}
 
       - name: Install NPM dependencies
         run: npm ci


### PR DESCRIPTION
# What does this PR do?

After splitting out the CI jobs (build/check/typecheck), the build times increased by ~30-45secs.  

The reason for this is that the build & check steps each use go and rely on the default caching of go dependencies from `actions/setup-go`.  Unfortunately, the action does not contemplate that multiple jobs may result in different modules being downloaded (e.g., build will get everything but fmt only obtains a portion of the modules) and if the inputs are the same (which they are) across jobs, the first job to "save the cache" will win.  In our case, the `check` job finishes first so the cache only contains the modules of what was required for `go fmt`.  This results in `go build` needing to download modules every time since some modules aren't in the cache.

Unfortunately, `actions/setup-go` does not support a "cache prefix/key" in its options and [doesn't appear](https://github.com/actions/setup-go/issues/358#issuecomment-1598303300) that it is going to be added any time soon (if ever).  See https://github.com/actions/setup-go/issues/358 for full details.

This PR resolves the issue by including a job specific text file in the dependency graph to ensure that the cache key is different for each job.

# Testing

Manual testing of CI build confirms that each job is getting its own cache and once the cache is built for a given set of input, job times are back to previous duration levels.
