### PR TITLE
use new appkit note component

### DIFF
--- a/libs/apps/uesio/appkit/bundle/components/note.yaml
+++ b/libs/apps/uesio/appkit/bundle/components/note.yaml
@@ -1,0 +1,38 @@
+name: note
+category: LAYOUT
+type: DECLARATIVE
+slots:
+  - name: extra
+    label: Extra
+properties:
+  - type: TEXT
+    name: text
+    label: Text Content
+definition:
+  - uesio/io.box:
+      uesio.variant: uesio/appkit.note
+      uesio.styleTokens:
+        root:
+          - $Region{root}
+      components:
+        - uesio/io.text:
+            uesio.styleTokens:
+              root:
+                - $Region{text}
+            text: $Prop{text}
+        - uesio/io.box:
+            uesio.display:
+              - type: hasValue
+                value: $Prop{extra}
+            uesio.styleTokens:
+              root:
+                - $Region{extra}
+            components:
+              - $Slot{extra}
+title: Note
+discoverable: true
+description: Display a note or help text to the user.
+sections:
+  - type: HOME
+    properties:
+  - type: DISPLAY

--- a/libs/apps/uesio/appkit/bundle/views/login.yaml
+++ b/libs/apps/uesio/appkit/bundle/views/login.yaml
@@ -20,14 +20,11 @@ definition:
     - uesio/appkit.splash:
         content:
           - $Slot{logo}
-          - uesio/io.box:
+          - uesio/appkit.note:
               uesio.display:
                 - type: paramIsSet
                   param: expired
-              uesio.variant: uesio/appkit.note
-              components:
-                - uesio/io.text:
-                    text: $Label{uesio/core.session_expiration_msg}
+              text: $Label{uesio/core.session_expiration_msg}
           - uesio/appkit.login_mock:
           - uesio/appkit.login_platform:
           - uesio/appkit.login_google:

--- a/libs/apps/uesio/studio/bundle/components/section_app_access.yaml
+++ b/libs/apps/uesio/studio/bundle/components/section_app_access.yaml
@@ -14,11 +14,8 @@ definition:
                   fieldId: uesio/studio.public
                   uesio.id: new-app-public
             note:
-              - uesio/io.box:
-                  uesio.variant: uesio/appkit.note
-                  components:
-                    - uesio/io.text:
-                        text: "This determines whether other apps can see this app. (Only select this box if you plan on publishing your app on the bundle store.)"
+              - uesio/appkit.note:
+                  text: "This determines whether other apps can see this app. (Only select this box if you plan on publishing your app on the bundle store.)"
 title: App Access Section
 discoverable: false
 description: App Access Section

--- a/libs/apps/uesio/studio/bundle/components/section_app_icon_color.yaml
+++ b/libs/apps/uesio/studio/bundle/components/section_app_icon_color.yaml
@@ -16,11 +16,8 @@ definition:
                   fieldId: uesio/studio.icon
                   colorFieldId: uesio/studio.color
             note:
-              - uesio/io.box:
-                  uesio.variant: uesio/appkit.note
-                  components:
-                    - uesio/io.text:
-                        text: Select a color and icon for your app. These settings will help you quickly recognize your app when you are working with it. (You can change these settings later.)
+              - uesio/appkit.note:
+                  text: Select a color and icon for your app. These settings will help you quickly recognize your app when you are working with it. (You can change these settings later.)
 title: App Icon and Color
 discoverable: false
 description: App Icon and Color

--- a/libs/apps/uesio/studio/bundle/components/section_app_name_desc.yaml
+++ b/libs/apps/uesio/studio/bundle/components/section_app_name_desc.yaml
@@ -17,11 +17,8 @@ definition:
                   fieldId: uesio/studio.description
                   uesio.id: new-app-description
             note:
-              - uesio/io.box:
-                  uesio.variant: uesio/appkit.note
-                  components:
-                    - uesio/io.text:
-                        text: "Note: Your app name must contain only lowercase characters a-z, the underscore character, or the numerals 0-9. The app description is optional."
+              - uesio/appkit.note:
+                  text: "Note: Your app name must contain only lowercase characters a-z, the underscore character, or the numerals 0-9. The app description is optional."
 title: App Name and Description
 discoverable: false
 description: App Name and Description

