### PR TITLE
Fix regression with fonts in safari and menus

### DIFF
--- a/apps/platform/platform/index.gohtml
+++ b/apps/platform/platform/index.gohtml
@@ -21,9 +21,15 @@
         <meta name="robots" content="none"/>
             {{- end -}}
         {{- end }}
-        <style>
-
-        </style>
+        {{$workspace := .Route.Workspace -}}
+        {{$site := .Site -}}
+        {{- if .PreloadMetadata -}}
+            {{- if .PreloadMetadata.Font -}}
+                {{- range getFontCSSURLs .PreloadMetadata.Font $workspace $site }}
+        <link rel="stylesheet" type="text/css" href="{{.}}"/>
+                {{- end }}
+            {{- end -}}
+        {{- end }}
         {{- range .VendorScriptUrls }}
         <script src="{{.}}"></script>
         {{- end }}
@@ -38,17 +44,12 @@
         window.uesioStaticAssetsPath = "{{ .StaticAssetsPath }}"
         window.monacoEditorVersion = "{{ .MonacoEditorVersion }}"
     </script>
-    {{$workspace := .Route.Workspace -}}
-    {{$site := .Site -}}
     {{- if .PreloadMetadata -}}
         {{- if .PreloadMetadata.ComponentPack -}}
             {{- range getComponentPackURLs .PreloadMetadata.ComponentPack $workspace $site }}
     <script src="{{.}}" type="module"></script>
             {{- end }}
             {{- range getComponentPackStyleURLs .PreloadMetadata.ComponentPack $workspace $site }}
-    <link rel="stylesheet" type="text/css" href="{{.}}"/>
-            {{- end }}
-            {{- range getFontCSSURLs .PreloadMetadata.Font $workspace $site }}
     <link rel="stylesheet" type="text/css" href="{{.}}"/>
             {{- end }}
         {{- end -}}

--- a/libs/apps/uesio/builder/bundle/componentpacks/main/src/components/mainwrapper/buildbar/buildbar_header.tsx
+++ b/libs/apps/uesio/builder/bundle/componentpacks/main/src/components/mainwrapper/buildbar/buildbar_header.tsx
@@ -69,7 +69,7 @@ const BuildBarHeader: definition.UtilityComponent = (props) => {
           link={`/app/${workspace.app}`}
           classes={{ root: classes.linkButton }}
           styleTokens={{
-            root: [`text-[${nsInfo?.color}]`],
+            root: [`text-[${nsInfo?.color}]`, "max-w-[2.4em]"],
           }}
           context={context}
         />
@@ -87,7 +87,7 @@ const BuildBarHeader: definition.UtilityComponent = (props) => {
               },
             ],
             "uesio.styleTokens": {
-              root: ["ml-2.5"],
+              root: ["ml-2.5", "max-w-[2.4em]"],
             },
           }}
           context={context.deleteWorkspace()}
@@ -106,7 +106,7 @@ const BuildBarHeader: definition.UtilityComponent = (props) => {
               },
             ],
             "uesio.styleTokens": {
-              root: ["ml-1.5"],
+              root: ["ml-1.5", "max-w-[2.4em]"],
             },
           }}
           context={context.deleteWorkspace()}

--- a/libs/apps/uesio/builder/bundle/componentpacks/main/src/components/mainwrapper/buildbar/buildbar_tools.tsx
+++ b/libs/apps/uesio/builder/bundle/componentpacks/main/src/components/mainwrapper/buildbar/buildbar_tools.tsx
@@ -8,6 +8,7 @@ const StyleDefaults = Object.freeze({
     "rounded",
     "text-slate-600",
     "text-xs",
+    "[max-width:1.65em]",
   ],
 })
 

