### PR TITLE
chore: modify detection of credentials to use for cypress tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -207,13 +207,9 @@ jobs:
         run: npm ci
 
       - name: Check formatting
-        env:
-          UESIO_DEV: "true"
         run: npx nx format:check --verbose
 
       - name: Lint
-        env:
-          UESIO_DEV: "true"
         run: npx nx affected -t lint --configuration=ci --parallel=5
 
   typecheck:
@@ -245,8 +241,6 @@ jobs:
         run: npm ci
 
       - name: Typecheck
-        env:
-          UESIO_DEV: "true"
         run: npx nx affected -t typecheck --configuration=ci --parallel=5
 
   update-dev-branch:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,13 +73,13 @@ jobs:
 
       - name: Build and test
         env:
-          UESIO_DEV: "true"
+          UESIO_DEV: "true" # required to ensure packui gets built
         run: npx nx affected -t build test --configuration=ci --parallel=5
 
       - name: Prep for docker image
         id: setDockerSHAs
         env:
-          UESIO_DEV: "true"
+          UESIO_DEV: "true" # required to ensure packui gets built
         run: |
           # We lint/test/build affected but in order to build image, we need to ensure everything
           # is built.  Build anything that hasn't been built yet (takes advantage of nx cache

--- a/apps/platform-e2e/cypress.config.ts
+++ b/apps/platform-e2e/cypress.config.ts
@@ -5,13 +5,8 @@ const studioBaseUrl =
   process.env.UESIO_APP_URL || `https://studio.uesio-dev.com:3000`
 const automationUsername = process.env.UESIO_AUTOMATION_USERNAME || "uesio"
 const automationPassword = process.env.UESIO_AUTOMATION_PASSWORD
-const useMockLogin = process.env.UESIO_DEV
+const useMockLogin = !automationPassword
 const inCi = process.env.CI === "true"
-
-if (!useMockLogin && !automationPassword) {
-  throw new Error("UESIO_AUTOMATION_PASSWORD was not provided")
-}
-
 export default defineConfig({
   e2e: {
     ...nxE2EPreset(__filename, {


### PR DESCRIPTION
# What does this PR do?

Ensures nx graph can be built without requiring that either `UESIO_DEV` or `UESIO_AUTOMATION_PASSWORD` is present in environment.

Did not see much of (any) reason to not default to just using Mock credentials if automation password is not supplied.  If the server is not configured to support mock auth, the tests will fail anyway.  Seems more appropriate to use mock by default unless overridden via automation environment variable values.

Resolves #4579

# Testing

ci & e2e will cover.
