### PR TITLE
Make appkit note component collapsible

### DIFF
--- a/libs/apps/uesio/appkit/bundle/components/layout_detail_split.yaml
+++ b/libs/apps/uesio/appkit/bundle/components/layout_detail_split.yaml
@@ -6,19 +6,21 @@ slots:
   - name: left
 definition:
   - uesio/io.grid:
-      uesio.variant: uesio/io.three_columns
       uesio.styleTokens:
         root:
+          - grid-cols-1
+          - lg:grid-cols-3
+          - xl:grid-cols-4
           - gap-0
-          - h-screen
+          - h-full
           - overflow-auto
       items:
         - uesio/io.box:
             uesio.styleTokens:
               root:
-                - col-span-2
+                - lg:col-span-2
+                - xl:col-span-3
                 - "[container-type:inline-size]"
-                - pb-40
             components:
               - $Slot{main}
         - uesio/io.box:

--- a/libs/apps/uesio/appkit/bundle/components/note.yaml
+++ b/libs/apps/uesio/appkit/bundle/components/note.yaml
@@ -17,6 +17,10 @@ properties:
   - type: CHECKBOX
     name: collapsed
     label: Start Collapsed
+  - type: TEXT
+    name: icon
+    label: Icon
+    defaultValue: help
 definition:
   - uesio/io.box:
       uesio.variant: uesio/appkit.note
@@ -39,6 +43,13 @@ definition:
               title:
                 - font-normal
             uesio.variant: uesio/appkit.item
+            avatar:
+              - uesio/io.text:
+                  uesio.styleTokens:
+                    root:
+                      - text-lg
+                  uesio.variant: uesio/io.iconoutline
+                  text: $Prop{icon}
         - uesio/io.text:
             uesio.styleTokens:
               root:
@@ -61,18 +72,28 @@ definition:
       uesio.styleTokens:
         root:
           - $Region{root}
+          - p-0
       components:
         - uesio/io.accordion:
+            avataricon: $Prop{icon}
+            avatariconfill: false
             uesio.styleTokens:
               content:
-                - mt-4
+                - px-4
+                - pb-4
               icon:
                 - bg-primary-200/60
                 - rounded-full
                 - leading-none
                 - p-1
+              titlebar:
+                - p-4
               titlebarTitle:
                 - font-normal
+              titlebarAvatar:
+                - leading-none
+              avataricon:
+                - text-lg
             titlebarVariant: uesio/appkit.item
             initialItem: $If{[$Prop{collapsed}][][note]}
             items:

--- a/libs/apps/uesio/appkit/bundle/components/note.yaml
+++ b/libs/apps/uesio/appkit/bundle/components/note.yaml
@@ -8,13 +8,37 @@ properties:
   - type: TEXT
     name: text
     label: Text Content
+  - type: TEXT
+    name: title
+    label: Note Title
+  - type: CHECKBOX
+    name: collapsible
+    label: Is Collapsible
+  - type: CHECKBOX
+    name: collapsed
+    label: Start Collapsed
 definition:
   - uesio/io.box:
       uesio.variant: uesio/appkit.note
+      uesio.display:
+        - type: hasNoValue
+          value: $Prop{collapsible}
       uesio.styleTokens:
         root:
           - $Region{root}
       components:
+        - uesio/io.titlebar:
+            uesio.display:
+              - type: hasValue
+                value: $Prop{title}
+            title: $Prop{title}
+            uesio.styleTokens:
+              root:
+                - mt-1
+                - mb-2
+              title:
+                - font-normal
+            uesio.variant: uesio/appkit.item
         - uesio/io.text:
             uesio.styleTokens:
               root:
@@ -29,6 +53,47 @@ definition:
                 - $Region{extra}
             components:
               - $Slot{extra}
