### PR TITLE
chore: support live reload in dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ npm run watch-all
 
 ## Live Reload (for development)
 
-> ![NOTE]
+> [!NOTE]
 > Live reload is not currently supported when running against the docker image (e.g., `npm run in-docker`).
 
 When running the platform, in addition to [watching](#watch-mode-for-development) and rebuilding when files change, you likely want to have the platform itself and/or the browser to automatically reload after assets have been rebuilt.
@@ -487,7 +487,7 @@ bash apps/platform/migrations_test/test_migrations.sh
 
 ## Testing (Unit, Integration & E2E)
 
-> ![IMPORTANT]
+> [!IMPORTANT]
 > The default behavior for all tests is to run against `https://studio.uesio-dev.com:3000` so you must ensure that [SSL](#set-up-ssl) and [local DNS](#set-up-your-local-dns) have been configured.
 
 To run the various test suites, there are a number of commands available:

--- a/README.md
+++ b/README.md
@@ -92,6 +92,16 @@ While developing you may want the entire monorepo to rebuild changed files. You 
 npm run watch-all
 ```
 
+Or, if you want to watch just a single project, you can do the following which will watch the project for changes and ensure that any of the projects its dependent on are (re)built (if needed) first:
+
+`npx nx watch -p <projectname> --includeDependentProjects -- nx run-many -t build -p \$NX_PROJECT_NAME`
+
+For example, to monitor the `apps-uesio-studio` project:
+
+```bash
+npx nx watch -p apps-uesio-studio --includeDependentProjects -- nx run-many -t build -p \$NX_PROJECT_NAME
+```
+
 ## Live Reload (for development)
 
 > [!NOTE]

--- a/README.md
+++ b/README.md
@@ -88,8 +88,46 @@ nx build apps-uesio-studio
 
 While developing you may want the entire monorepo to rebuild changed files. You can do this with:
 
-```
+```bash
 npm run watch-all
+```
+
+## Live Reload (for development)
+
+> ![NOTE]
+> Live reload is not currently supported when running against the docker image (e.g., `npm run in-docker`).
+
+When running the platform, in addition to [watching](#watch-mode-for-development) and rebuilding when files change, you likely want to have the platform itself and/or the browser to automatically reload after assets have been rebuilt.
+
+See [Live Reload](./docs/development/live-reload.md) for more details on how live reload works.
+
+Depending on your preference, there are two options:
+
+### Platform & Browser
+
+Whenever any changes are made to code within the platform go module itself or any of the libraries that are a part of the platform itself (e.g., `libs/apps/uesio/studio`, `libs/apps/uesio/appkit`, `libs/ui`, `libs/vendor`, etc.) the module/package will be rebuilt and if necessary, the platform automatically restarted. Additionally, the browser will automatically refresh.
+
+In order to accomplish, the [Air](https://github.com/air-verse/air) package must be installed on your machine. This is a one-time installation:
+
+```bash
+go install github.com/air-verse/air@latest
+```
+
+Once `Air` is installed, you can simply run the following:
+
+```bash
+npm run watch-dev
+```
+
+### Browser Only
+
+Whenever any changes are made to code within the libraries that the platform uses (e.g., `libs/apps/uesio/studio`, `libs/apps/uesio/appkit`, `libs/ui`, `libs/vendor`, etc.), the module/package will be rebuilt and the browser reloaded. This is very similar to [Platform & Browser](#platform--browser) but changes to the platform itself (e.g., `*.go` files) will not trigger a rebuild or a restart of the platform go module.
+
+It is recommended to use [Platform & Browser](#platform--browser) for live reload, however `Browser Only` can be used if you do not want to install `Air` or if you know you will not be making any changes to the platform module directly.
+
+```bash
+npm run watch-platform-deps # In a separate terminal
+npm run start # In a separate terminal
 ```
 
 ## (Optional) Using Uesio CLI globally

--- a/apps/platform-integration-tests/hurl_specs/workspace_context.hurl
+++ b/apps/platform-integration-tests/hurl_specs/workspace_context.hurl
@@ -98,7 +98,7 @@ Accept: application/json
 HTTP 200
 [Asserts]
 header "Location" == "/login?r=/workspace/uesio/tests/dev/configvalues&expired=true"
-body == "<a href=\"/login?r=/workspace/uesio/tests/dev/configvalues&amp;expired=true\">OK</a>.\n\n"
+body startsWith "<a href=\"/login?r=/workspace/uesio/tests/dev/configvalues&amp;expired=true\">OK</a>.\n\n"
 
 # Logout
 POST https://{{host}}:{{port}}/site/auth/logout

--- a/apps/platform/.air.toml
+++ b/apps/platform/.air.toml
@@ -1,0 +1,52 @@
+root = "."
+testdata_dir = "testdata"
+tmp_dir = ".watch"
+
+[build]
+  args_bin = []
+  bin = "./.watch/main"
+  cmd = "go build -o ./.watch/main ."
+  delay = 1000
+  exclude_dir = ["localbundlestore", "migrations", "migrations_test", "scripts", "seed", "ssl", "userfiles"]
+  exclude_file = []
+  exclude_regex = ["_test.go"]
+  exclude_unchanged = false
+  follow_symlink = false
+  full_bin = ""
+  include_dir = []
+  include_ext = ["go", "gohtml"]
+  include_file = []
+  kill_delay = "0s"
+  log = "build-errors.log"
+  poll = false
+  poll_interval = 0
+  post_cmd = []
+  pre_cmd = []
+  rerun = false
+  rerun_delay = 500
+  send_interrupt = false
+  stop_on_error = false
+
+[color]
+  app = ""
+  build = "yellow"
+  main = "magenta"
+  runner = "green"
+  watcher = "cyan"
+
+[log]
+  main_only = false
+  silent = false
+  time = false
+
+[misc]
+  clean_on_exit = false
+
+[proxy]
+  app_port = 3000
+  enabled = false
+  proxy_port = 8000
+
+[screen]
+  clear_on_rebuild = false
+  keep_scroll = true

--- a/apps/platform/.gitignore
+++ b/apps/platform/.gitignore
@@ -19,9 +19,9 @@ pgdata
 /temp/
 /ssl/certificate.crt
 /ssl/private.key
-sessions/*
-userfiles/*
-localbundlestore/*
+sessions/
+userfiles/
+localbundlestore/
 .DS_Store
 .idea
 .vscode/launch.json
@@ -34,6 +34,7 @@ firebase-debug.log
 __debug_bin*
 uesiofiles-dev/
 uesiobundlestore-dev/
+.watch/
 
 # static js files, compilated by webpack, which are served by gorilla/mux
 /platform/*.js

--- a/apps/platform/go.mod
+++ b/apps/platform/go.mod
@@ -5,6 +5,7 @@ go 1.23.5
 require (
 	github.com/NYTimes/gziphandler v1.1.1
 	github.com/PaesslerAG/gval v1.2.4
+	github.com/aarol/reload v1.2.0
 	github.com/aws/aws-sdk-go-v2 v1.36.0
 	github.com/aws/aws-sdk-go-v2/config v1.29.4
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.57
@@ -61,9 +62,11 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.28.13 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.33.12 // indirect
 	github.com/beevik/etree v1.5.0 // indirect
+	github.com/bep/debounce v1.2.1 // indirect
 	github.com/crewjam/httperr v0.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dlclark/regexp2 v1.11.4 // indirect
+	github.com/fsnotify/fsnotify v1.8.0 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
@@ -74,6 +77,7 @@ require (
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.4 // indirect
 	github.com/googleapis/gax-go/v2 v2.14.1 // indirect
+	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/apps/platform/go.sum
+++ b/apps/platform/go.sum
@@ -26,6 +26,8 @@ github.com/PaesslerAG/gval v1.2.4 h1:rhX7MpjJlcxYwL2eTTYIOBUyEKZ+A96T9vQySWkVUiU
 github.com/PaesslerAG/gval v1.2.4/go.mod h1:XRFLwvmkTEdYziLdaCeCa5ImcGVrfQbeNUbVR+C6xac=
 github.com/PaesslerAG/jsonpath v0.1.0 h1:gADYeifvlqK3R3i2cR5B4DGgxLXIPb3TRTH1mGi0jPI=
 github.com/PaesslerAG/jsonpath v0.1.0/go.mod h1:4BzmtoM/PI8fPO4aQGIusjGxGir2BzcV0grWtFzq1Y8=
+github.com/aarol/reload v1.2.0 h1:zJZuWREX+rrB5V8o/PfQn1y9bG3rG8vmE0NeJl8aep0=
+github.com/aarol/reload v1.2.0/go.mod h1:3XL4gixCRx2VRXr4l3/qemjo2oWq8WxDRetd+EUkBcg=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/aws/aws-sdk-go-v2 v1.36.0 h1:b1wM5CcE65Ujwn565qcwgtOTT1aT4ADOHHgglKjG7fk=
 github.com/aws/aws-sdk-go-v2 v1.36.0/go.mod h1:5PMILGVKiW32oDzjj6RU52yrNrDPUHcbZQYr1sM7qmM=
@@ -71,6 +73,8 @@ github.com/beevik/etree v1.1.0/go.mod h1:r8Aw8JqVegEf0w2fDnATrX9VpkMcyFeM0FhwO62
 github.com/beevik/etree v1.5.0 h1:iaQZFSDS+3kYZiGoc9uKeOkUY3nYMXOKLl6KIJxiJWs=
 github.com/beevik/etree v1.5.0/go.mod h1:gPNJNaBGVZ9AwsidazFZyygnd+0pAU38N4D+WemwKNs=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
+github.com/bep/debounce v1.2.1 h1:v67fRdBA9UQu2NhLFXrSg0Brw7CexQekrBwDMM8bzeY=
+github.com/bep/debounce v1.2.1/go.mod h1:H8yggRPQKLUhUoqrJC1bO2xNya7vanpDl7xR3ISbCJ0=
 github.com/bigkevmcd/go-cachewrapper v0.0.0-20240507155736-346a72d92df1 h1:Y26bsH9MpuAIa0xGk4TplHKxgKWOBp40r9I9p9gm044=
 github.com/bigkevmcd/go-cachewrapper v0.0.0-20240507155736-346a72d92df1/go.mod h1:X9bv2LO4wvNDIGtHmvY7p9rITSOeNp4X28Dy35xwtD8=
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=
@@ -113,6 +117,8 @@ github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI
 github.com/francoispqt/gojay v1.2.13 h1:d2m3sFjloqoIUQU3TsHBgj6qg/BVGlTBeHDUmyJnXKk=
 github.com/francoispqt/gojay v1.2.13/go.mod h1:ehT5mTG4ua4581f1++1WLG0vPdaA9HaiDsoyrBGkyDY=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/8M=
+github.com/fsnotify/fsnotify v1.8.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gliderlabs/ssh v0.1.1/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
@@ -169,6 +175,8 @@ github.com/googleapis/gax-go/v2 v2.14.1/go.mod h1:Hb/NubMaVM88SrNkvl8X/o8XWwDJEP
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
 github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/grpc-gateway v1.5.0/go.mod h1:RSKVYQBd5MCa4OVpNdGskqpgL2+G+NZTnrVHpWWfpdw=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=

--- a/apps/platform/pkg/auth/cache.go
+++ b/apps/platform/pkg/auth/cache.go
@@ -29,6 +29,10 @@ func DeleteUserCacheEntries(userKeys ...string) error {
 	return userCache.Del(userKeys...)
 }
 
+func InvalidateUserCache() error {
+	return userCache.DeleteAll()
+}
+
 func setUserCache(userUniqueKey string, site *meta.Site, user *meta.User) error {
 	// Shallow clone the user, so the caller doesn't have
 	// a reference to the one in the cache.
@@ -71,10 +75,26 @@ func ClearHostCacheForDomains(ids []string) error {
 	return hostCache.Del(keys...)
 }
 
+func InvalidateHostCache() error {
+	return hostCache.DeleteAll()
+}
+
 func getHostKeyFromDomainId(id string) (string, error) {
 	idParts := strings.Split(id, ":")
 	if len(idParts) != 2 {
 		return "", errors.New("Bad Domain ID: " + id)
 	}
 	return getHostKey(idParts[1], idParts[0]), nil
+}
+
+func InvalidateCache() error {
+	if err := InvalidateUserCache(); err != nil {
+		return err
+	}
+
+	if err := InvalidateHostCache(); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/apps/platform/pkg/bundle/cache.go
+++ b/apps/platform/pkg/bundle/cache.go
@@ -63,3 +63,23 @@ func (bsc *BundleStoreCache) AddItemToCache(namespace, version, groupName, itemK
 func (bsc *BundleStoreCache) InvalidateCacheItem(namespace, version, groupName, itemKey string) error {
 	return bsc.bundleEntryCache.Del(bsc.getItemCacheKey(namespace, version, groupName, itemKey))
 }
+
+func (bsc *BundleStoreCache) InvalidateCache() error {
+	if err := bsc.invalidateBundleEntryCache(); err != nil {
+		return err
+	}
+
+	if err := bsc.invalidateFileListCache(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (bsc *BundleStoreCache) invalidateBundleEntryCache() error {
+	return bsc.bundleEntryCache.DeleteAll()
+}
+
+func (bsc *BundleStoreCache) invalidateFileListCache() error {
+	return bsc.fileListCache.DeleteAll()
+}

--- a/apps/platform/pkg/bundlestore/platformbundlestore/platformbundlestore.go
+++ b/apps/platform/pkg/bundlestore/platformbundlestore/platformbundlestore.go
@@ -44,6 +44,14 @@ func (b *PlatformBundleStore) GetConnection(options bundlestore.ConnectionOption
 	}, nil
 }
 
+func InvalidateCache() error {
+	if bundleStoreCache != nil {
+		return bundleStoreCache.InvalidateCache()
+	}
+
+	return nil
+}
+
 func getBasePath(namespace, version string) string {
 	return filepath.Join(namespace, version, "bundle")
 }

--- a/apps/platform/pkg/bundlestore/systembundlestore/systembundlestore.go
+++ b/apps/platform/pkg/bundlestore/systembundlestore/systembundlestore.go
@@ -39,3 +39,11 @@ func (b *SystemBundleStore) GetConnection(options bundlestore.ConnectionOptions)
 		ReadOnly:          false,
 	}, nil
 }
+
+func InvalidateCache() error {
+	if bundleStoreCache != nil {
+		return bundleStoreCache.InvalidateCache()
+	}
+
+	return nil
+}

--- a/apps/platform/pkg/cache/cache.go
+++ b/apps/platform/pkg/cache/cache.go
@@ -6,6 +6,7 @@ type Cache[T any] interface {
 	Get(key string) (T, error)
 	Set(key string, value T) error
 	Del(keys ...string) error
+	DeleteAll() error
 }
 
 type CacheOptions[T any] struct {

--- a/apps/platform/pkg/cache/memory.go
+++ b/apps/platform/pkg/cache/memory.go
@@ -50,6 +50,7 @@ func (mc *MemoryCache[T]) GetAll() map[string]T {
 	return result
 }
 
-func (mc *MemoryCache[T]) DeleteAll() {
+func (mc *MemoryCache[T]) DeleteAll() error {
 	mc.c.Flush()
+	return nil
 }

--- a/apps/platform/pkg/cache/redis.go
+++ b/apps/platform/pkg/cache/redis.go
@@ -71,6 +71,11 @@ func (r RedisCache[T]) Del(keys ...string) error {
 	return deleteKeys(namespacedKeys)
 }
 
+func (r RedisCache[T]) DeleteAll() error {
+	// TODO: This may need to change to flushDB if/when we partition in to different databases in redis
+	return flushAll()
+}
+
 func (r RedisCache[T]) WithExpiration(expiration time.Duration) RedisCache[T] {
 	r.options.Expiration = expiration
 	return r
@@ -171,6 +176,16 @@ func deleteKeys(keys []string) error {
 	_, err := conn.Do("DEL", redis.Args{}.AddFlat(keys)...)
 	if err != nil {
 		return fmt.Errorf("Error deleting cache keys from bot: %w", err)
+	}
+	return nil
+}
+
+func flushAll() error {
+	conn := GetRedisConn()
+	defer conn.Close()
+	_, err := conn.Do("FLUSHALL")
+	if err != nil {
+		return fmt.Errorf("Error flushing cache from bot: %w", err)
 	}
 	return nil
 }

--- a/apps/platform/pkg/controller/bundlesretrieve.go
+++ b/apps/platform/pkg/controller/bundlesretrieve.go
@@ -9,6 +9,7 @@ import (
 	"github.com/thecloudmasters/uesio/pkg/bundlestore"
 	"github.com/thecloudmasters/uesio/pkg/controller/ctlutil"
 	"github.com/thecloudmasters/uesio/pkg/controller/file"
+	"github.com/thecloudmasters/uesio/pkg/env"
 	"github.com/thecloudmasters/uesio/pkg/middleware"
 	"github.com/thecloudmasters/uesio/pkg/types/exceptions"
 )
@@ -43,7 +44,9 @@ func BundlesRetrieve(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Disposition", fmt.Sprintf("; filename=\"%s.zip\"", version))
-	w.Header().Set("Cache-Control", file.CacheFor1Year)
+	if !env.InDevMode() {
+		w.Header().Set("Cache-Control", file.CacheFor1Year)
+	}
 	err = source.GetBundleZip(w, nil)
 	if err != nil {
 		ctlutil.HandleError(w, exceptions.NewBadRequestException("Failed Getting Bundle: "+err.Error()))

--- a/apps/platform/pkg/controller/file/serve_file.go
+++ b/apps/platform/pkg/controller/file/serve_file.go
@@ -13,6 +13,7 @@ import (
 	"github.com/thecloudmasters/uesio/pkg/bundle"
 	"github.com/thecloudmasters/uesio/pkg/controller/ctlutil"
 	"github.com/thecloudmasters/uesio/pkg/datasource"
+	"github.com/thecloudmasters/uesio/pkg/env"
 	"github.com/thecloudmasters/uesio/pkg/filesource"
 	"github.com/thecloudmasters/uesio/pkg/meta"
 	"github.com/thecloudmasters/uesio/pkg/middleware"
@@ -37,7 +38,7 @@ func respondFile(w http.ResponseWriter, r *http.Request, fileRequest *FileReques
 	}
 
 	w.Header().Set("Content-Disposition", fmt.Sprintf("; filename=\"%s\"", fileRequest.Path))
-	if fileRequest.TreatAsImmutable() {
+	if fileRequest.TreatAsImmutable() && !env.InDevMode() {
 		w.Header().Set("Cache-Control", CacheFor1Year)
 	}
 

--- a/apps/platform/pkg/controller/file/static_assets.go
+++ b/apps/platform/pkg/controller/file/static_assets.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/thecloudmasters/uesio/pkg/env"
 	"github.com/thecloudmasters/uesio/pkg/middleware"
 )
 
@@ -37,7 +38,7 @@ func Static(currentWorkingDirectory, routePrefix string, cache bool) http.Handle
 	if staticAssetsHost != "" {
 		handler = middleware.WithAccessControlAllowOriginHeader(handler, "*")
 	}
-	if cache {
+	if cache && !env.InDevMode() {
 		handler = middleware.With1YearCache(handler)
 	}
 	return handler

--- a/apps/platform/pkg/controller/file/vendor.go
+++ b/apps/platform/pkg/controller/file/vendor.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/thecloudmasters/uesio/pkg/env"
 	"github.com/thecloudmasters/uesio/pkg/middleware"
 )
 
@@ -108,7 +109,7 @@ func ServeVendor(routePrefix string, cache bool) http.Handler {
 	if vendorAssetsHost != "" {
 		handler = middleware.WithAccessControlAllowOriginHeader(handler, "*")
 	}
-	if cache {
+	if cache && !env.InDevMode() {
 		handler = middleware.With1YearCache(handler)
 	}
 	return handler

--- a/apps/platform/pkg/controller/server.go
+++ b/apps/platform/pkg/controller/server.go
@@ -11,8 +11,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/gorilla/mux"
-
 	"github.com/thecloudmasters/uesio/pkg/env"
 )
 
@@ -33,7 +31,7 @@ func GetGracefulShutdownSeconds() int {
 	return gracefulShutdownSeconds
 }
 
-func NewServer(serveAddress string, router *mux.Router) *ServerWithShutdown {
+func NewServer(serveAddress string, router http.Handler) *ServerWithShutdown {
 	return &ServerWithShutdown{
 		Server: http.Server{
 			Addr:    serveAddress,

--- a/apps/platform/pkg/datasource/licensing.go
+++ b/apps/platform/pkg/datasource/licensing.go
@@ -22,6 +22,10 @@ func InvalidateLicenseCaches(namespaces []string) error {
 	return licenseCache.Del(namespaces...)
 }
 
+func InvalidateCache() error {
+	return licenseCache.DeleteAll()
+}
+
 func setLicenseCache(namespace string, licenses LicenseMap) error {
 	return licenseCache.Set(namespace, licenses)
 }

--- a/apps/platform/pkg/middleware/http_caching.go
+++ b/apps/platform/pkg/middleware/http_caching.go
@@ -5,13 +5,18 @@ import (
 	"time"
 
 	cw "github.com/bigkevmcd/go-cachewrapper"
+	"github.com/thecloudmasters/uesio/pkg/env"
 )
 
 const ONE_YEAR_IN_HOURS = time.Hour * 24 * 365
 
 // With1YearCache implements a default caching policy for client-side assets
-func With1YearCache(handler http.Handler) *cw.CacheControl {
-	return cw.Cached(handler, cw.Immutable(), cw.SharedMaxAge(ONE_YEAR_IN_HOURS), cw.NoTransform(), cw.Private())
+func With1YearCache(handler http.Handler) http.Handler {
+	if !env.InDevMode() {
+		return cw.Cached(handler, cw.Immutable(), cw.SharedMaxAge(ONE_YEAR_IN_HOURS), cw.NoTransform(), cw.Private())
+	}
+
+	return handler
 }
 
 func WithAccessControlAllowOriginHeader(h http.Handler, origins string) http.Handler {

--- a/apps/platform/pkg/oauth2/authorizationcode.go
+++ b/apps/platform/pkg/oauth2/authorizationcode.go
@@ -86,3 +86,7 @@ func GetRedirectMetadata(conf *oauth2.Config, integrationName string, s *sess.Se
 		State:   stateString,
 	}, nil
 }
+
+func InvalidateCache() error {
+	return oauthExchangeCache.DeleteAll()
+}

--- a/apps/platform/pkg/usage/usage_memory/usage_memory.go
+++ b/apps/platform/pkg/usage/usage_memory/usage_memory.go
@@ -40,6 +40,7 @@ func (pcuh *MemoryUsageHandler) ApplyBatch(session *sess.Session) error {
 	}
 
 	// Remove Keys
+	// TODO: Should we be ignoring the error here?
 	usageCache.DeleteAll()
 
 	return nil

--- a/apps/platform/project.json
+++ b/apps/platform/project.json
@@ -68,6 +68,26 @@
     },
     "tidy": {
       "executor": "@nx-go/nx-go:tidy"
+    },
+    "watch-deps": {
+      "executor": "nx:run-commands",
+      "options": {
+        "commands": [
+          "mkdir -p apps/platform/.watch",
+          "nx watch -p tag:type:platform-dep  -- \"date && nx run-many -t build -p \\$NX_PROJECT_NAME && date > apps/platform/.watch/nxwatch.log\""
+        ]
+      }
+    },
+    "serve:watch": {
+      "executor": "nx:run-commands",
+      "options": {
+        "commands": [
+          "cd apps/platform && air serve",
+          "nx run platform:watch-deps"
+        ],
+        "parallel": true
+      },
+      "dependsOn": [{ "projects": "tag:type:platform-dep", "target": "build" }]
     }
   },
   "tags": [],

--- a/docs/development/live-reload.md
+++ b/docs/development/live-reload.md
@@ -1,0 +1,42 @@
+# Live Reload
+
+Due to the nature of the [ues.io](https://ues.io) platform and its robust feature set, coordinating a full live reload development experience is not straightforward. Some of the complexities of a solution are:
+
+1. Platform Module - The platform relies on other packages (e.g, `libs/app/uesio/*`) and caches them which means those assets must be (re)built prior to the platform restarting/cache clearing
+2. Platform Bundles - The bundles themselves rely on the CLI module to be built which means the CLI must be (re)built prior to building the bundle
+3. General - With several layers in the architecture, building everything on each change, even the smallest of changes, would negatively impact the time required to surface the change in the browser
+
+Given the above and other complexities, a true hot module reload (HMR) solution is not possible, however a live reload solution is.
+
+In order to accomplish, once a change is detected, any items that the changed package is dependent on must be "current" (and things its dependent on, etc.). Rather than use a manual approach to dependency detection, we rely on [Nx](https://nx.dev/) and it's project graph (which identifies each projects dependencies).
+
+Leveraging the dependency graph of Nx, we achieve a full live reload solution in two parts:
+
+## Platform Module Reload
+
+This piece is responsible for monitoring the Platform module itself for changes (e.g., `*.go` files) and rebuilding/restarting the Platform (`serve` command) when detected. This piece is only responsible for platform changes and the platform process will only restart when changes are made to the platform directly. Any changes to packages the platform is dependent on (e.g., `libs/apps/uesio/*`) are monitored/handled via [Platform Dependency Reload](#platform-dependency-reload).
+
+The [Air](https://github.com/air-verse/air) package is used to monitor and restart the Platform module. In short, instead of running the platform directly (e.g., `go run apps/platform/main.go`), Air is executed and it handles (re)starting the platform. The [configuration](../../apps/platform/.air.toml) defines what files/directories are monitored, etc.
+
+Air is also capable of being a proxy to the platform web application which would allow it to handle not only reloading/restarting the platform when it changes but also ensuring the browser reloads when downstream dependencies change. Unfortunately, there are a couple of limitations/downsides to using Air solely for all live reload aspects:
+
+1. Air proxy does not support SSL
+2. Air would also restart the entire platform process (in addition to reloading the browser) and this has a performance impact in situations where the platform itself isn't changing. For example, when a view yaml file is changed in Studio, it would take ~5secs to ensure that Studio is built, notify Air of the change, have Air restart the process and the browser reload. By handling dependency reloads within the Platform directly (instead of via proxy), we eliminate the need to restart the platform itself thereby decreasing the total time for changes to be reflected.
+
+One final note here is that we do not use `nx watch` on the platform itself to re-build since Air handles the platform specific rebuild/restart.
+
+## Platform Dependency Reload
+
+This piece is responsible for monitoring when any items the platform is dependent on have changed, rebuild them and then reload the browser. There are two parts to this solution:
+
+1. `nx watch` is used to monitor for changes within a project and rebuild that project
+2. [Reload](https://github.com/aarol/reload) package is used to monitor whenever `nx` has re-built something and inform the browser to reload (via websockets)
+
+The process works as follows:
+
+1. `nx watch` detects a change
+2. `nx watch` runs the `build` target for the project that was changed (and any projects that the changed project relies on that need to be re-built if not already current)
+3. After the project is built, the file `apps/platform/.watch/nxwatch.log` is updated with the current date (could be any change to the file, content is not important)
+4. `Reload` is monitoring the `apps/platform/.watch` directory for changes and when one is detected, issues the "reload" command to the browser
+
+See the [live reload](../../README.md#live-reload-for-development) for instructions on the various ways to run live reload.

--- a/libs/apps/uesio/aikit/project.json
+++ b/libs/apps/uesio/aikit/project.json
@@ -26,15 +26,6 @@
         "cwd": "libs/apps/uesio/aikit"
       }
     },
-    "watch": {
-      "executor": "nx:run-commands",
-      "outputs": ["{projectRoot}/bundle/componentpacks/main/dist"],
-      "options": {
-        "command": "../../../../dist/cli/uesio pack -w",
-        "cwd": "libs/apps/uesio/aikit"
-      },
-      "dependsOn": ["^build"]
-    },
     "test": {
       "options": {
         "passWithNoTests": true

--- a/libs/apps/uesio/appkit/project.json
+++ b/libs/apps/uesio/appkit/project.json
@@ -26,15 +26,6 @@
         "cwd": "libs/apps/uesio/appkit"
       }
     },
-    "watch": {
-      "executor": "nx:run-commands",
-      "outputs": ["{projectRoot}/bundle/componentpacks/main/dist"],
-      "options": {
-        "command": "../../../../dist/cli/uesio pack -w",
-        "cwd": "libs/apps/uesio/appkit"
-      },
-      "dependsOn": ["^build"]
-    },
     "test": {
       "options": {
         "passWithNoTests": true

--- a/libs/apps/uesio/builder/project.json
+++ b/libs/apps/uesio/builder/project.json
@@ -27,15 +27,6 @@
         "cwd": "libs/apps/uesio/builder"
       }
     },
-    "watch": {
-      "executor": "nx:run-commands",
-      "outputs": ["{projectRoot}/bundle/componentpacks/main/dist"],
-      "options": {
-        "command": "../../../../dist/cli/uesio pack -w",
-        "cwd": "libs/apps/uesio/builder"
-      },
-      "dependsOn": ["^build"]
-    },
     "test": {
       "configurations": {
         "ci": {

--- a/libs/apps/uesio/core/project.json
+++ b/libs/apps/uesio/core/project.json
@@ -26,15 +26,6 @@
         "cwd": "libs/apps/uesio/core"
       }
     },
-    "watch": {
-      "executor": "nx:run-commands",
-      "outputs": ["{projectRoot}/bundle/componentpacks/app/dist"],
-      "options": {
-        "command": "../../../../dist/cli/uesio pack -w",
-        "cwd": "libs/apps/uesio/core"
-      },
-      "dependsOn": ["^build"]
-    },
     "test": {
       "options": {
         "passWithNoTests": true

--- a/libs/apps/uesio/io/project.json
+++ b/libs/apps/uesio/io/project.json
@@ -26,15 +26,6 @@
         "cwd": "libs/apps/uesio/io"
       }
     },
-    "watch": {
-      "executor": "nx:run-commands",
-      "outputs": ["{projectRoot}/bundle/componentpacks/main/dist"],
-      "options": {
-        "command": "../../../../dist/cli/uesio pack -w",
-        "cwd": "libs/apps/uesio/io"
-      },
-      "dependsOn": ["^build"]
-    },
     "test": {
       "configurations": {
         "ci": {

--- a/libs/apps/uesio/sitekit/project.json
+++ b/libs/apps/uesio/sitekit/project.json
@@ -26,15 +26,6 @@
         "cwd": "libs/apps/uesio/sitekit"
       }
     },
-    "watch": {
-      "executor": "nx:run-commands",
-      "outputs": ["{projectRoot}/bundle/componentpacks/main/dist"],
-      "options": {
-        "command": "../../../../dist/cli/uesio pack -w",
-        "cwd": "libs/apps/uesio/sitekit"
-      },
-      "dependsOn": ["^build"]
-    },
     "test": {
       "options": {
         "passWithNoTests": true

--- a/libs/apps/uesio/studio/project.json
+++ b/libs/apps/uesio/studio/project.json
@@ -26,15 +26,6 @@
         "cwd": "libs/apps/uesio/studio"
       }
     },
-    "watch": {
-      "executor": "nx:run-commands",
-      "outputs": ["{projectRoot}/bundle/componentpacks/main/dist"],
-      "options": {
-        "command": "../../../../dist/cli/uesio pack -w",
-        "cwd": "libs/apps/uesio/studio"
-      },
-      "dependsOn": ["^build"]
-    },
     "test": {
       "configurations": {
         "ci": {

--- a/libs/ui/project.json
+++ b/libs/ui/project.json
@@ -26,14 +26,6 @@
         "cwd": "libs/ui"
       }
     },
-    "watch": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "../../dist/cli/uesio packui --watch",
-        "cwd": "libs/ui"
-      },
-      "dependsOn": ["build"]
-    },
     "test": {
       "configurations": {
         "ci": {

--- a/libs/vendor/project.json
+++ b/libs/vendor/project.json
@@ -23,13 +23,6 @@
         ],
         "cwd": "libs/vendor"
       }
-    },
-    "watch": {
-      "builder": "nx:run-commands",
-      "options": {
-        "command": "echo TODO: watch libs/vendor",
-        "cwd": "libs/vendor"
-      }
     }
   },
   "tags": ["type:platform-dep"]

--- a/package.json
+++ b/package.json
@@ -40,10 +40,11 @@
     "typecheck-all": "nx run-many -t typecheck --all",
     "seeds": "nx seed platform",
     "setup-ssl": "cd ./apps/platform/ssl && ./create.sh",
-    "start": "nx serve platform",
+    "start": "nx run platform:serve",
     "test": "nx run-many --target=test --all",
-    "watch-all": "nx run-many --target=watch --all --parallel=8",
-    "watch-all-nx": "nx run-many --target=build --all && nx watch --all -- nx run-many -t build --all"
+    "watch-all": "npm run build-all && nx watch --all -- nx run-many -t build -p \\$NX_PROJECT_NAME",
+    "watch-platform-deps": "nx run platform:watch-deps",
+    "watch-dev": "nx run platform:serve:watch"
   },
   "files": [],
   "devDependencies": {


### PR DESCRIPTION
# What does this PR do?

Adds support for live reload in development (UESIO_DEV=true).

Running `npm run watch-dev` will monitor all changes to platform and all of its dependencies and restart platform process (if platform itself changed) and/or rebuild dependencies and then reload browser.

See README.md and docs/live-reload.md for full details

Demo: https://app.screencast.com/ugmKgkOsDPzwc

# Testing

Manual testing of changing various file and file types to ensure everything rebuilds/restarts.
