### PR TITLE
chore: restrict latest tag to v#.#.# tags only

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -63,7 +63,10 @@ jobs:
 
           echo "Pushing tag $GHCR_IMAGE_TAG_BASE to Github Container Registry..."=
           docker tag $ECR_SHA_TAG $GHCR_IMAGE_TAG_BASE:$RELEASE_TAG
-          docker tag $ECR_SHA_TAG $GHCR_IMAGE_TAG_BASE:latest
+          # Only tag latest if v#.#.# (e.g., not a pre-release/beta/etc.)
+          if [[ "$RELEASE_TAG" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+            docker tag $ECR_SHA_TAG $GHCR_IMAGE_TAG_BASE:latest
+          fi
           docker push --all-tags $GHCR_IMAGE_TAG_BASE
 
   cli_release_artifacts:


### PR DESCRIPTION
# What does this PR do?

Only tag GHCR image with "latest" when tag is v#.#.# - for example, do not tag it "latest" when its a pre-release or manual workflow.

# Testing

workflow itself will be the test.
