### PR TITLE
test: force a full PR build/test cycle

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,3 +1,4 @@
+# Force a change that will require everything to be fully built & tested
 name: CI
 run-name: ${{ (github.event_name == 'workflow_dispatch' && format('manual{0} {1}', ':', github.sha)) || '' }}
 on:


### PR DESCRIPTION
# What does this PR do?

This is a test PR to verify go caching.  It contains a change to ci.yaml that will ensure all projects are built/tested fully.

It will be discarded and not merged.

# Testing

For testing purposes only.
