### PR TITLE
Add has slot value display conditio

### DIFF
--- a/libs/apps/uesio/appkit/bundle/components/note.yaml
+++ b/libs/apps/uesio/appkit/bundle/components/note.yaml
@@ -57,7 +57,7 @@ definition:
             text: $Prop{text}
         - uesio/io.box:
             uesio.display:
-              - type: hasValue
+              - type: hasSlotValue
                 value: $Prop{extra}
             uesio.styleTokens:
               root:
@@ -107,7 +107,7 @@ definition:
                       text: $Prop{text}
                   - uesio/io.box:
                       uesio.display:
-                        - type: hasValue
+                        - type: hasSlotValue
                           value: $Prop{extra}
                       uesio.styleTokens:
                         root:

--- a/libs/apps/uesio/sitekit/bundle/components/feature.yaml
+++ b/libs/apps/uesio/sitekit/bundle/components/feature.yaml
@@ -41,7 +41,7 @@ definition:
             element: div
         - uesio/io.group:
             uesio.display:
-              - type: hasValue
+              - type: hasSlotValue
                 value: $Prop{actions}
             uesio.styleTokens:
               root:

--- a/libs/apps/uesio/sitekit/bundle/components/header.yaml
+++ b/libs/apps/uesio/sitekit/bundle/components/header.yaml
@@ -25,7 +25,7 @@ definition:
       uesio.type: uesio/io.sidepanel
       uesio.variant: uesio/io.right
       uesio.display:
-        - type: hasValue
+        - type: hasSlotValue
           value: $Prop{menu}
       uesio.styleTokens:
         blocker:

--- a/libs/apps/uesio/sitekit/bundle/components/hero.yaml
+++ b/libs/apps/uesio/sitekit/bundle/components/hero.yaml
@@ -53,7 +53,7 @@ definition:
             text: $Prop{subtitle}
         - uesio/io.box:
             uesio.display:
-              - type: hasValue
+              - type: hasSlotValue
                 value: $Prop{extra}
             uesio.styleTokens:
               root:
@@ -62,7 +62,7 @@ definition:
               - $Slot{extra}
         - uesio/io.group:
             uesio.display:
-              - type: hasValue
+              - type: hasSlotValue
                 value: $Prop{actions}
             uesio.styleTokens:
               root:
@@ -71,7 +71,7 @@ definition:
               - $Slot{actions}
         - uesio/io.box:
             uesio.display:
-              - type: hasValue
+              - type: hasSlotValue
                 value: $Prop{image}
             uesio.styleTokens:
               root:

--- a/libs/apps/uesio/sitekit/bundle/components/section_hero.yaml
+++ b/libs/apps/uesio/sitekit/bundle/components/section_hero.yaml
@@ -46,8 +46,10 @@ definition:
             category: $Prop{category}
             title: $Prop{title}
             subtitle: $Prop{subtitle}
-            actions: $Prop{actions}
-            image: $Prop{image}
+            actions:
+              - $Slot{actions}
+            image:
+              - $Slot{image}
 title: Hero Section
 discoverable: true
 description: A hero section

--- a/libs/apps/uesio/sitekit/bundle/components/section_split.yaml
+++ b/libs/apps/uesio/sitekit/bundle/components/section_split.yaml
@@ -32,7 +32,7 @@ definition:
               - $Slot{content}
         - uesio/io.box:
             uesio.display:
-              - type: hasValue
+              - type: hasSlotValue
                 value: $Prop{image}
             uesio.styleTokens:
               root:

--- a/libs/apps/uesio/sitekit/bundle/components/testimonial.yaml
+++ b/libs/apps/uesio/sitekit/bundle/components/testimonial.yaml
@@ -85,7 +85,7 @@ definition:
                   image: $File{$Prop{avatar}:$Prop{avatarPath}}
         - uesio/io.box:
             uesio.display:
-              - type: hasValue
+              - type: hasSlotValue
                 value: $Prop{extra}
             uesio.styleTokens:
               root:

--- a/libs/apps/uesio/studio/bundle/components/layout_note_form.yaml
+++ b/libs/apps/uesio/studio/bundle/components/layout_note_form.yaml
@@ -17,7 +17,7 @@ definition:
               - $Slot{content}
         - uesio/io.box:
             uesio.display:
-              - type: hasValue
+              - type: hasSlotValue
                 value: $Prop{note}
             uesio.styleTokens:
               root:

--- a/libs/ui/src/component/display.spec.ts
+++ b/libs/ui/src/component/display.spec.ts
@@ -864,6 +864,77 @@ const shouldTestCases = [
       },
     ],
   },
+  {
+    type: "hasSlotValue",
+    tests: [
+      {
+        name: "hasSlotValue - no value",
+        condition: {
+          type: "hasSlotValue",
+        },
+        context: new Context(),
+        expected: false,
+      },
+      {
+        name: "hasSlotValue - array",
+        condition: {
+          type: "hasSlotValue",
+          value: [],
+        },
+        context: new Context(),
+        expected: false,
+      },
+      {
+        name: "hasSlotValue - normal component",
+        condition: {
+          type: "hasSlotValue",
+          value: [
+            {
+              "uesio/io.box": {
+                components: [],
+              },
+            },
+          ],
+        },
+        context: new Context(),
+        expected: true,
+      },
+      {
+        name: "hasSlotValue - with value",
+        condition: {
+          type: "hasSlotValue",
+          value: [
+            {
+              "uesio/core.slot": {
+                name: "foo",
+                definition: {
+                  foo: [],
+                },
+              },
+            },
+          ],
+        },
+        context: new Context(),
+        expected: true,
+      },
+      {
+        name: "hasSlotValue - with no value",
+        condition: {
+          type: "hasSlotValue",
+          value: [
+            {
+              "uesio/core.slot": {
+                name: "foo",
+                definition: {},
+              },
+            },
+          ],
+        },
+        context: new Context(),
+        expected: false,
+      },
+    ],
+  },
 ]
 
 describe("should", () => {

--- a/libs/ui/src/component/display.ts
+++ b/libs/ui/src/component/display.ts
@@ -122,6 +122,11 @@ type HasValueCondition = {
   wire?: string
 }
 
+type HasSlotValueCondition = {
+  type: "hasSlotValue"
+  value: unknown
+}
+
 type CollectionContextCondition = {
   type: "collectionContext"
   collection: string
@@ -250,6 +255,7 @@ type DisplayCondition =
   | WireHasMoreRecordsToLoad
   | MergeValue
   | HasConfigValue
+  | HasSlotValueCondition
 
 type ItemContext<T> = {
   item: T
@@ -346,6 +352,23 @@ function should(condition: DisplayCondition, context: Context): boolean {
     return conditions[
       conjunction === "OR" && conditions?.length ? "some" : "every"
     ]((c) => should(c, context))
+  }
+
+  if (type === "hasSlotValue") {
+    const slotValue = condition.value
+    if (!slotValue) return false
+    if (!Array.isArray(slotValue)) return false
+    const slotContent = slotValue[0]
+    if (!slotContent) return false
+    if (typeof slotContent !== "object") return false
+    const slotComponent = slotContent["uesio/core.slot"]
+    if (!slotComponent) return true
+    const slotName = slotComponent.name
+    const compDef = slotComponent.definition
+    if (!slotName || !compDef) return false
+    const slotDef = compDef[slotName]
+    if (!slotDef) return false
+    return true
   }
 
   if (type === "paramIsSet") return !!context.getParam(condition.param)


### PR DESCRIPTION
# What does this PR do?

Adds a `hasSlotValue` condition that handles displaying a node or not depending on whether a slot value was provided.