### PR TITLE
Fix error message formatting in Go

### DIFF
--- a/apps/platform/pkg/bot/tsdialect/tsdialect.go
+++ b/apps/platform/pkg/bot/tsdialect/tsdialect.go
@@ -33,7 +33,7 @@ func (b *TSDialect) hydrateBot(bot *meta.Bot, session *sess.Session, connection 
 	if len(result.Errors) > 0 {
 		slog.Error(fmt.Sprintf("TS Bot %s compilation had %d errors and %d warnings\n",
 			bot.GetKey(), len(result.Errors), len(result.Warnings)))
-		return fmt.Errorf(result.Errors[0].Text)
+		return fmt.Errorf("%s", result.Errors[0].Text)
 	}
 	bot.FileContents = string(result.Code)
 	return nil

--- a/apps/platform/pkg/bulk/stringers.go
+++ b/apps/platform/pkg/bulk/stringers.go
@@ -25,7 +25,7 @@ func getStringValue(fieldMetadata *wire.FieldMetadata, value interface{}) (strin
 	case "LIST", "STRUCT", "MAP":
 		byteValue, err := json.Marshal(value)
 		if err != nil {
-			return "", fmt.Errorf("Failed to serialize: " + fieldMetadata.GetFullName() + ": " + err.Error())
+			return "", fmt.Errorf("Failed to serialize: %s: %w", fieldMetadata.GetFullName(), err)
 		}
 		return string(byteValue), nil
 	case "MULTISELECT":
@@ -36,7 +36,7 @@ func getStringValue(fieldMetadata *wire.FieldMetadata, value interface{}) (strin
 		sort.Strings(values)
 		byteValue, err := json.Marshal(values)
 		if err != nil {
-			return "", fmt.Errorf("Failed to serialize: " + fieldMetadata.GetFullName() + ": " + err.Error())
+			return "", fmt.Errorf("Failed to serialize: %s: %w", fieldMetadata.GetFullName(), err)
 		}
 		return string(byteValue), nil
 	case "TIMESTAMP":

--- a/apps/platform/pkg/cache/redis.go
+++ b/apps/platform/pkg/cache/redis.go
@@ -170,7 +170,7 @@ func deleteKeys(keys []string) error {
 	defer conn.Close()
 	_, err := conn.Do("DEL", redis.Args{}.AddFlat(keys)...)
 	if err != nil {
-		return fmt.Errorf("Error deleting cache keys from bot: " + err.Error())
+		return fmt.Errorf("Error deleting cache keys from bot: %w", err)
 	}
 	return nil
 }

--- a/apps/platform/pkg/datasource/autonumber.go
+++ b/apps/platform/pkg/datasource/autonumber.go
@@ -10,7 +10,7 @@ import (
 func getAutonumber(connection wire.Connection, collectionMetadata *wire.CollectionMetadata, session *sess.Session) (int, error) {
 	autonumber, err := connection.GetAutonumber(collectionMetadata, session)
 	if err != nil {
-		return 0, fmt.Errorf("error getting max autonumber value from database: " + err.Error())
+		return 0, fmt.Errorf("error getting max autonumber value from database: %w", err)
 	}
 	return autonumber, nil
 }

--- a/apps/platform/pkg/meta/field.go
+++ b/apps/platform/pkg/meta/field.go
@@ -174,7 +174,7 @@ func (f *Field) UnmarshalYAML(node *yaml.Node) error {
 	if fieldType == "SELECT" || fieldType == "MULTISELECT" {
 		f.SelectList, err = pickRequiredMetadataItem(node, "selectList", f.Namespace)
 		if err != nil {
-			return fmt.Errorf("Invalid selectlist metadata provided for field: " + f.GetKey() + " : Missing select list name")
+			return fmt.Errorf("Invalid selectlist metadata provided for field: %s : Missing select list name", f.GetKey())
 		}
 	}
 

--- a/apps/platform/pkg/meta/yamlnodeutils.go
+++ b/apps/platform/pkg/meta/yamlnodeutils.go
@@ -114,7 +114,7 @@ func GetMapNodeWithIndex(node *yaml.Node, key string) (*yaml.Node, int, error) {
 		}
 	}
 
-	return nil, 0, fmt.Errorf("Node not found of key: " + key)
+	return nil, 0, fmt.Errorf("Node not found of key: %s", key)
 }
 
 // Removes an entry from a map node and returns it.

--- a/apps/platform/pkg/reflecttool/get.go
+++ b/apps/platform/pkg/reflecttool/get.go
@@ -52,7 +52,7 @@ func GetField(obj interface{}, name string) (interface{}, error) {
 
 		obj, err = getFieldReflect(objValue.FieldByName(fieldName))
 		if err != nil {
-			return nil, fmt.Errorf("%v: %s", err, name)
+			return nil, fmt.Errorf("%w: %s", err, name)
 		}
 	}
 

--- a/apps/platform/pkg/retrieve/retrieve.go
+++ b/apps/platform/pkg/retrieve/retrieve.go
@@ -231,7 +231,7 @@ func copyFileIntoZip(create bundlestore.FileCreator, sourcePath, targetPath stri
 	defer f.Close()
 	_, err = io.Copy(f, source)
 	if err != nil {
-		return fmt.Errorf("failed to create file at path %s : %s", targetPath, err.Error())
+		return fmt.Errorf("failed to create file at path %s : %w", targetPath, err)
 	}
 	return nil
 }

--- a/apps/platform/pkg/types/wire/save.go
+++ b/apps/platform/pkg/types/wire/save.go
@@ -405,7 +405,7 @@ func GetFieldValue(value interface{}, key string) (interface{}, error) {
 	if ok {
 		fk, ok := valueMap[key]
 		if !ok {
-			return "", fmt.Errorf("could not get map property: "+key+" %T", value)
+			return "", fmt.Errorf("could not get map property: %s %T", key, value)
 		}
 		return fk, nil
 	}

--- a/apps/platform/pkg/usage/usage.go
+++ b/apps/platform/pkg/usage/usage.go
@@ -42,7 +42,7 @@ func RegisterEvent(actiontype, metadatatype, metadataname string, size int64, se
 	}
 
 	if user.ID == "" {
-		return fmt.Errorf("Error Registering Usage Event: Empty User ID ")
+		return fmt.Errorf("Error Registering Usage Event: Empty User ID")
 	}
 
 	currentTime := time.Now()

--- a/apps/platform/pkg/usage/usage_redis/usage_redis.go
+++ b/apps/platform/pkg/usage/usage_redis/usage_redis.go
@@ -32,7 +32,7 @@ func (ruh *RedisUsageHandler) ApplyBatch(session *sess.Session) error {
 	// in order to ensure that a subsequent job processes them.
 	keys, err := redis.Strings(conn.Do("SPOP", KEYS_SET_NAME, MAX_USAGE_PER_RUN))
 	if err != nil {
-		return fmt.Errorf("Error getting usage set members: " + err.Error())
+		return fmt.Errorf("Error getting usage set members: %w", err)
 	}
 
 	if len(keys) == 0 {
@@ -44,7 +44,7 @@ func (ruh *RedisUsageHandler) ApplyBatch(session *sess.Session) error {
 
 	values, err := redis.Strings(conn.Do("MGET", keyArgs...))
 	if err != nil {
-		return fmt.Errorf("Error fetching usage keys: " + err.Error())
+		return fmt.Errorf("Error fetching usage keys: %w", err)
 	}
 
 	changes := meta.UsageCollection{}
@@ -94,11 +94,11 @@ func setRedisUsage(key string, size int64) error {
 
 	err := conn.Flush()
 	if err != nil {
-		return fmt.Errorf("Error Setting cache value: " + err.Error())
+		return fmt.Errorf("Error Setting cache value: %w", err)
 	}
 	_, err = conn.Receive()
 	if err != nil {
-		return fmt.Errorf("Error Setting cache value: " + err.Error())
+		return fmt.Errorf("Error Setting cache value: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
# What does this PR do?

Fixes cases where we were putting variable expressions into `fmt.Errorf`

In Go, the fmt.Errorf function expects a constant format string as its first argument. This means the format string should be a literal string, not a variable that could potentially change at runtime.

Why is this important?

Security:
Using non-constant format strings can open your code to format string vulnerabilities, where an attacker can manipulate the format string to gain unauthorized access or cause crashes.

Type safety:
The compiler can check the format string and its arguments at compile time when it's a constant, ensuring that the types match and preventing potential runtime errors.