--- a/libs/apps/uesio/studio/bundle/components/section_app_owner.yaml
+++ b/libs/apps/uesio/studio/bundle/components/section_app_owner.yaml
@@ -16,11 +16,8 @@ definition:
                   reference:
                     requirewriteaccess: true
             note:
-              - uesio/io.box:
-                  uesio.variant: uesio/appkit.note
-                  components:
-                    - uesio/io.text:
-                        text: Choose who will own this app. If this is a personal app you can leave yourself as the owner. If you are a member of an organization, you can also make that organization the owner of the app.
+              - uesio/appkit.note:
+                  text: Choose who will own this app. If this is a personal app you can leave yourself as the owner. If you are a member of an organization, you can also make that organization the owner of the app.
 title: App Owner Section
 discoverable: false
 description: App Owner Section

--- a/libs/apps/uesio/studio/bundle/views/admin.yaml
+++ b/libs/apps/uesio/studio/bundle/views/admin.yaml
@@ -23,8 +23,5 @@ definition:
           - uesio/io.box:
               uesio.variant: uesio/appkit.primarysection
               components:
-                - uesio/io.box:
-                    uesio.variant: uesio/appkit.note
-                    components:
-                      - uesio/io.text:
-                          text: This is where you manage your ues.io instance. More features are coming here soon.
+                - uesio/appkit.note:
+                    text: This is where you manage your ues.io instance. More features are coming here soon.

--- a/libs/apps/uesio/studio/bundle/views/app_new.yaml
+++ b/libs/apps/uesio/studio/bundle/views/app_new.yaml
@@ -55,14 +55,11 @@ definition:
                             - signal: route/NAVIGATE
                               path: home
               content:
-                - uesio/io.box:
-                    uesio.variant: uesio/appkit.note
-                    components:
-                      - uesio/io.text:
-                          text: |
-                            Let's create a new app!
+                - uesio/appkit.note:
+                    text: |
+                      Let's create a new app!
 
-                            In ues.io, an app is the starting place for everything you will build. An app can have many versions and improve and change over time.
+                      In ues.io, an app is the starting place for everything you will build. An app can have many versions and improve and change over time.
               footer:
                 - uesio/core.view:
                     view: profiletag
@@ -141,11 +138,8 @@ definition:
                                                 field: uesio/studio.starter_template
                                                 value: ""
                                 note:
-                                  - uesio/io.box:
-                                      uesio.variant: uesio/appkit.note
-                                      components:
-                                        - uesio/io.text:
-                                            text: Get started quickly with a starter template. (Using a starter template is recommended for new users.)
+                                  - uesio/appkit.note:
+                                      text: Get started quickly with a starter template. (Using a starter template is recommended for new users.)
                       - uesio/io.box:
                           uesio.variant: uesio/appkit.section
                           uesio.display:

--- a/libs/apps/uesio/studio/bundle/views/apppublish.yaml
+++ b/libs/apps/uesio/studio/bundle/views/apppublish.yaml
@@ -185,21 +185,15 @@ definition:
                                   - type: wireHasNoRecords
                                     wire: bundles
                                 components:
-                                  - uesio/io.box:
-                                      uesio.variant: uesio/appkit.note
-                                      components:
-                                        - uesio/io.text:
-                                            text: It seems that you don't have any bundles yet, try creating one and then return to this page.
+                                  - uesio/appkit.note:
+                                      text: It seems that you don't have any bundles yet, try creating one and then return to this page.
                             - uesio/io.box:
                                 uesio.display:
                                   - type: wireHasRecords
                                     wire: bundles
                                 components:
-                                  - uesio/io.box:
-                                      uesio.variant: uesio/appkit.note
-                                      components:
-                                        - uesio/io.text:
-                                            text: Welcome! Now that you have your application $Param{app} ready, it's time to share it with the world!
+                                  - uesio/appkit.note:
+                                      text: Welcome! Now that you have your application $Param{app} ready, it's time to share it with the world!
                                   - uesio/io.button:
                                       uesio.styleTokens:
                                         root:

--- a/libs/apps/uesio/studio/bundle/views/homeleftnav.yaml
+++ b/libs/apps/uesio/studio/bundle/views/homeleftnav.yaml
@@ -129,8 +129,7 @@ definition:
                                           collection: uesio/studio.app
                                           viewtype: createnew
                     content:
-                      - uesio/io.box:
-                          uesio.variant: uesio/appkit.note
+                      - uesio/appkit.note:
                           uesio.display:
                             - type: wireHasNoRecords
                               wire: apps
@@ -138,9 +137,8 @@ definition:
                               wire: apps
                             - type: wireIsNotLoading
                               wire: apps
-                          components:
-                            - uesio/io.text:
-                                text: Welcome to the ues.io studio! Create an app to get started.
+                          text: Welcome to the ues.io studio! Create an app to get started.
+                          extra:
                             - uesio/io.button:
                                 uesio.variant: uesio/studio.navcta
                                 icon: add

--- a/libs/apps/uesio/studio/bundle/views/login.yaml
+++ b/libs/apps/uesio/studio/bundle/views/login.yaml
@@ -5,6 +5,12 @@ definition:
     - uesio/core.view:
         view: uesio/appkit.login
         uesio.id: login
+        params:
+          expired: $Param{expired}
         slots:
           splash:
             - uesio/studio.splash:
+  params:
+    expired:
+      type: CHECKBOX
+      required: false

--- a/libs/apps/uesio/studio/bundle/views/signup.yaml
+++ b/libs/apps/uesio/studio/bundle/views/signup.yaml
@@ -69,14 +69,11 @@ definition:
                       - uesio/io.field:
                           fieldId: username
                           label: Pick a username
-                      - uesio/io.box:
-                          uesio.variant: uesio/appkit.note
+                      - uesio/appkit.note:
                           uesio.styleTokens:
                             root:
                               - mb-4
-                          components:
-                            - uesio/io.text:
-                                text: "Your username must contain only lowercase characters a-z, the underscore character, or the numerals 0-9."
+                          text: "Your username must contain only lowercase characters a-z, the underscore character, or the numerals 0-9."
                       - uesio/io.button:
                           uesio.variant: uesio/appkit.primary
                           text: Check Availability

--- a/libs/apps/uesio/studio/bundle/views/signuplanding.yaml
+++ b/libs/apps/uesio/studio/bundle/views/signuplanding.yaml
@@ -25,11 +25,8 @@ definition:
                         - border-b-1
                         - border-slate-200
                         - pb-4
-                - uesio/io.box:
-                    uesio.variant: uesio/appkit.note
-                    components:
-                      - uesio/io.text:
-                          text: "Check your email for a confirmation link. Once you've confirmed your email, you'll be logged in automatically."
+                - uesio/appkit.note:
+                    text: "Check your email for a confirmation link. Once you've confirmed your email, you'll be logged in automatically."
                 - uesio/io.grid:
                     uesio.styleTokens:
                       root:

--- a/libs/apps/uesio/studio/bundle/views/site_new.yaml
+++ b/libs/apps/uesio/studio/bundle/views/site_new.yaml
@@ -60,14 +60,11 @@ definition:
                             - signal: route/NAVIGATE
                               path: home
               content:
-                - uesio/io.box:
-                    uesio.variant: uesio/appkit.note
-                    components:
-                      - uesio/io.text:
-                          text: |
-                            Let's create a new site!
+                - uesio/appkit.note:
+                    text: |
+                      Let's create a new site!
 
-                            Publish your app to users with sites. Each site has completely separate users and data and is associated with a specific version of your app.
+                      Publish your app to users with sites. Each site has completely separate users and data and is associated with a specific version of your app.
               footer:
                 - uesio/core.view:
                     view: profiletag
@@ -107,11 +104,8 @@ definition:
                                       fieldId: uesio/studio.description
                                       uesio.id: workspace-description
                                 note:
-                                  - uesio/io.box:
-                                      uesio.variant: uesio/appkit.note
-                                      components:
-                                        - uesio/io.text:
-                                            text: "Note: Your site name must contain only lowercase characters a-z, the underscore character, or the numerals 0-9. The site description is optional."
+                                  - uesio/appkit.note:
+                                      text: "Note: Your site name must contain only lowercase characters a-z, the underscore character, or the numerals 0-9. The site description is optional."
                             - uesio/io.titlebar:
                                 title: Source Bundle
                                 uesio.variant: uesio/appkit.sub
