### PR TITLE
fix: email template "if mso" conditional statement format

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -17,6 +17,7 @@ workspace.json
 **/*.template.yaml
 **/*.template.ts
 **/dist/**
+**/emailtemplates/**/*.html
 
 # Ignore prettier errors for generated files
 **/generated/@types/**

--- a/libs/apps/uesio/appkit/bundle/files/emailtemplates/templates/confirmemail.html
+++ b/libs/apps/uesio/appkit/bundle/files/emailtemplates/templates/confirmemail.html
@@ -146,13 +146,11 @@
                       "
                       target="_blank"
                       ><span
-                        ><!--[if mso
-                          ]><i
+                        ><!--[if mso]><i
                             style="mso-font-width: 450%; mso-text-raise: 18"
                             hidden
                             >&#8202;&#8202;</i
-                          ><!
-                        [endif]--></span
+                          ><![endif]--></span
                       ><span
                         style="
                           max-width: 100%;
@@ -163,11 +161,9 @@
                         "
                         >Confirm Email</span
                       ><span
-                        ><!--[if mso
-                          ]><i style="mso-font-width: 450%" hidden
+                        ><!--[if mso]><i style="mso-font-width: 450%" hidden
                             >&#8202;&#8202;&#8203;</i
-                          ><!
-                        [endif]--></span
+                          ><![endif]--></span
                       ></a
                     >
                   </td>

--- a/libs/apps/uesio/appkit/bundle/files/emailtemplates/templates/createlogin.html
+++ b/libs/apps/uesio/appkit/bundle/files/emailtemplates/templates/createlogin.html
@@ -146,13 +146,11 @@
                       "
                       target="_blank"
                       ><span
-                        ><!--[if mso
-                          ]><i
+                        ><!--[if mso]><i
                             style="mso-font-width: 450%; mso-text-raise: 18"
                             hidden
                             >&#8202;&#8202;</i
-                          ><!
-                        [endif]--></span
+                          ><![endif]--></span
                       ><span
                         style="
                           max-width: 100%;
@@ -163,11 +161,9 @@
                         "
                         >Set Password</span
                       ><span
-                        ><!--[if mso
-                          ]><i style="mso-font-width: 450%" hidden
+                        ><!--[if mso]><i style="mso-font-width: 450%" hidden
                             >&#8202;&#8202;&#8203;</i
-                          ><!
-                        [endif]--></span
+                          ><![endif]--></span
                       ></a
                     >
                   </td>

--- a/libs/apps/uesio/appkit/bundle/files/emailtemplates/templates/resetpassword.html
+++ b/libs/apps/uesio/appkit/bundle/files/emailtemplates/templates/resetpassword.html
@@ -146,13 +146,11 @@
                       "
                       target="_blank"
                       ><span
-                        ><!--[if mso
-                          ]><i
+                        ><!--[if mso]><i
                             style="mso-font-width: 450%; mso-text-raise: 18"
                             hidden
                             >&#8202;&#8202;</i
-                          ><!
-                        [endif]--></span
+                          ><![endif]--></span
                       ><span
                         style="
                           max-width: 100%;
@@ -163,11 +161,9 @@
                         "
                         >Reset Password</span
                       ><span
-                        ><!--[if mso
-                          ]><i style="mso-font-width: 450%" hidden
+                        ><!--[if mso]><i style="mso-font-width: 450%" hidden
                             >&#8202;&#8202;&#8203;</i
-                          ><!
-                        [endif]--></span
+                          ><![endif]--></span
                       ></a
                     >
                   </td>


### PR DESCRIPTION
# What does this PR do?

This PR fixes the truncated emails in Outlook Desktop.  It does not address the display/formatting issues generally in Outlook desktop or other email clients (e.g., dark mode, formatting, etc.) covered in #4558.
 
Resolves #4557

# Testing

Tested all three email templates locally and all render with full text and all integration & e2e tests pass.