+  - uesio/io.box:
+      uesio.variant: uesio/appkit.note
+      uesio.display:
+        - type: hasValue
+          value: $Prop{collapsible}
+      uesio.styleTokens:
+        root:
+          - $Region{root}
+      components:
+        - uesio/io.accordion:
+            uesio.styleTokens:
+              content:
+                - mt-4
+              icon:
+                - bg-primary-200/60
+                - rounded-full
+                - leading-none
+                - p-1
+              titlebarTitle:
+                - font-normal
+            titlebarVariant: uesio/appkit.item
+            initialItem: $If{[$Prop{collapsed}][][note]}
+            items:
+              - id: note
+                title: $Prop{title}
+                components:
+                  - uesio/io.text:
+                      uesio.styleTokens:
+                        root:
+                          - $Region{text}
+                      text: $Prop{text}
+                  - uesio/io.box:
+                      uesio.display:
+                        - type: hasValue
+                          value: $Prop{extra}
+                      uesio.styleTokens:
+                        root:
+                          - $Region{extra}
+                      components:
+                        - $Slot{extra}
+
 title: Note
 discoverable: true
 description: Display a note or help text to the user.

--- a/libs/apps/uesio/io/bundle/componentpacks/main/src/components/accordion/accordion.tsx
+++ b/libs/apps/uesio/io/bundle/componentpacks/main/src/components/accordion/accordion.tsx
@@ -16,8 +16,11 @@ type AccordionDefinition = {
   items?: AccordionItemDefinition[]
   titlebarVariant?: metadata.MetadataKey
   expandicon: string
-  collapseicon: string
+  collapseicon?: string
+  collapseiconfill?: boolean
   initialItem?: string
+  avataricon?: string
+  avatariconfill?: boolean
 }
 
 interface SelectItemSignal extends signal.SignalDefinition {
@@ -34,9 +37,11 @@ const StyleDefaults = Object.freeze({
   root: [],
   content: [],
   icon: [],
+  avataricon: [],
   expanded: [],
   titlebar: [],
   titlebarTitle: [],
+  titlebarAvatar: [],
   titlebarContent: [],
   titlebarContentExpanded: [],
 })
@@ -48,6 +53,9 @@ const Accordion: definition.UC<AccordionDefinition> = (props) => {
     titlebarVariant,
     expandicon = "expand_more",
     collapseicon = "expand_less",
+    collapseiconfill,
+    avataricon,
+    avatariconfill,
     initialItem,
   } = definition
   const classes = styles.useStyleTokens(StyleDefaults, props)
@@ -95,6 +103,7 @@ const Accordion: definition.UC<AccordionDefinition> = (props) => {
                   expanded && classes.titlebarContentExpanded,
                 ),
                 title: classes.titlebarTitle,
+                avatar: classes.titlebarAvatar,
               }}
               variant={titlebarVariant}
               onClick={() => setSelectedItem(expanded ? "" : item.id)}
@@ -103,7 +112,18 @@ const Accordion: definition.UC<AccordionDefinition> = (props) => {
                   className={classes.icon}
                   context={context}
                   icon={expanded === true ? collapseicon : expandicon}
+                  fill={collapseiconfill}
                 />
+              }
+              avatar={
+                avataricon && (
+                  <IconButton
+                    className={classes.avataricon}
+                    context={context}
+                    icon={avataricon}
+                    fill={avatariconfill}
+                  />
+                )
               }
             />
             <ExpandPanel

--- a/libs/apps/uesio/studio/bundle/views/app.yaml
+++ b/libs/apps/uesio/studio/bundle/views/app.yaml
@@ -153,7 +153,7 @@ definition:
                                       uesio.styleTokens:
                                         root:
                                           - mt-8
-                                      title: Workspaces Help
+                                      title: What is a workspace?
                                       collapsible: true
                                       collapsed: true
                                       text: |
@@ -223,7 +223,7 @@ definition:
                                       uesio.styleTokens:
                                         root:
                                           - mt-8
-                                      title: Sites Help
+                                      title: What is a site?
                                       collapsible: true
                                       collapsed: true
                                       text: Sites are how we publish our app to users. Each site is a separate "tenant" of the ues.io platform. That means any data in on site can never be accessed from another site. You may want multiple sites for different stages of the application lifecycle, like "prod", "uat", "dev", etc., but you can also use sites for different customers of your app. You could have one site for Customer A, and another site for Customer B.