--- a/libs/apps/uesio/builder/bundle/componentpacks/main/src/utilities/autocompletefield/autocompletefield.tsx
+++ b/libs/apps/uesio/builder/bundle/componentpacks/main/src/utilities/autocompletefield/autocompletefield.tsx
@@ -140,7 +140,7 @@ const AutocompleteField: definition.UtilityComponent<
 
       {isOpen && (
         <FloatingPortal
-          root={refs.domReference.current?.closest<HTMLElement>(".uesio-theme")}
+          root={styles.getClosestThemeRoot(refs.domReference.current)}
         >
           <FloatingFocusManager context={floating.context} modal={false}>
             <div

--- a/libs/apps/uesio/io/bundle/componentpacks/main/src/components/menu/menu.tsx
+++ b/libs/apps/uesio/io/bundle/componentpacks/main/src/components/menu/menu.tsx
@@ -86,7 +86,7 @@ const Menu: definition.UC<MenuDefinition> = (props) => {
       </div>
       {isOpen && (
         <FloatingPortal
-          root={refs.domReference.current?.closest<HTMLElement>(".uesio-theme")}
+          root={styles.getClosestThemeRoot(refs.domReference.current)}
         >
           <FloatingFocusManager
             initialFocus={-1}

--- a/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/listmenu/listmenu.tsx
+++ b/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/listmenu/listmenu.tsx
@@ -133,7 +133,7 @@ const ListMenu: definition.UtilityComponent<MenuButtonUtilityProps<unknown>> = (
 
       {isOpen && (
         <FloatingPortal
-          root={refs.domReference.current?.closest<HTMLElement>(".uesio-theme")}
+          root={styles.getClosestThemeRoot(refs.domReference.current)}
         >
           <FloatingFocusManager context={floating.context} modal={false}>
             <div

--- a/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/tooltip/tooltip.tsx
+++ b/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/tooltip/tooltip.tsx
@@ -69,7 +69,7 @@ const Tooltip: definition.UtilityComponent<TooltipUtilityProps> = (props) => {
         )}
       {open && (
         <FloatingPortal
-          root={refs.domReference.current?.closest<HTMLElement>(".uesio-theme")}
+          root={styles.getClosestThemeRoot(refs.domReference.current)}
         >
           {
             <div

--- a/libs/apps/uesio/io/bundle/fonts/roboto/font.css
+++ b/libs/apps/uesio/io/bundle/fonts/roboto/font.css
@@ -2,38 +2,26 @@
   font-family: "Roboto";
   font-style: normal;
   font-weight: 300;
-  src:
-    local("Roboto Light"),
-    local("Roboto-Light"),
-    url("fonts/roboto-latin-300.woff2") format("woff2");
+  src: url("fonts/roboto-latin-300.woff2") format("woff2");
 }
 
 @font-face {
   font-family: "Roboto";
   font-style: normal;
   font-weight: 400;
-  src:
-    local("Roboto"),
-    local("Roboto-Regular"),
-    url("fonts/roboto-latin-regular.woff2") format("woff2");
+  src: url("fonts/roboto-latin-regular.woff2") format("woff2");
 }
 
 @font-face {
   font-family: "Roboto";
   font-style: normal;
   font-weight: 500;
-  src:
-    local("Roboto Medium"),
-    local("Roboto-Medium"),
-    url("fonts/roboto-latin-500.woff2") format("woff2");
+  src: url("fonts/roboto-latin-500.woff2") format("woff2");
 }
 
 @font-face {
   font-family: "Roboto";
   font-style: normal;
   font-weight: 700;
-  src:
-    local("Roboto Bold"),
-    local("Roboto-Bold"),
-    url("fonts/roboto-latin-700.woff2") format("woff2");
+  src: url("fonts/roboto-latin-700.woff2") format("woff2");
 }

--- a/libs/ui/src/styles/styles.ts
+++ b/libs/ui/src/styles/styles.ts
@@ -99,6 +99,11 @@ const DEFAULT_THEME_DATA = {
   name: "notheme",
 }
 
+const getClosestThemeRoot = (element: Element | null) => {
+  const themeRoot = element?.closest<HTMLElement>(".uesio-theme") || undefined
+  return themeRoot
+}
+
 const getTheme = (context: Context): ThemeState =>
   context.getTheme() || DEFAULT_THEME_DATA
 
@@ -327,6 +332,7 @@ export {
   useUtilityStyleTokens,
   useStyleTokens,
   getVariantTokens,
+  getClosestThemeRoot,
   getThemeValue,
   getThemeClass,
   colors,

--- a/libs/ui/src/utilities/route.tsx
+++ b/libs/ui/src/utilities/route.tsx
@@ -15,6 +15,38 @@ import { makeViewId } from "../bands/view"
 import { UtilityComponent } from "../definition/definition"
 import { setupStyles } from "../styles/styles"
 
+// This is a hack to get webfonts to show up in safari
+// after they've been loaded. I've tried a bunch of different things,
+// including different font-display: swap,block,optional,etc to no avail.
+// All this code does is cause the browser to repaint after a while.
+
+// https://stackoverflow.com/a/23522755 -- isSafari code
+const isSafari = () =>
+  /^((?!chrome|android).)*safari/i.test(navigator.userAgent)
+
+const repaintSafari = () => {
+  document.documentElement.style.display = "none"
+  // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+  document.documentElement.offsetHeight
+  document.documentElement.style.display = ""
+}
+
+if (isSafari()) {
+  // I realize this is super dumb. But i've tried all kinds of things to get
+  // safari to work correctly from FontFaceObserver, to the font-display property.
+  // The issue is that if the font isn't "used" in the initial html markup in safari,
+  // the browser isn't notified that the font has loaded.
+
+  // It would be nice to be able to figure out if we were successful in loading
+  // the font and cancel the rest of these.
+  window.setTimeout(repaintSafari, 100)
+  window.setTimeout(repaintSafari, 500)
+  window.setTimeout(repaintSafari, 1000)
+  window.setTimeout(repaintSafari, 2000)
+  window.setTimeout(repaintSafari, 4000)
+}
+// End hack
+
 const Route: UtilityComponent = (props) => {
   const site = useSite()
   const route = useRoute()


### PR DESCRIPTION
# What does this PR do?

1. Adds back a font hack for safari.
2. Fixes a regression in menus and customselects.