@@ -135,8 +129,5 @@ definition:
                                           - field: uesio/studio.app
                                             value: ${uesio/studio.app->uesio/core.id}
                                 note:
-                                  - uesio/io.box:
-                                      uesio.variant: uesio/appkit.note
-                                      components:
-                                        - uesio/io.text:
-                                            text: "Pick the version of your app you want this site to use. You can change this later easily by upgrading or rolling back to a different version."
+                                  - uesio/appkit.note:
+                                      text: "Pick the version of your app you want this site to use. You can change this later easily by upgrading or rolling back to a different version."

--- a/libs/apps/uesio/studio/bundle/views/user.yaml
+++ b/libs/apps/uesio/studio/bundle/views/user.yaml
@@ -509,15 +509,12 @@ definition:
                     - type: hasNoValue
                       value: ${value}
                   fieldId: name
-              - uesio/io.box:
-                  uesio.variant: uesio/appkit.note
+              - uesio/appkit.note:
                   uesio.display:
                     - type: hasValue
                       value: ${value}
-                  components:
-                    - uesio/io.text:
-                        text: Your api key has been generated. You will not be shown this key again. Keep it secret, keep it safe!
-                        element: div
+                  text: Your api key has been generated. You will not be shown this key again. Keep it secret, keep it safe!
+                  extra:
                     - uesio/io.text:
                         uesio.styleTokens:
                           root:
@@ -529,6 +526,7 @@ definition:
                             - rounded-md
                             - text-[8pt]
                             - text-center
+                        element: div
                         text: ${value}
       actions:
         - uesio/io.item:

--- a/libs/apps/uesio/studio/bundle/views/workspace_new.yaml
+++ b/libs/apps/uesio/studio/bundle/views/workspace_new.yaml
@@ -57,16 +57,13 @@ definition:
                             - signal: route/NAVIGATE
                               path: app/${uesio/core.uniquekey}
               content:
-                - uesio/io.box:
-                    uesio.variant: uesio/appkit.note
-                    components:
-                      - uesio/io.text:
-                          text: |
-                            Let's create a new workspace!
+                - uesio/appkit.note:
+                    text: |
+                      Let's create a new workspace!
 
-                            Workspaces allow you to make changes to your app without affecting your production sites.
+                      Workspaces allow you to make changes to your app without affecting your production sites.
 
-                            For individual builders and small teams, one workspace, (usually called "dev"), is all you'll need to start building. For larger teams, you might want to have a workspace per developer or per feature. You can think of them like branches in git.
+                      For individual builders and small teams, one workspace, (usually called "dev"), is all you'll need to start building. For larger teams, you might want to have a workspace per developer or per feature. You can think of them like branches in git.
               footer:
                 - uesio/core.view:
                     view: profiletag
@@ -106,11 +103,8 @@ definition:
                                       fieldId: uesio/studio.description
                                       uesio.id: workspace-description
                                 note:
-                                  - uesio/io.box:
-                                      uesio.variant: uesio/appkit.note
-                                      components:
-                                        - uesio/io.text:
-                                            text: "Note: Your workspace name must contain only lowercase characters a-z, the underscore character, or the numerals 0-9. The workspace description is optional."
+                                  - uesio/appkit.note:
+                                      text: "Note: Your workspace name must contain only lowercase characters a-z, the underscore character, or the numerals 0-9. The workspace description is optional."
                             - uesio/io.titlebar:
                                 title: Workspace Clone Settings
                                 uesio.variant: uesio/appkit.sub
@@ -154,11 +148,8 @@ definition:
                                                 field: uesio/studio.clonefrombundle
                                                 value: true
                                 note:
-                                  - uesio/io.box:
-                                      uesio.variant: uesio/appkit.note
-                                      components:
-                                        - uesio/io.text:
-                                            text: If you've already created bundles for this app, you can use one of those a starting point.
+                                  - uesio/appkit.note:
+                                      text: If you've already created bundles for this app, you can use one of those a starting point.
                             - uesio/io.box:
                                 uesio.display:
                                   - type: hasValue


### PR DESCRIPTION
# What does this PR do?

Adds a declarative component to appkit called `uesio/appkit.note`. We'll use this throughout the studio to add helpful notes.

In a subsequent PR, I'll add the ability to add a title to the note and to make it collapsible.