### PR TITLE
builder styling cleanup light mode

### DIFF
--- a/libs/apps/uesio/builder/bundle/componentpacks/main/src/components/iconprop/iconprop.tsx
+++ b/libs/apps/uesio/builder/bundle/componentpacks/main/src/components/iconprop/iconprop.tsx
@@ -24,7 +24,9 @@ const StyleDefaults = Object.freeze({
   iconfield: ["grid", "grid-cols-[1fr_min-content]", "items-center", "gap-2"],
   iconpreview: [
     "bg-field_bg_color",
-    "p-2",
+    "p-1.5",
+    "border-1",
+    "border-field_border_color",
     "rounded-full",
     "text-xs",
     "leading-none",

--- a/libs/apps/uesio/builder/bundle/componentpacks/main/src/components/mainwrapper/codepanel.tsx
+++ b/libs/apps/uesio/builder/bundle/componentpacks/main/src/components/mainwrapper/codepanel.tsx
@@ -45,8 +45,8 @@ const getSelectedAreaDecorations = (range: monaco.Range, className: string) => [
 ]
 
 const StyleDefaults = Object.freeze({
-  lineDecoration: ["bg-slate-800", "-z-10"],
-  root: ["h-[300px]", "border-t-8", "border-slate-700"],
+  lineDecoration: ["bg-slate-100", "-z-10"],
+  root: ["h-[300px]", "border-t-8", "border-panel_divider_color"],
 })
 
 const CodePanel: definition.UtilityComponent = (props) => {
@@ -118,6 +118,7 @@ const CodePanel: definition.UtilityComponent = (props) => {
   }
 
   const beforeMount: EditorProps["beforeMount"] = (monaco) => {
+    /*
     monaco.editor.defineTheme("custom-dark", {
       base: "vs-dark",
       inherit: true,
@@ -128,6 +129,7 @@ const CodePanel: definition.UtilityComponent = (props) => {
       },
     })
     monaco.editor.setTheme("custom-dark")
+    */
   }
 
   const onMount: EditorProps["onMount"] = (editor, monaco) => {

--- a/libs/apps/uesio/builder/bundle/componentpacks/main/src/components/mainwrapper/indexcomponent.tsx
+++ b/libs/apps/uesio/builder/bundle/componentpacks/main/src/components/mainwrapper/indexcomponent.tsx
@@ -16,7 +16,7 @@ import CloneAction from "../../actions/cloneaction"
 
 const StyleDefaults = Object.freeze({
   tag: ["m-0"],
-  tagSelected: ["p-1"],
+  tagSelected: ["p-1", "bg-index_selected_header_bg_color"],
   tagTitleSelected: [],
   tagTitle: [
     "py-1",
@@ -32,7 +32,8 @@ const StyleDefaults = Object.freeze({
     "text-index_action_button_color",
     "px-1",
     "border-b",
-    "border-index_selected_divider_color",
+    "border-index_selected_header_border_color",
+    "bg-index_selected_header_bg_color",
   ],
   tagContent: [],
   tagContentSelected: ["p-1", "empty:hidden"],

--- a/libs/apps/uesio/builder/bundle/componentpacks/main/src/components/mainwrapper/indexpanel.tsx
+++ b/libs/apps/uesio/builder/bundle/componentpacks/main/src/components/mainwrapper/indexpanel.tsx
@@ -17,7 +17,7 @@ import {
 import IndexSlot from "./indexslot"
 
 const StyleDefaults = Object.freeze({
-  root: ["w-[296px]"],
+  root: ["w-[300px]"],
   index: ["px-2", "py-1"],
 })
 

--- a/libs/apps/uesio/builder/bundle/componentpacks/main/src/components/mainwrapper/indexslot.tsx
+++ b/libs/apps/uesio/builder/bundle/componentpacks/main/src/components/mainwrapper/indexslot.tsx
@@ -46,10 +46,18 @@ type IndexSlotProps = {
 
 const SlotStyleDefaults = Object.freeze({
   slot: ["grid", "border-transparent"],
-  slotSelected: ["rounded-lg", "bg-index_selected_bg_color", "ml-1", "mb-1"],
+  slotSelected: [
+    "rounded-lg",
+    "bg-index_selected_bg_color",
+    "border-1",
+    "border-index_selected_border_color",
+    "ml-1",
+    "mb-1",
+    "overflow-hidden",
+  ],
   slotIndent: ["ml-2"],
   slotHeader: ["flex", "p-1"],
-  slotHeaderSelected: ["p-2"],
+  slotHeaderSelected: ["p-2", "bg-index_selected_header_bg_color"],
   slotTitle: [
     "uppercase",
     "text-index_slot_title_color",
@@ -58,7 +66,7 @@ const SlotStyleDefaults = Object.freeze({
     "grow",
     "p-0.5",
   ],
-  slotContent: [],
+  slotContent: ["border-index_selected_divider_color"],
   slotContentSelected: ["p-1", "empty:hidden"],
   visibilityIcon: [
     "text-[8pt]",
@@ -71,7 +79,8 @@ const SlotStyleDefaults = Object.freeze({
     "text-index_action_button_color",
     "px-1",
     "border-b",
-    "border-index_selected_divider_color",
+    "border-index_selected_header_border_color",
+    "bg-index_selected_header_bg_color",
   ],
 })
 
@@ -113,7 +122,7 @@ const IndexSlot: definition.UtilityComponent<IndexSlotProps> = (props) => {
           )}
         >
           <div className={classes.slotTitle}>{label}</div>
-          {!hasSlotNode && (
+          {!hasSlotNode && selected && (
             <IOIcon
               className={classes.visibilityIcon}
               context={context}

--- a/libs/apps/uesio/builder/bundle/componentpacks/main/src/components/mainwrapper/propertiespanel/propertieswrapper.tsx
+++ b/libs/apps/uesio/builder/bundle/componentpacks/main/src/components/mainwrapper/propertiespanel/propertieswrapper.tsx
@@ -78,7 +78,7 @@ const PropertiesWrapper: definition.UtilityComponent<Props> = (props) => {
 
   const classes = styles.useUtilityStyleTokens(
     {
-      root: ["w-[296px]"],
+      root: ["w-[300px]"],
       crumbwrapper: ["leading-[8px]"],
       crumb: [
         "bg-properties_crumb_bg_color",

--- a/libs/apps/uesio/builder/bundle/componentpacks/main/src/components/mainwrapper/propertiespanel/wire/fieldsproperties.tsx
+++ b/libs/apps/uesio/builder/bundle/componentpacks/main/src/components/mainwrapper/propertiespanel/wire/fieldsproperties.tsx
@@ -82,7 +82,7 @@ const FieldsProperties: definition.UC<FieldsPropertiesDefinition> = (props) => {
                     variant="uesio/builder.actionicon"
                   />
                 }
-                label={"Collection Fields"}
+                label={"Collection Field"}
                 onClick={() => {
                   setShowPopper(true)
                 }}

--- a/libs/apps/uesio/builder/bundle/componentpacks/main/src/helpers/searcharea.tsx
+++ b/libs/apps/uesio/builder/bundle/componentpacks/main/src/helpers/searcharea.tsx
@@ -11,7 +11,14 @@ interface Props {
 }
 
 const StyleDefaults = Object.freeze({
-  root: ["flex", "p-2", "relative", "align-center", "gap-2"],
+  root: [
+    "flex",
+    "p-2",
+    "relative",
+    "align-center",
+    "gap-2",
+    "bg-panel_header_bg_color",
+  ],
   input: [
     "grow",
     "text-xs",
@@ -19,6 +26,8 @@ const StyleDefaults = Object.freeze({
     "py-1.5",
     "font-light",
     "rounded",
+    "border-1",
+    "border-searchbox_border_color",
     "text-searchbox_text_color",
     "bg-searchbox_bg_color",
     "outline-offset-0",

--- a/libs/apps/uesio/builder/bundle/componentpacks/main/src/utilities/autocompletefield/autocompletefield.tsx
+++ b/libs/apps/uesio/builder/bundle/componentpacks/main/src/utilities/autocompletefield/autocompletefield.tsx
@@ -139,7 +139,9 @@ const AutocompleteField: definition.UtilityComponent<
       </div>
 
       {isOpen && (
-        <FloatingPortal>
+        <FloatingPortal
+          root={refs.domReference.current?.closest<HTMLElement>(".uesio-theme")}
+        >
           <FloatingFocusManager context={floating.context} modal={false}>
             <div
               ref={refs.setFloating}

--- a/libs/apps/uesio/builder/bundle/componentvariants/uesio/io/button/panelactionbutton.yaml
+++ b/libs/apps/uesio/builder/bundle/componentvariants/uesio/io/button/panelactionbutton.yaml
@@ -5,11 +5,15 @@ definition:
   uesio.styleTokens:
     root:
       - bg-panel_action_button_bg_color
+      - border-1
+      - border-panel_action_button_border_color
+      - text-panel_action_button_text_color
       - gap-x-1
-      - px-2
+      - px-2.5
       - py-1.5
       - rounded-md
-      - hover:bg-slate-700
-      - hover:text-slate-100
-      - text-panel_action_button_text_color
+      - hover:bg-panel_action_button_hover_bg_color
+      - hover:text-panel_action_button_hover_text_color
+      - hover:border-panel_action_button_hover_border_color
+
 public: true

--- a/libs/apps/uesio/builder/bundle/componentvariants/uesio/io/customselectfield/propfield.yaml
+++ b/libs/apps/uesio/builder/bundle/componentvariants/uesio/io/customselectfield/propfield.yaml
@@ -15,7 +15,8 @@ definition:
       - gap-1
       - bg-field_bg_color
       - text-field_text_color
-      - border-0
+      - border-1
+      - border-field_border_color
       - text-xs
       - px-1.5
       - py-1

--- a/libs/apps/uesio/builder/bundle/componentvariants/uesio/io/field/propfield.yaml
+++ b/libs/apps/uesio/builder/bundle/componentvariants/uesio/io/field/propfield.yaml
@@ -6,10 +6,13 @@ definition:
     input:
       - bg-field_bg_color
       - text-field_text_color
-      - border-0
+      - border-1
       - text-xs
       - px-1.5
       - py-1
+      - border-field_border_color
     readonly:
+      - border-1
       - bg-field_bg_color
+      - border-field_border_color
 public: true

--- a/libs/apps/uesio/builder/bundle/componentvariants/uesio/io/selectfield/propfield.yaml
+++ b/libs/apps/uesio/builder/bundle/componentvariants/uesio/io/selectfield/propfield.yaml
@@ -10,7 +10,8 @@ definition:
     input:
       - bg-field_bg_color
       - text-field_text_color
-      - border-0
+      - border-1
+      - border-field_border_color
       - text-xs
       - px-1.5
       - py-1

--- a/libs/apps/uesio/builder/bundle/componentvariants/uesio/io/tablabels/mainsection.yaml
+++ b/libs/apps/uesio/builder/bundle/componentvariants/uesio/io/tablabels/mainsection.yaml
@@ -4,15 +4,17 @@ definition:
   uesio.styleTokens:
     root:
       - p-2
-      - gap-x-2
+      - gap-x-1
       - gap-y-1
       - grid
       - grid-flow-col
       - auto-cols-max
       - leading-none
+      - bg-panel_header_bg_color
     tab:
       - uppercase
-      - p-1.5
+      - py-1.5
+      - px-2
       - text-[8pt]
       - rounded
       - tracking-wide

--- a/libs/apps/uesio/builder/bundle/componentvariants/uesio/io/tile/indextag.yaml
+++ b/libs/apps/uesio/builder/bundle/componentvariants/uesio/io/tile/indextag.yaml
@@ -7,7 +7,9 @@ definition:
       - select-none
     selected:
       - bg-index_selected_bg_color
-      - -ml-1
+      - -ml-[5px]
+      - border-1
+      - border-index_selected_border_color
       - mb-1
       - rounded-lg
 public: true

--- a/libs/apps/uesio/builder/bundle/componentvariants/uesio/io/tile/propnodetag.yaml
+++ b/libs/apps/uesio/builder/bundle/componentvariants/uesio/io/tile/propnodetag.yaml
@@ -9,6 +9,8 @@ definition:
       - rounded
       - overflow-hidden
       - bg-item_tag_bg_color
+      - border-1
+      - border-item_tag_border_color
       - select-none
       - m-2
     selected:

--- a/libs/apps/uesio/builder/bundle/componentvariants/uesio/io/titlebar/primary.yaml
+++ b/libs/apps/uesio/builder/bundle/componentvariants/uesio/io/titlebar/primary.yaml
@@ -4,6 +4,7 @@ extends: uesio/io.default
 definition:
   uesio.styleTokens:
     root:
+      - bg-panel_header_bg_color
     content:
       - p-2
     title:

--- a/libs/apps/uesio/builder/bundle/themes/default.yaml
+++ b/libs/apps/uesio/builder/bundle/themes/default.yaml
@@ -9,40 +9,94 @@ definition:
     success: "#4caf50"
     fontcolor: slate
     accent: rose
-    panel_bg_color: slate-900
-    panel_header_divider_color: slate-800
-    panel_header_title_color: slate-100
-    panel_header_subtitle_color: slate-200
-    panel_divider_color: slate-700
-    panel_action_button_bg_color: slate-700
-    panel_action_button_text_color: slate-300
-    panel_subsection_text_color: slate-400
-    tab_label_text_color: slate-400
+    # panel_bg_color: slate-900
+    # panel_header_bg_color: transparent
+    # panel_header_divider_color: slate-800
+    # panel_header_title_color: slate-100
+    # panel_header_subtitle_color: slate-200
+    # panel_divider_color: slate-700
+    # panel_action_button_bg_color: slate-700
+    # panel_action_button_border_color: slate-700
+    # panel_action_button_text_color: slate-300
+    # panel_action_button_hover_bg_color: bg-slate-700
+    # panel_action_button_hover_border_color: bg-slate-700
+    # panel_action_button_hover_text_color: text-slate-100
+    # panel_subsection_text_color: slate-400
+    # tab_label_text_color: slate-400
+    # tab_label_selected_bg_color: slate-800
+    # tab_label_selected_text_color: slate-100
+    # searchbox_bg_color: slate-800
+    # searchbox_text_color: slate-300
+    # searchbox_placeholder_text_color: slate-400
+    # properties_crumb_bg_color: slate-400
+    # properties_header_button_bg_color: slate-400
+    # properties_header_title_bg_color: slate-400
+    # properties_header_subtitle_bg_color: slate-400
+    # index_selected_bg_color: slate-800
+    # index_selected_border_color: slate-800
+    # index_selected_divider_color: slate-900
+    # index_slot_title_color: slate-400
+    # index_component_title_color: slate-300
+    # index_visibility_button_color: slate-400
+    # index_action_button_color: slate-200
+    # item_tag_bg_color: slate-800
+    # item_tag_badge_bg_color: slate-900
+    # item_tag_badge_text_color: slate-400
+    # item_tag_title_color: slate-300
+    # item_tag_subtitle_color: slate-400
+    # item_tag_action_color: slate-400
+    # field_bg_color: slate-800
+    # field_border_color: slate-800
+    # field_text_color: slate-100
+    # field_label_text_color: slate-200
+    # field_badge_bg_color: slate-700
+    # field_badge_text_color: slate-100
+    # field_badge_action_text_color: slate-400
+    panel_bg_color: white
+    panel_header_bg_color: slate-100
+    panel_header_divider_color: slate-200
+    panel_header_title_color: slate-900
+    panel_header_subtitle_color: slate-800
+    panel_divider_color: slate-200
+    panel_action_button_bg_color: slate-100
+    panel_action_button_border_color: slate-300
+    panel_action_button_text_color: slate-700
+    panel_action_button_hover_bg_color: slate-200
+    panel_action_button_hover_border_color: slate-500
+    panel_action_button_hover_text_color: slate-800
+    panel_subsection_text_color: slate-600
+    tab_label_text_color: slate-600
     tab_label_selected_bg_color: slate-800
-    tab_label_selected_text_color: slate-100
-    searchbox_bg_color: slate-800
-    searchbox_text_color: slate-300
-    searchbox_placeholder_color: slate-400
-    properties_crumb_bg_color: slate-400
-    properties_header_button_bg_color: slate-400
-    properties_header_title_bg_color: slate-400
-    properties_header_subtitle_bg_color: slate-400
-    index_selected_bg_color: slate-800
-    index_selected_divider_color: slate-900
-    index_slot_title_color: slate-400
-    index_component_title_color: slate-300
-    index_visibility_button_color: slate-400
-    index_action_button_color: slate-200
-    item_tag_bg_color: slate-800
-    item_tag_badge_bg_color: slate-900
-    item_tag_badge_text_color: slate-400
-    item_tag_title_color: slate-300
-    item_tag_subtitle_color: slate-400
-    item_tag_action_color: slate-400
-    field_bg_color: slate-800
-    field_text_color: slate-100
-    field_label_text_color: slate-200
-    field_badge_bg_color: slate-700
-    field_badge_text_color: slate-100
-    field_badge_action_text_color: slate-400
+    tab_label_selected_text_color: slate-50
+    searchbox_bg_color: slate-50
+    searchbox_text_color: slate-700
+    searchbox_border_color: slate-300
+    searchbox_placeholder_text_color: slate-500
+    properties_crumb_bg_color: slate-600
+    properties_header_button_bg_color: slate-600
+    properties_header_title_bg_color: slate-600
+    properties_header_subtitle_bg_color: slate-600
+    index_selected_bg_color: slate-50
+    index_selected_header_bg_color: slate-100
+    index_selected_header_border_color: slate-200
+    index_selected_border_color: slate-300
+    index_selected_divider_color: slate-100
+    index_slot_title_color: slate-800
+    index_component_title_color: slate-900
+    index_visibility_button_color: slate-600
+    index_action_button_color: slate-700
+    item_tag_bg_color: slate-50
+    item_tag_border_color: slate-300
+    item_tag_badge_bg_color: slate-100
+    item_tag_badge_text_color: slate-600
+    item_tag_title_color: slate-700
+    item_tag_subtitle_color: slate-600
+    item_tag_action_color: slate-600
+    field_bg_color: slate-50
+    field_border_color: slate-300
+    field_text_color: slate-700
+    field_label_text_color: slate-800
+    field_badge_bg_color: slate-200
+    field_badge_text_color: slate-900
+    field_badge_action_text_color: slate-600
 public: true

--- a/libs/apps/uesio/io/bundle/componentpacks/main/src/components/menu/menu.tsx
+++ b/libs/apps/uesio/io/bundle/componentpacks/main/src/components/menu/menu.tsx
@@ -85,7 +85,9 @@ const Menu: definition.UC<MenuDefinition> = (props) => {
         />
       </div>
       {isOpen && (
-        <FloatingPortal>
+        <FloatingPortal
+          root={refs.domReference.current?.closest<HTMLElement>(".uesio-theme")}
+        >
           <FloatingFocusManager
             initialFocus={-1}
             context={floating.context}

--- a/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/listmenu/listmenu.tsx
+++ b/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/listmenu/listmenu.tsx
@@ -132,7 +132,9 @@ const ListMenu: definition.UtilityComponent<MenuButtonUtilityProps<unknown>> = (
       </div>
 
       {isOpen && (
-        <FloatingPortal>
+        <FloatingPortal
+          root={refs.domReference.current?.closest<HTMLElement>(".uesio-theme")}
+        >
           <FloatingFocusManager context={floating.context} modal={false}>
             <div
               ref={refs.setFloating}

--- a/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/tooltip/tooltip.tsx
+++ b/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/tooltip/tooltip.tsx
@@ -67,30 +67,34 @@ const Tooltip: definition.UtilityComponent<TooltipUtilityProps> = (props) => {
             ...children.props,
           }),
         )}
-      <FloatingPortal>
-        {open && (
-          <div
-            {...getFloatingProps()}
-            className={classes.tooltip}
-            ref={refs.setFloating}
-            style={{
-              position: strategy,
-              top: y ?? 0,
-              left: x ?? 0,
-              width: "max-content",
-            }}
-          >
-            {props.text}
-            <FloatingArrow
-              width={12}
-              height={6}
-              className={classes.arrow}
-              ref={arrowRef}
-              context={context}
-            />
-          </div>
-        )}
-      </FloatingPortal>
+      {open && (
+        <FloatingPortal
+          root={refs.domReference.current?.closest<HTMLElement>(".uesio-theme")}
+        >
+          {
+            <div
+              {...getFloatingProps()}
+              className={classes.tooltip}
+              ref={refs.setFloating}
+              style={{
+                position: strategy,
+                top: y ?? 0,
+                left: x ?? 0,
+                width: "max-content",
+              }}
+            >
+              {props.text}
+              <FloatingArrow
+                width={12}
+                height={6}
+                className={classes.arrow}
+                ref={arrowRef}
+                context={context}
+              />
+            </div>
+          }
+        </FloatingPortal>
+      )}
     </>
   )
 }


### PR DESCRIPTION
# What does this PR do?

Cleans up some builder styling issues, and switches back to a more traditional "light mode". We can work on a dark mode at a later date, but this was causing problems for some issues with users who needed higher contrast.