### PR TITLE
Treat if merge with false string as false

### DIFF
--- a/libs/ui/src/context/merge.spec.ts
+++ b/libs/ui/src/context/merge.spec.ts
@@ -563,6 +563,51 @@ const mergeFormulaTestCases: MergeWithContextTestCase[] = [
   },
 ]
 
+const mergeIfTestCases: MergeWithContextTestCase[] = [
+  {
+    name: "simple if statement true",
+    context: new Context(),
+    input: "$If{[true][a][b]}",
+    expected: "a",
+  },
+  {
+    name: "simple if statement false",
+    context: new Context(),
+    input: "$If{[false][a][b]}",
+    expected: "b",
+  },
+  {
+    name: "if with context value present",
+    context: new Context().addRecordDataFrame({
+      foo: "A value",
+    }),
+    input: "$If{[${foo}][a][b]}",
+    expected: "a",
+  },
+  {
+    name: "if with context value empty string",
+    context: new Context().addRecordDataFrame({
+      foo: "",
+    }),
+    input: "$If{[${foo}][a][b]}",
+    expected: "b",
+  },
+  {
+    name: "if with context value missing",
+    context: new Context().addRecordDataFrame({}),
+    input: "$If{[${foo}][a][b]}",
+    expected: "b",
+  },
+  {
+    name: "if with context value false string",
+    context: new Context().addRecordDataFrame({
+      foo: "false",
+    }),
+    input: "$If{[${foo}][a][b]}",
+    expected: "b",
+  },
+]
+
 describe("merge", () => {
   describe("$SignalOutput context", () => {
     signalOutputMergeTestCases.forEach((tc) => {
@@ -674,6 +719,14 @@ describe("merge", () => {
 
   describe("mergeFormula", () => {
     mergeFormulaTestCases.forEach((tc) => {
+      test(tc.name, () => {
+        expect(tc.context.merge(tc.input, tc.options)).toEqual(tc.expected)
+      })
+    })
+  })
+
+  describe("mergeIf", () => {
+    mergeIfTestCases.forEach((tc) => {
       test(tc.name, () => {
         expect(tc.context.merge(tc.input, tc.options)).toEqual(tc.expected)
       })

--- a/libs/ui/src/context/merge.ts
+++ b/libs/ui/src/context/merge.ts
@@ -250,7 +250,8 @@ const handlers: Record<MergeType, MergeHandler> = {
     } catch {
       throw InvalidIfMergeMsg
     }
-    return context.merge(parts[0])
+    const conditionResult = context.merge(parts[0])
+    return conditionResult && conditionResult !== "false"
       ? context.merge(parts[1])
       : context.merge(parts[2])
   },


### PR DESCRIPTION
# What does this PR do?

We have an `$If{}` merge that accepts a three-part value. First a condition, and then an if_true_merge and finally, and if_false_merge.

Since we merge into template strings in multiple stages, merges in the condition could result in the string "false". These conditions should still trigger the "false" condition, not the "true" condition.

Example Merge:

`$If{[$Prop{collapsed}][trueValue][falseValue]}`

If `$Prop{collapsed}` resolves to the string "false" we want the falseValue to be the final result of the if merge.