### PR TITLE
Add retrieve types only command

### DIFF
--- a/apps/cli/pkg/cmd/workspace.go
+++ b/apps/cli/pkg/cmd/workspace.go
@@ -26,7 +26,7 @@ func init() {
 		Long:  "Retrieves all metadata from a remote workspace to the local directory",
 		Run:   workspaceRetrieve,
 	}
-	workspaceRetrieveCmd.Flags().BoolP("onlyTypes", "t", false, "Only retrieve types")
+	workspaceRetrieveCmd.Flags().Bool("onlyTypes", false, "Only retrieve types")
 
 	workspaceDeployCmd := &cobra.Command{
 		Use:   "deploy",
@@ -73,7 +73,7 @@ func init() {
 		Short: "uesio retrieve",
 		Run:   workspaceRetrieve,
 	}
-	oldRetrieveCommand.Flags().BoolP("onlyTypes", "t", false, "Only retrieve types")
+	oldRetrieveCommand.Flags().Bool("onlyTypes", false, "Only retrieve types")
 
 	rootCmd.AddCommand(workspaceCommand, oldDeployCommand, oldRetrieveCommand)
 

--- a/apps/cli/pkg/cmd/workspace.go
+++ b/apps/cli/pkg/cmd/workspace.go
@@ -26,6 +26,7 @@ func init() {
 		Long:  "Retrieves all metadata from a remote workspace to the local directory",
 		Run:   workspaceRetrieve,
 	}
+	workspaceRetrieveCmd.Flags().BoolP("onlyTypes", "t", false, "Only retrieve types")
 
 	workspaceDeployCmd := &cobra.Command{
 		Use:   "deploy",
@@ -72,13 +73,17 @@ func init() {
 		Short: "uesio retrieve",
 		Run:   workspaceRetrieve,
 	}
+	oldRetrieveCommand.Flags().BoolP("onlyTypes", "t", false, "Only retrieve types")
 
 	rootCmd.AddCommand(workspaceCommand, oldDeployCommand, oldRetrieveCommand)
 
 }
 
 func workspaceRetrieve(cmd *cobra.Command, args []string) {
-	err := workspace.Retrieve()
+	onlyTypes, _ := cmd.Flags().GetBool("onlyTypes")
+	err := workspace.Retrieve(&workspace.RetrieveOptions{
+		OnlyTypes: onlyTypes,
+	})
 	if err != nil {
 		fmt.Println("Error: " + err.Error())
 		os.Exit(1)

--- a/apps/cli/pkg/command/workspace/retrieve.go
+++ b/apps/cli/pkg/command/workspace/retrieve.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/thecloudmasters/cli/pkg/auth"
 	"github.com/thecloudmasters/cli/pkg/call"
+	"github.com/thecloudmasters/cli/pkg/command"
 	"github.com/thecloudmasters/cli/pkg/config"
 	"github.com/thecloudmasters/cli/pkg/config/ws"
 	"github.com/thecloudmasters/cli/pkg/context"
@@ -16,7 +17,15 @@ import (
 	"github.com/thecloudmasters/uesio/pkg/meta"
 )
 
-func Retrieve() error {
+type RetrieveOptions struct {
+	OnlyTypes bool
+}
+
+func Retrieve(options *RetrieveOptions) error {
+
+	if options == nil {
+		options = &RetrieveOptions{}
+	}
 
 	_, err := auth.Login()
 	if err != nil {
@@ -35,6 +44,22 @@ func Retrieve() error {
 
 	if workspace == "" {
 		return errors.New("No active workspace is set. Use \"uesio work\" to set one.")
+	}
+
+	if options.OnlyTypes {
+		appContext := context.NewWorkspaceContext(appName, workspace)
+
+		sessionId, err := config.GetSessionID()
+		if err != nil {
+			return err
+		}
+
+		if err = command.GenerateAppTypeDefinitions(appName, workspace, sessionId, appContext); err != nil {
+			return err
+		}
+
+		fmt.Println("Type definitions successfully updated.")
+		return nil
 	}
 
 	err = RetrieveBundleForAppWorkspace(appName, workspace, "")

--- a/apps/platform/pkg/meta/bot.go
+++ b/apps/platform/pkg/meta/bot.go
@@ -550,7 +550,7 @@ const NEWLINE = `
 `
 
 func (b *Bot) GenerateTypeDefinitions() (string, error) {
-	if b.Type != "ROUTE" && b.Type != "LISTENER" && b.Type != "RUNACTION" {
+	if b.Type != "ROUTE" && b.Type != "LISTENER" && b.Type != "RUNACTION" && b.Type != "GENERATOR" {
 		return "", nil
 	}
 	if b.Name == "" || b.Namespace == "" {

--- a/apps/platform/pkg/meta/botcollection.go
+++ b/apps/platform/pkg/meta/botcollection.go
@@ -182,6 +182,7 @@ func init() {
 				"LISTENER",
 				"ROUTE",
 				"RUNACTION",
+				"GENERATOR",
 			},
 		}
 	}


### PR DESCRIPTION
# What does this PR do?

Adds an option to `uesio retrieve` to only retrieve app specific type definitions.

`uesio retrieve --onlyTypes`