--- a/libs/apps/uesio/studio/bundle/views/app.yaml
+++ b/libs/apps/uesio/studio/bundle/views/app.yaml
@@ -149,6 +149,17 @@ definition:
                                             title: No Workspaces
                                             subtitle: You haven't created any yet.
                                             icon: handyman
+                                  - uesio/appkit.note:
+                                      uesio.styleTokens:
+                                        root:
+                                          - mt-8
+                                      title: Workspaces Help
+                                      collapsible: true
+                                      collapsed: true
+                                      text: |
+                                        A workspace is a named environment where you can make changes to an app's metadata. Workspaces are created from the app home screen, and can be either long-lived or transient.
+
+                                        For those familiar with Git, a workspace is similar to a Git branch. You could just have one workspace and do all your work there, or you could have one long-lived "main" workspace and have each team member do all of their work on short-lived "feature" workspaces, and merge changes into the "main" workspace with Git and a continuous-integration process.
                             - uesio/io.griditem:
                                 components:
                                   - uesio/io.titlebar:
@@ -208,3 +219,11 @@ definition:
                                             title: No Sites
                                             subtitle: You haven't created any yet.
                                             icon: public
+                                  - uesio/appkit.note:
+                                      uesio.styleTokens:
+                                        root:
+                                          - mt-8
+                                      title: Sites Help
+                                      collapsible: true
+                                      collapsed: true
+                                      text: Sites are how we publish our app to users. Each site is a separate "tenant" of the ues.io platform. That means any data in on site can never be accessed from another site. You may want multiple sites for different stages of the application lifecycle, like "prod", "uat", "dev", etc., but you can also use sites for different customers of your app. You could have one site for Customer A, and another site for Customer B.

--- a/libs/apps/uesio/studio/bundle/views/app.yaml
+++ b/libs/apps/uesio/studio/bundle/views/app.yaml
@@ -66,164 +66,175 @@ definition:
                 app: $Param{app}
                 selected: home
         content:
-          - uesio/io.box:
-              uesio.display:
-                - type: wireHasNoRecords
-                  wire: apps
-              components:
-                - uesio/io.titlebar:
-                    uesio.variant: uesio/appkit.main
-                    title: App not found
-                    subtitle: The app you are looking for either does not exist, or you do not have access to it.
+          - uesio/appkit.layout_detail_split:
+              main:
                 - uesio/io.box:
-                    uesio.variant: uesio/appkit.primarysection
-                    components:
-                      - uesio/io.button:
-                          text: Return to Studio home
-                          uesio.variant: uesio/appkit.primary
-                          signals:
-                            - signal: "route/NAVIGATE"
-                              path: "home"
-          - uesio/io.box:
-              uesio.display:
-                - type: wireHasRecords
-                  wire: apps
-              components:
-                - uesio/io.list:
-                    wire: apps
+                    uesio.display:
+                      - type: wireHasNoRecords
+                        wire: apps
                     components:
                       - uesio/io.titlebar:
                           uesio.variant: uesio/appkit.main
-                          uesio.styleTokens:
-                            avatar:
-                              - bg-[${uesio/studio.color}]
-                          title: ${uesio/studio.name}
-                          subtitle: ${uesio/studio.description}
-                          avatar:
-                            - uesio/io.text:
-                                uesio.variant: uesio/io.icon
-                                text: ${uesio/studio.icon}
-                                color: white
+                          title: App not found
+                          subtitle: The app you are looking for either does not exist, or you do not have access to it.
+                      - uesio/io.box:
+                          uesio.variant: uesio/appkit.primarysection
+                          components:
+                            - uesio/io.button:
+                                text: Return to Studio home
+                                uesio.variant: uesio/appkit.primary
+                                signals:
+                                  - signal: "route/NAVIGATE"
+                                    path: "home"
                 - uesio/io.box:
-                    uesio.variant: uesio/appkit.primarysection
+                    uesio.display:
+                      - type: wireHasRecords
+                        wire: apps
                     components:
-                      - uesio/io.grid:
-                          uesio.variant: uesio/io.two_columns
+                      - uesio/io.list:
+                          wire: apps
+                          components:
+                            - uesio/io.titlebar:
+                                uesio.variant: uesio/appkit.main
+                                uesio.styleTokens:
+                                  avatar:
+                                    - bg-[${uesio/studio.color}]
+                                title: ${uesio/studio.name}
+                                subtitle: ${uesio/studio.description}
+                                avatar:
+                                  - uesio/io.text:
+                                      uesio.variant: uesio/io.icon
+                                      text: ${uesio/studio.icon}
+                                      color: white
+                      - uesio/io.box:
+                          uesio.variant: uesio/appkit.primarysection
+                          components:
+                            - uesio/io.grid:
+                                uesio.variant: uesio/io.two_columns
+                                uesio.styleTokens:
+                                  root:
+                                    - gap-10
+                                items:
+                                  - uesio/io.griditem:
+                                      components:
+                                        - uesio/io.titlebar:
+                                            uesio.variant: uesio/io.section
+                                            title: Workspaces
+                                            subtitle: Make changes to your app.
+                                            actions:
+                                              - uesio/io.button:
+                                                  uesio.variant: uesio/appkit.secondary
+                                                  uesio.id: add-workspace
+                                                  text: New Workspace
+                                                  icon: add
+                                                  signals:
+                                                    - signal: route/NAVIGATE
+                                                      path: "app/$Param{app}/workspaces/new"
+                                        - uesio/io.deck:
+                                            wire: workspaces
+                                            uesio.variant: uesio/appkit.main
+                                            components:
+                                              - uesio/io.card:
+                                                  uesio.variant: uesio/appkit.main
+                                                  title: ${uesio/studio.name}
+                                                  avatar:
+                                                    - uesio/io.text:
+                                                        uesio.variant: uesio/appkit.avataricon
+                                                        text: handyman
+                                                  content:
+                                                  signals:
+                                                    - signal: "route/NAVIGATE"
+                                                      path: "app/$Param{app}/workspace/${uesio/studio.name}"
+                                            emptyState:
+                                              - uesio/io.emptystate:
+                                                  uesio.variant: uesio/studio.main
+                                                  title: No Workspaces
+                                                  subtitle: You haven't created any yet.
+                                                  icon: handyman
+                                  - uesio/io.griditem:
+                                      components:
+                                        - uesio/io.titlebar:
+                                            uesio.variant: uesio/io.section
+                                            title: Sites
+                                            subtitle: Publish your app to users.
+                                            actions:
+                                              - uesio/io.button:
+                                                  uesio.variant: uesio/appkit.secondary
+                                                  uesio.id: add-site
+                                                  text: New Site
+                                                  icon: add
+                                                  signals:
+                                                    - signal: route/NAVIGATE
+                                                      path: "app/$Param{app}/sites/new"
+                                        - uesio/io.deck:
+                                            wire: sites
+                                            uesio.styleTokens:
+                                              root:
+                                                - gap-6
+                                            components:
+                                              - uesio/io.card:
+                                                  uesio.variant: uesio/appkit.main
+                                                  title: ${uesio/studio.name}
+                                                  subtitle: v${bundle->version}
+                                                  avatar:
+                                                    - uesio/io.text:
+                                                        uesio.variant: uesio/appkit.avataricon
+                                                        text: public
+                                                  actions:
+                                                    - uesio/io.group:
+                                                        components:
+                                                          - uesio/io.text:
+                                                              uesio.styleTokens:
+                                                                root:
+                                                                  - bg-emerald-600
+                                                                  - text-white
+                                                              uesio.variant: uesio/appkit.badge
+                                                              text: Active
+                                                  content:
+                                                    - uesio/io.titlebar:
+                                                        uesio.variant: uesio/appkit.item_sub
+                                                        title: Domains
+                                                    - uesio/io.field:
+                                                        fieldId: uesio/studio.sitedomains
+                                                        labelPosition: none
+                                                        reference:
+                                                          components:
+                                                            - uesio/studio.sitedomain_link_tag:
+                                                  signals:
+                                                    - signal: "route/NAVIGATE"
+                                                      path: "app/$Param{app}/site/${uesio/studio.name}"
+                                                      preventLinkTag: true
+                                            emptyState:
+                                              - uesio/io.emptystate:
+                                                  uesio.variant: uesio/studio.main
+                                                  title: No Sites
+                                                  subtitle: You haven't created any yet.
+                                                  icon: public
+              left:
+                - uesio/io.box:
+                    components:
+                      - uesio/io.titlebar:
                           uesio.styleTokens:
                             root:
-                              - gap-10
-                          items:
-                            - uesio/io.griditem:
-                                components:
-                                  - uesio/io.titlebar:
-                                      uesio.variant: uesio/io.section
-                                      title: Workspaces
-                                      subtitle: Make changes to your app.
-                                      actions:
-                                        - uesio/io.button:
-                                            uesio.variant: uesio/appkit.secondary
-                                            uesio.id: add-workspace
-                                            text: New Workspace
-                                            icon: add
-                                            signals:
-                                              - signal: route/NAVIGATE
-                                                path: "app/$Param{app}/workspaces/new"
-                                  - uesio/io.deck:
-                                      wire: workspaces
-                                      uesio.variant: uesio/appkit.main
-                                      components:
-                                        - uesio/io.card:
-                                            uesio.variant: uesio/appkit.main
-                                            title: ${uesio/studio.name}
-                                            avatar:
-                                              - uesio/io.text:
-                                                  uesio.variant: uesio/appkit.avataricon
-                                                  text: handyman
-                                            content:
-                                            signals:
-                                              - signal: "route/NAVIGATE"
-                                                path: "app/$Param{app}/workspace/${uesio/studio.name}"
-                                      emptyState:
-                                        - uesio/io.emptystate:
-                                            uesio.variant: uesio/studio.main
-                                            title: No Workspaces
-                                            subtitle: You haven't created any yet.
-                                            icon: handyman
-                                  - uesio/appkit.note:
-                                      uesio.styleTokens:
-                                        root:
-                                          - mt-8
-                                      title: What is a workspace?
-                                      collapsible: true
-                                      collapsed: true
-                                      text: |
-                                        A workspace is a named environment where you can make changes to an app's metadata. Workspaces are created from the app home screen, and can be either long-lived or transient.
+                              - mb-4
+                          uesio.variant: uesio/appkit.sub
+                          title: Learn ues.io
+                      - uesio/appkit.note:
+                          uesio.styleTokens:
+                            root:
+                              - mb-4
+                          title: What is a workspace?
+                          collapsible: true
+                          collapsed: true
+                          text: |
+                            A workspace is a named environment where you can make changes to an app's metadata. Workspaces are created from the app home screen, and can be either long-lived or transient.
 
-                                        For those familiar with Git, a workspace is similar to a Git branch. You could just have one workspace and do all your work there, or you could have one long-lived "main" workspace and have each team member do all of their work on short-lived "feature" workspaces, and merge changes into the "main" workspace with Git and a continuous-integration process.
-                            - uesio/io.griditem:
-                                components:
-                                  - uesio/io.titlebar:
-                                      uesio.variant: uesio/io.section
-                                      title: Sites
-                                      subtitle: Publish your app to users.
-                                      actions:
-                                        - uesio/io.button:
-                                            uesio.variant: uesio/appkit.secondary
-                                            uesio.id: add-site
-                                            text: New Site
-                                            icon: add
-                                            signals:
-                                              - signal: route/NAVIGATE
-                                                path: "app/$Param{app}/sites/new"
-                                  - uesio/io.deck:
-                                      wire: sites
-                                      uesio.styleTokens:
-                                        root:
-                                          - gap-6
-                                      components:
-                                        - uesio/io.card:
-                                            uesio.variant: uesio/appkit.main
-                                            title: ${uesio/studio.name}
-                                            subtitle: v${bundle->version}
-                                            avatar:
-                                              - uesio/io.text:
-                                                  uesio.variant: uesio/appkit.avataricon
-                                                  text: public
-                                            actions:
-                                              - uesio/io.group:
-                                                  components:
-                                                    - uesio/io.text:
-                                                        uesio.styleTokens:
-                                                          root:
-                                                            - bg-emerald-600
-                                                            - text-white
-                                                        uesio.variant: uesio/appkit.badge
-                                                        text: Active
-                                            content:
-                                              - uesio/io.titlebar:
-                                                  uesio.variant: uesio/appkit.item_sub
-                                                  title: Domains
-                                              - uesio/io.field:
-                                                  fieldId: uesio/studio.sitedomains
-                                                  labelPosition: none
-                                                  reference:
-                                                    components:
-                                                      - uesio/studio.sitedomain_link_tag:
-                                            signals:
-                                              - signal: "route/NAVIGATE"
-                                                path: "app/$Param{app}/site/${uesio/studio.name}"
-                                                preventLinkTag: true
-                                      emptyState:
-                                        - uesio/io.emptystate:
-                                            uesio.variant: uesio/studio.main
-                                            title: No Sites
-                                            subtitle: You haven't created any yet.
-                                            icon: public
-                                  - uesio/appkit.note:
-                                      uesio.styleTokens:
-                                        root:
-                                          - mt-8
-                                      title: What is a site?
-                                      collapsible: true
-                                      collapsed: true
-                                      text: Sites are how we publish our app to users. Each site is a separate "tenant" of the ues.io platform. That means any data in on site can never be accessed from another site. You may want multiple sites for different stages of the application lifecycle, like "prod", "uat", "dev", etc., but you can also use sites for different customers of your app. You could have one site for Customer A, and another site for Customer B.
+                            For those familiar with Git, a workspace is similar to a Git branch. You could just have one workspace and do all your work there, or you could have one long-lived "main" workspace and have each team member do all of their work on short-lived "feature" workspaces, and merge changes into the "main" workspace with Git and a continuous-integration process.
+                      - uesio/appkit.note:
+                          uesio.styleTokens:
+                            root:
+                              - mb-4
+                          title: What is a site?
+                          collapsible: true
+                          collapsed: true
+                          text: Sites are how we publish our app to users. Each site is a separate "tenant" of the ues.io platform. That means any data in on site can never be accessed from another site. You may want multiple sites for different stages of the application lifecycle, like "prod", "uat", "dev", etc., but you can also use sites for different customers of your app. You could have one site for Customer A, and another site for Customer B.

--- a/libs/apps/uesio/studio/bundle/views/homecontent.yaml
+++ b/libs/apps/uesio/studio/bundle/views/homecontent.yaml
@@ -31,137 +31,167 @@ definition:
       batchsize: 5
   # Components are how we describe the layout of our view
   components:
-    - uesio/io.box:
-        uesio.variant: uesio/appkit.section
-        uesio.styleTokens:
-          root:
-            - overflow-hidden
-            - shadow-lg
-            - bg-white
-            - rounded-lg
-            - mb-10
-        components:
+    - uesio/appkit.layout_detail_split:
+        main:
           - uesio/io.box:
+              uesio.variant: uesio/appkit.section
               uesio.styleTokens:
                 root:
-                  - mb-0
-                  - p-32
-                  - bg-black
-                  - bg-cover
-                  - bg-[url($File{uesio/appkit.splash})]
-          - uesio/io.box:
-              uesio.styleTokens:
-                root:
-                  - p-10
-                  - text-[#FFFFFFC0]
-                  - bg-neutral-900
+                  - overflow-hidden
+                  - shadow-lg
+                  - bg-white
+                  - rounded-lg
+                  - mb-10
               components:
                 - uesio/io.box:
                     uesio.styleTokens:
                       root:
-                        - font-[Gosha]
-                        - text-5xl
-                        - mb-2
-                    components:
-                      - uesio/io.text:
-                          text: "Get started with "
-                      - uesio/io.text:
-                          color: white
-                          text: ues.io
+                        - mb-0
+                        - p-32
+                        - bg-black
+                        - bg-cover
+                        - bg-[url($File{uesio/appkit.splash})]
                 - uesio/io.box:
                     uesio.styleTokens:
                       root:
-                        - font-light
+                        - p-10
+                        - text-[#FFFFFFC0]
+                        - bg-neutral-900
                     components:
-                      - uesio/io.text:
+                      - uesio/io.box:
                           uesio.styleTokens:
                             root:
-                              - text-white
-                          text: "Build "
-                      - uesio/io.text:
-                          text: "web applications declaratively. "
-                      - uesio/io.text:
-                          uesio.styleTokens:
-                            root:
-                              - text-white
-                          text: "Reuse "
-                      - uesio/io.text:
-                          text: "components from other apps. "
-                      - uesio/io.text:
-                          uesio.styleTokens:
-                            root:
-                              - text-white
-                          text: "Iterate "
-                      - uesio/io.text:
-                          text: "quickly."
-    - uesio/io.box:
-        uesio.variant: uesio/appkit.section
-        components:
-          - uesio/io.grid:
-              uesio.variant: uesio/io.two_columns
-              uesio.styleTokens:
-                root:
-                  - gap-x-12
-              items:
-                - uesio/io.griditem:
-                    components:
-                      - uesio/io.titlebar:
-                          uesio.variant: uesio/io.section
-                          title: Latest Updates & News
-                      - uesio/io.deck:
-                          wire: blogentries
-                          mode: READ
-                          uesio.variant: uesio/appkit.main
-                          emptyState:
-                            - uesio/io.emptystate:
-                                uesio.variant: uesio/studio.main
-                                title: Such Empty
-                                subtitle: No news is good news.
-                                icon: newspaper
+                              - font-[Gosha]
+                              - text-5xl
+                              - mb-2
                           components:
-                            - uesio/io.tile:
-                                uesio.variant: uesio/appkit.card
-                                content:
-                                  - uesio/io.text:
-                                      text: ${uesio/studio.name}
-                                      element: div
-                                  - uesio/io.text:
-                                      text: ${uesio/studio.description}
-                                      uesio.variant: uesio/io.smallcontent
-                                      element: div
-                                signals:
-                                  - signal: "route/REDIRECT"
-                                    path: "https://$Site{domain}/news/${uesio/studio.slug}"
-                                    newtab: true
-                                avatar:
-                                  - uesio/io.text:
-                                      uesio.variant: uesio/appkit.avataricon
-                                      text: newspaper
-                - uesio/io.griditem:
-                    components:
-                      - uesio/io.titlebar:
-                          uesio.variant: uesio/io.section
-                          title: Recent Documentation
-                      - uesio/io.deck:
-                          wire: recentdocs
-                          mode: READ
-                          uesio.variant: uesio/appkit.main
+                            - uesio/io.text:
+                                text: "Get started with "
+                            - uesio/io.text:
+                                color: white
+                                text: ues.io
+                      - uesio/io.box:
+                          uesio.styleTokens:
+                            root:
+                              - font-light
                           components:
-                            - uesio/io.tile:
-                                uesio.variant: uesio/appkit.card
-                                content:
-                                  - uesio/io.text:
-                                      text: ${uesio/studio.name}
-                                      element: div
-                                  - uesio/io.text:
-                                      text: ${uesio/studio.description}
-                                      uesio.variant: uesio/io.smallcontent
-                                      element: div
-                                signals:
-                                  - signal: "route/REDIRECT"
-                                    path: "https://docs.$Site{domain}/${uesio/studio.slug}"
-                                    newtab: true
-                                avatar:
-                                  - uesio/io.text:
-                                      uesio.variant: uesio/appkit.avataricon
-                                      text: school
+                            - uesio/io.text:
+                                uesio.styleTokens:
+                                  root:
+                                    - text-white
+                                text: "Build "
+                            - uesio/io.text:
+                                text: "web applications declaratively. "
+                            - uesio/io.text:
+                                uesio.styleTokens:
+                                  root:
+                                    - text-white
+                                text: "Reuse "
+                            - uesio/io.text:
+                                text: "components from other apps. "
+                            - uesio/io.text:
+                                uesio.styleTokens:
+                                  root:
+                                    - text-white
+                                text: "Iterate "
+                            - uesio/io.text:
+                                text: "quickly."
+          - uesio/io.box:
+              uesio.variant: uesio/appkit.section
+              components:
+                - uesio/io.grid:
+                    uesio.variant: uesio/io.two_columns
+                    uesio.styleTokens:
+                      root:
+                        - gap-x-12
+                    items:
+                      - uesio/io.griditem:
+                          components:
+                            - uesio/io.titlebar:
+                                uesio.variant: uesio/io.section
+                                title: Latest Updates & News
+                            - uesio/io.deck:
+                                wire: blogentries
+                                mode: READ
+                                uesio.variant: uesio/appkit.main
+                                emptyState:
+                                  - uesio/io.emptystate:
+                                      uesio.variant: uesio/studio.main
+                                      title: Such Empty
+                                      subtitle: No news is good news.
+                                      icon: newspaper
+                                components:
+                                  - uesio/io.tile:
+                                      uesio.variant: uesio/appkit.card
+                                      content:
+                                        - uesio/io.text:
+                                            text: ${uesio/studio.name}
+                                            element: div
+                                        - uesio/io.text:
+                                            text: ${uesio/studio.description}
+                                            uesio.variant: uesio/io.smallcontent
+                                            element: div
+                                      signals:
+                                        - signal: "route/REDIRECT"
+                                          path: "https://$Site{domain}/news/${uesio/studio.slug}"
+                                          newtab: true
+                                      avatar:
+                                        - uesio/io.text:
+                                            uesio.variant: uesio/appkit.avataricon
+                                            text: newspaper
+                      - uesio/io.griditem:
+                          components:
+                            - uesio/io.titlebar:
+                                uesio.variant: uesio/io.section
+                                title: Recent Documentation
+                            - uesio/io.deck:
+                                wire: recentdocs
+                                mode: READ
+                                uesio.variant: uesio/appkit.main
+                                components:
+                                  - uesio/io.tile:
+                                      uesio.variant: uesio/appkit.card
+                                      content:
+                                        - uesio/io.text:
+                                            text: ${uesio/studio.name}
+                                            element: div
+                                        - uesio/io.text:
+                                            text: ${uesio/studio.description}
+                                            uesio.variant: uesio/io.smallcontent
+                                            element: div
+                                      signals:
+                                        - signal: "route/REDIRECT"
+                                          path: "https://docs.$Site{domain}/${uesio/studio.slug}"
+                                          newtab: true
+                                      avatar:
+                                        - uesio/io.text:
+                                            uesio.variant: uesio/appkit.avataricon
+                                            text: school
+        left:
+          - uesio/io.box:
+              components:
+                - uesio/io.titlebar:
+                    uesio.styleTokens:
+                      root:
+                        - mb-4
+                    uesio.variant: uesio/appkit.sub
+                    title: Learn ues.io
+                - uesio/appkit.note:
+                    uesio.styleTokens:
+                      root:
+                        - mb-4
+                    title: What is an app?
+                    collapsible: true
+                    collapsed: true
+                    text: |
+                      In ues.io, an App is a bundle of metadata items. An App could have a few metadata items, e.g. a custom component that you've created and want to share with other ues.io builders, or an App could have a lot of items that comprise what we traditionally think of as an "application", e.g. a recruiting management application or an employee portal, which each might have various collections, views, routes, and other metadata items.
+
+                      Each user (or organization) can create or own one or more apps. Apps are referred to by the combination of their name and the name of the user/orgnaization who owns the app, e.g. anna/restaurant-management, jose/animal-finder. This combination of user and app name is also sometimes referred to as a namespace.
+                - uesio/appkit.note:
+                    uesio.styleTokens:
+                      root:
+                        - mb-4
+                    title: What is an organization?
+                    collapsible: true
+                    collapsed: true
+                    text: In ues.io, an organization is just like another user who can be the "owner" of an app. However an organization cannot log in on their own. Users who are real people must log in and be associated with an organization. Apps that are part of an organization have their usage billed to that organization instead of a particular user.


### PR DESCRIPTION
# What does this PR do?

Makes the appkit note component have the `collapsible` option.


<img width="1692" alt="Screenshot 2025-02-05 at 2 57 59 PM" src="https://github.com/user-attachments/assets/4240e61d-ca45-4df1-8f7d-12ea3be5a2ce" />
