### PR TITLE
update nx minor version to 20.4.6

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,7 +74,7 @@ jobs:
       - name: Build and test
         env:
           UESIO_DEV: "true" # required to ensure packui gets built
-        run: npx nx affected -t build test --configuration=ci --parallel=5
+        run: npx nx affected -t build test --configuration=ci --parallel=5 --verbose
 
       - name: Prep for docker image
         id: setDockerSHAs
@@ -209,6 +209,9 @@ jobs:
 
       - name: Install NPM dependencies
         run: npm ci
+
+      - name: test step
+        run: npx nx graph --verbose
 
       - name: Check formatting
         run: npx nx format:check --verbose

--- a/package-lock.json
+++ b/package-lock.json
@@ -85,7 +85,7 @@
         "ts-jest": "^29.2.5",
         "ts-json-schema-generator": "^2.3.0",
         "tslib": "^2.8.1",
-        "typescript": "^5.7.3",
+        "typescript": "5.7.3",
         "typescript-eslint": "^8.22.0",
         "yaml": "^2.7.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,13 +19,13 @@
         "@fullcalendar/timegrid": "^6.1.15",
         "@monaco-editor/react": "^4.6.0",
         "@nx-go/nx-go": "^3.3.1",
-        "@nx/cypress": "20.4.0",
-        "@nx/eslint": "20.4.0",
-        "@nx/eslint-plugin": "20.4.0",
-        "@nx/jest": "20.4.0",
-        "@nx/js": "20.4.0",
-        "@nx/react": "20.4.0",
-        "@nx/workspace": "20.4.0",
+        "@nx/cypress": "20.4.6",
+        "@nx/eslint": "20.4.6",
+        "@nx/eslint-plugin": "20.4.6",
+        "@nx/jest": "20.4.6",
+        "@nx/js": "20.4.6",
+        "@nx/react": "20.4.6",
+        "@nx/workspace": "20.4.6",
         "@orangeopensource/hurl": "^6.0.0",
         "@react-hook/resize-observer": "^2.0.2",
         "@reduxjs/toolkit": "^2.5.1",
@@ -66,7 +66,7 @@
         "jest-environment-jsdom": "^29.7.0",
         "lodash": "^4.17.21",
         "monaco-editor": "0.50.0",
-        "nx": "20.4.0",
+        "nx": "20.4.6",
         "papaparse": "^5.5.2",
         "prettier": "^3.4.2",
         "react": "^18.3.1",
@@ -2974,24 +2974,26 @@
       "dev": true
     },
     "node_modules/@module-federation/bridge-react-webpack-plugin": {
-      "version": "0.8.9",
-      "resolved": "https://registry.npmjs.org/@module-federation/bridge-react-webpack-plugin/-/bridge-react-webpack-plugin-0.8.9.tgz",
-      "integrity": "sha512-gM5fnWvFfTEfh5UjSmNod1H/np/pUUjvJnnN31ucKcZ21mL6wJo0A+Vfj8a5gv34S+1n5lWR1b6eVv9CofwgDQ==",
+      "version": "0.8.12",
+      "resolved": "https://registry.npmjs.org/@module-federation/bridge-react-webpack-plugin/-/bridge-react-webpack-plugin-0.8.12.tgz",
+      "integrity": "sha512-fiSf9Df4RqdKiL1WtS7eCqAWqDnLNwMZ9qU7ZMjXSAhI3wOLzycFflpVx7PWOxSoTJPtc61hwD5lkEpNoHezkg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@module-federation/sdk": "0.8.9",
+        "@module-federation/sdk": "0.8.12",
         "@types/semver": "7.5.8",
         "semver": "7.6.3"
       }
     },
     "node_modules/@module-federation/data-prefetch": {
-      "version": "0.8.9",
-      "resolved": "https://registry.npmjs.org/@module-federation/data-prefetch/-/data-prefetch-0.8.9.tgz",
-      "integrity": "sha512-doUzJ5uuLPrN5e/NMvKuyUE/lqiZFgGzFITwBF90/KKqOq7R2ZWh43R4RJgkUYfs/F119AYXZ9jxrSphIh+cjg==",
+      "version": "0.8.12",
+      "resolved": "https://registry.npmjs.org/@module-federation/data-prefetch/-/data-prefetch-0.8.12.tgz",
+      "integrity": "sha512-YjCk6KPBQ4Ml2/2aIKQt11I4jBKOTvK3xHyAQMKPpX5aBbMEwonDhkpTitygUw3SMBdi3CP1KMRDJ3suj3O6Mg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@module-federation/runtime": "0.8.9",
-        "@module-federation/sdk": "0.8.9",
+        "@module-federation/runtime": "0.8.12",
+        "@module-federation/sdk": "0.8.12",
         "fs-extra": "9.1.0"
       },
       "peerDependencies": {
@@ -3000,15 +3002,16 @@
       }
     },
     "node_modules/@module-federation/dts-plugin": {
-      "version": "0.8.9",
-      "resolved": "https://registry.npmjs.org/@module-federation/dts-plugin/-/dts-plugin-0.8.9.tgz",
-      "integrity": "sha512-Q40yqdQvTV8QRoegjUquTejhLl2gZoPv623hc8MWmGuP2vXLBIJJ9iV849LkFLeE8xaUgtwmn2uCQeBh2aJNjg==",
+      "version": "0.8.12",
+      "resolved": "https://registry.npmjs.org/@module-federation/dts-plugin/-/dts-plugin-0.8.12.tgz",
+      "integrity": "sha512-BhRZsG68XtGzKM0N02/3ldiW+PTc+QaHCMNyiZnk3GcxS0qe6USu7fTQwRIPCC2GONIdoHD+GVYPN/NJWjbTFg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@module-federation/error-codes": "0.8.9",
-        "@module-federation/managers": "0.8.9",
-        "@module-federation/sdk": "0.8.9",
-        "@module-federation/third-party-dts-extractor": "0.8.9",
+        "@module-federation/error-codes": "0.8.12",
+        "@module-federation/managers": "0.8.12",
+        "@module-federation/sdk": "0.8.12",
+        "@module-federation/third-party-dts-extractor": "0.8.12",
         "adm-zip": "^0.5.10",
         "ansi-colors": "^4.1.3",
         "axios": "^1.7.4",
@@ -3037,6 +3040,7 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
       "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -3046,21 +3050,22 @@
       }
     },
     "node_modules/@module-federation/enhanced": {
-      "version": "0.8.9",
-      "resolved": "https://registry.npmjs.org/@module-federation/enhanced/-/enhanced-0.8.9.tgz",
-      "integrity": "sha512-feZUhznCyFkyivWNSFPN+FHMZmyrxlKBhWW8ldWsp/LlKIzWI75vMLimpiydBWnWTZgnOhQDBZGZVxSlfnfKHQ==",
+      "version": "0.8.12",
+      "resolved": "https://registry.npmjs.org/@module-federation/enhanced/-/enhanced-0.8.12.tgz",
+      "integrity": "sha512-uJODfWqL3C87LUu1E0ZLPRqE0sUt6QFH97bMFoCWYhkf8JS7J+wMc4KSc31ApaJs7CeQICXR1CYBAZDSdxkrOQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@module-federation/bridge-react-webpack-plugin": "0.8.9",
-        "@module-federation/data-prefetch": "0.8.9",
-        "@module-federation/dts-plugin": "0.8.9",
-        "@module-federation/error-codes": "0.8.9",
-        "@module-federation/inject-external-runtime-core-plugin": "0.8.9",
-        "@module-federation/managers": "0.8.9",
-        "@module-federation/manifest": "0.8.9",
-        "@module-federation/rspack": "0.8.9",
-        "@module-federation/runtime-tools": "0.8.9",
-        "@module-federation/sdk": "0.8.9",
+        "@module-federation/bridge-react-webpack-plugin": "0.8.12",
+        "@module-federation/data-prefetch": "0.8.12",
+        "@module-federation/dts-plugin": "0.8.12",
+        "@module-federation/error-codes": "0.8.12",
+        "@module-federation/inject-external-runtime-core-plugin": "0.8.12",
+        "@module-federation/managers": "0.8.12",
+        "@module-federation/manifest": "0.8.12",
+        "@module-federation/rspack": "0.8.12",
+        "@module-federation/runtime-tools": "0.8.12",
+        "@module-federation/sdk": "0.8.12",
         "btoa": "^1.2.1",
         "upath": "2.0.1"
       },
@@ -3082,40 +3087,44 @@
       }
     },
     "node_modules/@module-federation/error-codes": {
-      "version": "0.8.9",
-      "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-0.8.9.tgz",
-      "integrity": "sha512-yUA3GZjOy8Ll6l193faXir2veexDaUiLdmptbzC9tIee/iSQiSwIlibdTafCfqaJ62cLZaytOUdmAFAKLv8QQw==",
-      "dev": true
+      "version": "0.8.12",
+      "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-0.8.12.tgz",
+      "integrity": "sha512-K+F4iiV62KY+IpjK6ggn3vI5Yt/T/LUb6xuazY78bhAGwLaHe1DYr7BfSutKMpiB+Dcs6U4dYOBogSMnnl0j4Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@module-federation/inject-external-runtime-core-plugin": {
-      "version": "0.8.9",
-      "resolved": "https://registry.npmjs.org/@module-federation/inject-external-runtime-core-plugin/-/inject-external-runtime-core-plugin-0.8.9.tgz",
-      "integrity": "sha512-F3s/3Iny20c0Y0CaXgOZdgl7PzgXj6ftCiT5FO6QWmyhzfl2R0o3KFuv54BmwtoimSFky1ShuC/jPluz4EGG1g==",
+      "version": "0.8.12",
+      "resolved": "https://registry.npmjs.org/@module-federation/inject-external-runtime-core-plugin/-/inject-external-runtime-core-plugin-0.8.12.tgz",
+      "integrity": "sha512-/vFW+eiBiqXOKkDYVKl5JXGI0H4Whj10P8JadowxuHcEuR+R7kkXXauYuGYKaxIFqG4zbN3r9su2qxIEEqOsOw==",
       "dev": true,
+      "license": "MIT",
       "peerDependencies": {
-        "@module-federation/runtime-tools": "0.8.9"
+        "@module-federation/runtime-tools": "0.8.12"
       }
     },
     "node_modules/@module-federation/managers": {
-      "version": "0.8.9",
-      "resolved": "https://registry.npmjs.org/@module-federation/managers/-/managers-0.8.9.tgz",
-      "integrity": "sha512-Fb28sa2iAqwSSSgiPBoL5Kp0RB9ZKJvdwLAEwZBV2c2LyZUqJCdTjmYuB5Q2sWB9wsudd/ijV6WWNK/nVoJxdA==",
+      "version": "0.8.12",
+      "resolved": "https://registry.npmjs.org/@module-federation/managers/-/managers-0.8.12.tgz",
+      "integrity": "sha512-+BBdBMptHiiT2ZsfPovQuHYkse6R1+dmDS6bAinw3UGpb418W8ERp5I4jHeyhEtr3t3mb/dh4sAsYM14/EWJ9Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@module-federation/sdk": "0.8.9",
+        "@module-federation/sdk": "0.8.12",
         "find-pkg": "2.0.0",
         "fs-extra": "9.1.0"
       }
     },
     "node_modules/@module-federation/manifest": {
-      "version": "0.8.9",
-      "resolved": "https://registry.npmjs.org/@module-federation/manifest/-/manifest-0.8.9.tgz",
-      "integrity": "sha512-48jIv50l0tTx+CVzs2JKMlTO0mcUvFRDxqO79nJaL1DLfpRQoCRQjCA8sXUp5PPIyJ8MHQqkHK/dnaal4NlR/A==",
+      "version": "0.8.12",
+      "resolved": "https://registry.npmjs.org/@module-federation/manifest/-/manifest-0.8.12.tgz",
+      "integrity": "sha512-UwC6/QK37x7Xr5K+89iKxOy/uQHqFMd49axOhgDmFSrWQOULFQd51EpTOxFXgwZfiq/h0uVBYq/c0GB3Tdu8GA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@module-federation/dts-plugin": "0.8.9",
-        "@module-federation/managers": "0.8.9",
-        "@module-federation/sdk": "0.8.9",
+        "@module-federation/dts-plugin": "0.8.12",
+        "@module-federation/managers": "0.8.12",
+        "@module-federation/sdk": "0.8.12",
         "chalk": "3.0.0",
         "find-pkg": "2.0.0"
       }
@@ -3125,6 +3134,7 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
       "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -3134,15 +3144,16 @@
       }
     },
     "node_modules/@module-federation/node": {
-      "version": "2.6.22",
-      "resolved": "https://registry.npmjs.org/@module-federation/node/-/node-2.6.22.tgz",
-      "integrity": "sha512-KlBJXakBO0KMCLTv7622aQNQk3JLfUqXJtd28nUt7xJNV9OZclHvRmKS83zHGEV/6hBKuLtYlP/+S4LMoMKiOw==",
+      "version": "2.6.26",
+      "resolved": "https://registry.npmjs.org/@module-federation/node/-/node-2.6.26.tgz",
+      "integrity": "sha512-5hWUv93LOeJOpwSpi2febxD25kIR0Ondmhpt9FCK0ggSpA8T4hxI2U5d4DN8MOYhSzPdM4EoVHfOT0t9r79MeA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@module-federation/enhanced": "0.8.9",
-        "@module-federation/runtime": "0.8.9",
-        "@module-federation/sdk": "0.8.9",
-        "@module-federation/utilities": "3.1.40",
+        "@module-federation/enhanced": "0.9.0",
+        "@module-federation/runtime": "0.9.0",
+        "@module-federation/sdk": "0.9.0",
+        "@module-federation/utilities": "3.1.44",
         "btoa": "1.2.1",
         "encoding": "^0.1.13",
         "node-fetch": "2.7.0"
@@ -3164,19 +3175,372 @@
         }
       }
     },
-    "node_modules/@module-federation/rspack": {
-      "version": "0.8.9",
-      "resolved": "https://registry.npmjs.org/@module-federation/rspack/-/rspack-0.8.9.tgz",
-      "integrity": "sha512-wuHRx+aUYhsrAQzU5yKQksaOJ8pwhuQJDl8I86xmzkEsnxcWsZcn49xIR4t7v1HcYAqjBXLNXSoQwkIMH9zu2w==",
+    "node_modules/@module-federation/node/node_modules/@module-federation/bridge-react-webpack-plugin": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/bridge-react-webpack-plugin/-/bridge-react-webpack-plugin-0.9.0.tgz",
+      "integrity": "sha512-EaUMMmNVx5IRXB8o39tPU05uWuDN38noQbUjwE2xi8Y5xTx3CFZ9tkgXX+tvzcWc+bu4RnaziaI0RtyBfHhHKw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@module-federation/bridge-react-webpack-plugin": "0.8.9",
-        "@module-federation/dts-plugin": "0.8.9",
-        "@module-federation/inject-external-runtime-core-plugin": "0.8.9",
-        "@module-federation/managers": "0.8.9",
-        "@module-federation/manifest": "0.8.9",
-        "@module-federation/runtime-tools": "0.8.9",
-        "@module-federation/sdk": "0.8.9"
+        "@module-federation/sdk": "0.9.0",
+        "@types/semver": "7.5.8",
+        "semver": "7.6.3"
+      }
+    },
+    "node_modules/@module-federation/node/node_modules/@module-federation/data-prefetch": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/data-prefetch/-/data-prefetch-0.9.0.tgz",
+      "integrity": "sha512-KFC3lOzW/Hwvcgm/tn7075fqC/ONhA+5zPqDz090EsCQqnWQHodzx0XF88/tTvWdfc3mYK9BGYfsnpjlVGT1zA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/runtime": "0.9.0",
+        "@module-federation/sdk": "0.9.0",
+        "fs-extra": "9.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@module-federation/node/node_modules/@module-federation/dts-plugin": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/dts-plugin/-/dts-plugin-0.9.0.tgz",
+      "integrity": "sha512-2Uu1sPRT9/uB+pG4vQGkLdpsMVM6FK7howulTdy42u6Dz0c2Ivc//od/noM0KEgWf1p54FAtWzpjkqjO5PyciA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/error-codes": "0.9.0",
+        "@module-federation/managers": "0.9.0",
+        "@module-federation/sdk": "0.9.0",
+        "@module-federation/third-party-dts-extractor": "0.9.0",
+        "adm-zip": "^0.5.10",
+        "ansi-colors": "^4.1.3",
+        "axios": "^1.7.4",
+        "chalk": "3.0.0",
+        "fs-extra": "9.1.0",
+        "isomorphic-ws": "5.0.0",
+        "koa": "2.15.4",
+        "lodash.clonedeepwith": "4.5.0",
+        "log4js": "6.9.1",
+        "node-schedule": "2.1.1",
+        "rambda": "^9.1.0",
+        "ws": "8.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^4.9.0 || ^5.0.0",
+        "vue-tsc": ">=1.0.24"
+      },
+      "peerDependenciesMeta": {
+        "vue-tsc": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@module-federation/node/node_modules/@module-federation/enhanced": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/enhanced/-/enhanced-0.9.0.tgz",
+      "integrity": "sha512-/fiIc+lZvP7pEiVWe0/0v2ueVcEumew2UNewguHFj3bxyyU5/+/5rHPRV5QIKcLzydrVLvTiS4/dB2Mqd7CVAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/bridge-react-webpack-plugin": "0.9.0",
+        "@module-federation/data-prefetch": "0.9.0",
+        "@module-federation/dts-plugin": "0.9.0",
+        "@module-federation/error-codes": "0.9.0",
+        "@module-federation/inject-external-runtime-core-plugin": "0.9.0",
+        "@module-federation/managers": "0.9.0",
+        "@module-federation/manifest": "0.9.0",
+        "@module-federation/rspack": "0.9.0",
+        "@module-federation/runtime-tools": "0.9.0",
+        "@module-federation/sdk": "0.9.0",
+        "btoa": "^1.2.1",
+        "upath": "2.0.1"
+      },
+      "peerDependencies": {
+        "typescript": "^4.9.0 || ^5.0.0",
+        "vue-tsc": ">=1.0.24",
+        "webpack": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "vue-tsc": {
+          "optional": true
+        },
+        "webpack": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@module-federation/node/node_modules/@module-federation/error-codes": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-0.9.0.tgz",
+      "integrity": "sha512-dNqIs5cQfE4p+WIdiZ64cTSRJ5KjGaV+epvZkGttrNjXW9XAAtE7zgpo7cMQ8GWA3wCGaKnFw7Dn48XcU5ZMNw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@module-federation/node/node_modules/@module-federation/inject-external-runtime-core-plugin": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/inject-external-runtime-core-plugin/-/inject-external-runtime-core-plugin-0.9.0.tgz",
+      "integrity": "sha512-gDvYmcJyuXy1qzBZ6c+AndQUm50iOXmc56C2GN+F9ILAOQ/dcWFfD+OxyjXr80Pvej6qawW9CTEEWHNF4m4a+w==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@module-federation/runtime-tools": "0.9.0"
+      }
+    },
+    "node_modules/@module-federation/node/node_modules/@module-federation/managers": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/managers/-/managers-0.9.0.tgz",
+      "integrity": "sha512-km8fVdS/r3TRLbSCV8IytKaQVuMbXbHvdZsgK4HRIWqGyBbA2q+gbXfWSC90OhdxNA9hhPEipmx+4hvuXDwaFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/sdk": "0.9.0",
+        "find-pkg": "2.0.0",
+        "fs-extra": "9.1.0"
+      }
+    },
+    "node_modules/@module-federation/node/node_modules/@module-federation/manifest": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/manifest/-/manifest-0.9.0.tgz",
+      "integrity": "sha512-o6+AyKdznP/Pyd6x/1staafUKNxIuXbmmpZxeL3VDvg8uR+6QM5bd/iXnBUgxaznIGQvUwvW/F1JixdgXwp7ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/dts-plugin": "0.9.0",
+        "@module-federation/managers": "0.9.0",
+        "@module-federation/sdk": "0.9.0",
+        "chalk": "3.0.0",
+        "find-pkg": "2.0.0"
+      }
+    },
+    "node_modules/@module-federation/node/node_modules/@module-federation/rspack": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/rspack/-/rspack-0.9.0.tgz",
+      "integrity": "sha512-Cw5/OGknuPwmkWc3jVj+T/uqtQ33cxDVMuaFIA6qGAiy/WfMyElKnOBe0n3JRaigH/A8qkyN/rNvMynYlTczLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/bridge-react-webpack-plugin": "0.9.0",
+        "@module-federation/dts-plugin": "0.9.0",
+        "@module-federation/inject-external-runtime-core-plugin": "0.9.0",
+        "@module-federation/managers": "0.9.0",
+        "@module-federation/manifest": "0.9.0",
+        "@module-federation/runtime-tools": "0.9.0",
+        "@module-federation/sdk": "0.9.0"
+      },
+      "peerDependencies": {
+        "@rspack/core": ">=0.7",
+        "typescript": "^4.9.0 || ^5.0.0",
+        "vue-tsc": ">=1.0.24"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "vue-tsc": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@module-federation/node/node_modules/@module-federation/runtime": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-0.9.0.tgz",
+      "integrity": "sha512-WByDEbJ/9fEUBOQILQRYX9CpAjCEmiU1MBSRoTg0emRKBcE9Ms5vTBN0XVuO+3gZSeyk08SfmaLtnCaeHK8ABA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/error-codes": "0.9.0",
+        "@module-federation/runtime-core": "0.6.21",
+        "@module-federation/sdk": "0.9.0"
+      }
+    },
+    "node_modules/@module-federation/node/node_modules/@module-federation/runtime-core": {
+      "version": "0.6.21",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-0.6.21.tgz",
+      "integrity": "sha512-CLQiPP3kpcPbgPkiu/A1VURI2v4geFnEdizlB1tq0c6eDZqb5aLzvp87ZCGDVSuwY7DCq6jh1k+CM2WGge/2xA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/error-codes": "0.9.0",
+        "@module-federation/sdk": "0.9.0"
+      }
+    },
+    "node_modules/@module-federation/node/node_modules/@module-federation/runtime-tools": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-0.9.0.tgz",
+      "integrity": "sha512-ioYVUsUfQjS7tgRBpZ6KFbz8YET2wD/2KmrO4zVaVHZ3RPyJzwVP9sLlDDdyf/Cn/1sQjNLg57FpyBADmY5M1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/runtime": "0.9.0",
+        "@module-federation/webpack-bundler-runtime": "0.9.0"
+      }
+    },
+    "node_modules/@module-federation/node/node_modules/@module-federation/sdk": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.9.0.tgz",
+      "integrity": "sha512-84MklxE6Z79gCAr+6HCyqOpF95pqSah+fGnhLz+g4ePcWf98J73bWfrdOWFO/UfxMRneXKBZBNbpDVvPLgaFeQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "isomorphic-rslog": "0.0.7"
+      }
+    },
+    "node_modules/@module-federation/node/node_modules/@module-federation/third-party-dts-extractor": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/third-party-dts-extractor/-/third-party-dts-extractor-0.9.0.tgz",
+      "integrity": "sha512-gNMiFxSAkyy85KmdcdapKOP0RVqfuhzosdj92T9xXxR9juuILNS0TtgKbgYwNwvDs/WjOhTON5gz2lsX0kFKRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-pkg": "2.0.0",
+        "fs-extra": "9.1.0",
+        "resolve": "1.22.8"
+      }
+    },
+    "node_modules/@module-federation/node/node_modules/@module-federation/webpack-bundler-runtime": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-0.9.0.tgz",
+      "integrity": "sha512-banXhVcgNYTqH13C6E9KrpwJ+UHaTvHfkvCRPs1y2EVvB9guPO6MnQ9Fd1DCwVMfpq3zMtJpPHobAqF5AmkCHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/runtime": "0.9.0",
+        "@module-federation/sdk": "0.9.0"
+      }
+    },
+    "node_modules/@module-federation/node/node_modules/chalk": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@module-federation/node/node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@module-federation/node/node_modules/http-errors": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@module-federation/node/node_modules/http-errors/node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@module-federation/node/node_modules/koa": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/koa/-/koa-2.15.4.tgz",
+      "integrity": "sha512-7fNBIdrU2PEgLljXoPWoyY4r1e+ToWCmzS/wwMPbUNs7X+5MMET1ObhJBlUkF5uZG9B6QhM2zS1TsH6adegkiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^1.3.5",
+        "cache-content-type": "^1.0.0",
+        "content-disposition": "~0.5.2",
+        "content-type": "^1.0.4",
+        "cookies": "~0.9.0",
+        "debug": "^4.3.2",
+        "delegates": "^1.0.0",
+        "depd": "^2.0.0",
+        "destroy": "^1.0.4",
+        "encodeurl": "^1.0.2",
+        "escape-html": "^1.0.3",
+        "fresh": "~0.5.2",
+        "http-assert": "^1.3.0",
+        "http-errors": "^1.6.3",
+        "is-generator-function": "^1.0.7",
+        "koa-compose": "^4.1.0",
+        "koa-convert": "^2.0.0",
+        "on-finished": "^2.3.0",
+        "only": "~0.0.2",
+        "parseurl": "^1.3.2",
+        "statuses": "^1.5.0",
+        "type-is": "^1.6.16",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": "^4.8.4 || ^6.10.1 || ^7.10.1 || >= 8.1.4"
+      }
+    },
+    "node_modules/@module-federation/node/node_modules/resolve": {
+      "version": "1.22.8",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.13.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@module-federation/node/node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@module-federation/rspack": {
+      "version": "0.8.12",
+      "resolved": "https://registry.npmjs.org/@module-federation/rspack/-/rspack-0.8.12.tgz",
+      "integrity": "sha512-G73Cq7VwKdpFZwMd9hEBsE2HLF7mNQEIvLSiW6HOZG/+iWRRED1opiVkrjOmkcg770rChYSqTBiLvUS7HDT5Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/bridge-react-webpack-plugin": "0.8.12",
+        "@module-federation/dts-plugin": "0.8.12",
+        "@module-federation/inject-external-runtime-core-plugin": "0.8.12",
+        "@module-federation/managers": "0.8.12",
+        "@module-federation/manifest": "0.8.12",
+        "@module-federation/runtime-tools": "0.8.12",
+        "@module-federation/sdk": "0.8.12"
       },
       "peerDependencies": {
         "@rspack/core": ">=0.7",
@@ -3193,50 +3557,55 @@
       }
     },
     "node_modules/@module-federation/runtime": {
-      "version": "0.8.9",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-0.8.9.tgz",
-      "integrity": "sha512-i+a+/hoT/c+EE52mT+gJrbA6DhL86PY9cd/dIv/oKpLz9i+yYBlG+RA+puc7YsUEO4irbFLvnIMq6AGDUKVzYA==",
+      "version": "0.8.12",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-0.8.12.tgz",
+      "integrity": "sha512-eYohRfambj/qzxz6tEakDn459ROcixWO4zL5gmTEOmwG+jCDnxGR14j1guopyrrpjb6EKFNrPVWtYZTPPfGdQQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@module-federation/error-codes": "0.8.9",
-        "@module-federation/runtime-core": "0.6.17",
-        "@module-federation/sdk": "0.8.9"
+        "@module-federation/error-codes": "0.8.12",
+        "@module-federation/runtime-core": "0.6.20",
+        "@module-federation/sdk": "0.8.12"
       }
     },
     "node_modules/@module-federation/runtime-core": {
-      "version": "0.6.17",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-0.6.17.tgz",
-      "integrity": "sha512-PXFN/TT9f64Un6NQYqH1Z0QLhpytW15jkZvTEOV8W7Ed319BECFI0Rv4xAsAGa8zJGFoaM/c7QOQfdFXtKj5Og==",
+      "version": "0.6.20",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-0.6.20.tgz",
+      "integrity": "sha512-rX7sd/i7tpkAbfMD4TtFt/57SWNC/iv7UYS8g+ad7mnCJggWE1YEKsKSFgcvp4zU3thwR+j2y+kOCwd1sQvxEA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@module-federation/error-codes": "0.8.9",
-        "@module-federation/sdk": "0.8.9"
+        "@module-federation/error-codes": "0.8.12",
+        "@module-federation/sdk": "0.8.12"
       }
     },
     "node_modules/@module-federation/runtime-tools": {
-      "version": "0.8.9",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-0.8.9.tgz",
-      "integrity": "sha512-xBUGx1oOZNuxXjPGdTMrLtAIDrbrN6jE2Mgb9w1qr2mQ4AW9b5TOlxbARBoX4q98xt9oFCGU6Q0eW5XJpsl8AQ==",
+      "version": "0.8.12",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-0.8.12.tgz",
+      "integrity": "sha512-H97wR/toSU9+UO9S0VHLmPg/7QgohMI52EZlR0Kh0F4PD6fbiWuO4kBIp7R6g0dMI9D4NVKWTKV8xA9ASU+k7g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@module-federation/runtime": "0.8.9",
-        "@module-federation/webpack-bundler-runtime": "0.8.9"
+        "@module-federation/runtime": "0.8.12",
+        "@module-federation/webpack-bundler-runtime": "0.8.12"
       }
     },
     "node_modules/@module-federation/sdk": {
-      "version": "0.8.9",
-      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.8.9.tgz",
-      "integrity": "sha512-QJ60itWC/SPjqduT7wDiF8UGwVU/yJ/Sz+QbnoxB9b7gNLzvI//swAXTo9eOtKsCy/V2BMwjt0F3eOcfnaqllA==",
+      "version": "0.8.12",
+      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.8.12.tgz",
+      "integrity": "sha512-zFgXYBHbzwIqlrLfn6ewIRXDZCctDDQT2nFhbsZr29yWQgpmW1fm2kJCxQsG0DENGGN1KpzfDoxjjvSKJS/ZHA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "isomorphic-rslog": "0.0.7"
       }
     },
     "node_modules/@module-federation/third-party-dts-extractor": {
-      "version": "0.8.9",
-      "resolved": "https://registry.npmjs.org/@module-federation/third-party-dts-extractor/-/third-party-dts-extractor-0.8.9.tgz",
-      "integrity": "sha512-53v6B5zfhGlAPpH0SrlJDp9B6kcOcZaUPi6J4L/7ie5F0YVe0vq/mJGOOzAStN9ggJjSrjBZLFT3gFmBYM3Z9A==",
+      "version": "0.8.12",
+      "resolved": "https://registry.npmjs.org/@module-federation/third-party-dts-extractor/-/third-party-dts-extractor-0.8.12.tgz",
+      "integrity": "sha512-+ZO5XpBwEhP9v/Tqk51YgswwbAzj4TXKZ54++uVDsLnOh9yydVGJ/b5pQcSrc8B1C55+498tsDEcNsFgZODgMQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "find-pkg": "2.0.0",
         "fs-extra": "9.1.0",
@@ -3248,6 +3617,7 @@
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
       "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
@@ -3261,12 +3631,13 @@
       }
     },
     "node_modules/@module-federation/utilities": {
-      "version": "3.1.40",
-      "resolved": "https://registry.npmjs.org/@module-federation/utilities/-/utilities-3.1.40.tgz",
-      "integrity": "sha512-/Oa0jtNCEEfQhXIV0/H/pm+PEfYy4QUfCIcgTr5TJ1QB3OR1D+tBYRFGYYJaTeMRzS4PI4Rh1vv/egzQ9pbgSg==",
+      "version": "3.1.44",
+      "resolved": "https://registry.npmjs.org/@module-federation/utilities/-/utilities-3.1.44.tgz",
+      "integrity": "sha512-kbINh8YXg9AGTjTeCHu8w6tSZ64S+x+hfK9l7r3GDEKotmbfHJKJ3R5DhhdzBf0OEEJzjDQkKbIJQbKEI+WoYQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@module-federation/sdk": "0.8.9"
+        "@module-federation/sdk": "0.9.0"
       },
       "peerDependencies": {
         "react": "^16 || ^17 || ^18",
@@ -3285,14 +3656,25 @@
         }
       }
     },
-    "node_modules/@module-federation/webpack-bundler-runtime": {
-      "version": "0.8.9",
-      "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-0.8.9.tgz",
-      "integrity": "sha512-DYLvVi4b2MUYu/B4g5wIC5SHxiODboKHkYGHYapOhCcqOchca/N16gtiAI8eSNjJPc+fgUXUGIyGiB18IlFEeQ==",
+    "node_modules/@module-federation/utilities/node_modules/@module-federation/sdk": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.9.0.tgz",
+      "integrity": "sha512-84MklxE6Z79gCAr+6HCyqOpF95pqSah+fGnhLz+g4ePcWf98J73bWfrdOWFO/UfxMRneXKBZBNbpDVvPLgaFeQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@module-federation/runtime": "0.8.9",
-        "@module-federation/sdk": "0.8.9"
+        "isomorphic-rslog": "0.0.7"
+      }
+    },
+    "node_modules/@module-federation/webpack-bundler-runtime": {
+      "version": "0.8.12",
+      "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-0.8.12.tgz",
+      "integrity": "sha512-zd343RO7/R7Xjh5ym5KdnYQ70z4LBmMxWsa44FS0nyNv04sOq6V1eZSCGKbEhbfqqhbS5Wfj8OzJyedeVvV/OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/runtime": "0.8.12",
+        "@module-federation/sdk": "0.8.12"
       }
     },
     "node_modules/@monaco-editor/loader": {
@@ -3378,14 +3760,15 @@
       }
     },
     "node_modules/@nx/cypress": {
-      "version": "20.4.0",
-      "resolved": "https://registry.npmjs.org/@nx/cypress/-/cypress-20.4.0.tgz",
-      "integrity": "sha512-K6ga2k5Cfqlg2uBayiOHcMe8sjHgT0AM6HajCFlYHc3ZsRhFx8vlN33mqU++u8VbStXG8m8vs9+yP21uZuJghA==",
+      "version": "20.4.6",
+      "resolved": "https://registry.npmjs.org/@nx/cypress/-/cypress-20.4.6.tgz",
+      "integrity": "sha512-Wh9OXWXBjEpt1ZMh4QGrGNkI0AyjeFaxrP2cSEqfFro8YFG1L081GeGXnJ5WzhYcr4bhIMSqflXg/q4W0x1YLw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@nx/devkit": "20.4.0",
-        "@nx/eslint": "20.4.0",
-        "@nx/js": "20.4.0",
+        "@nx/devkit": "20.4.6",
+        "@nx/eslint": "20.4.6",
+        "@nx/js": "20.4.6",
         "@phenomnomnominal/tsquery": "~5.0.1",
         "detect-port": "^1.5.1",
         "tslib": "^2.3.0"
@@ -3400,10 +3783,11 @@
       }
     },
     "node_modules/@nx/devkit": {
-      "version": "20.4.0",
-      "resolved": "https://registry.npmjs.org/@nx/devkit/-/devkit-20.4.0.tgz",
-      "integrity": "sha512-qog9oGbuz7DDoXH5k+19tTI3WtaR1p9G5NobiDPfcWmsr1BTK2WH2V2/vVYFAfAcM/DEFgK3ITC5L3PSaJvMmw==",
+      "version": "20.4.6",
+      "resolved": "https://registry.npmjs.org/@nx/devkit/-/devkit-20.4.6.tgz",
+      "integrity": "sha512-XGnCu4p9HUrs6pDZmfpBF5hmmvXzLvV+oZJP0slFRoi9hVdXiZ31t+Vh0AQc7zSbtPeCxEJDxY4dIJKgdesR0A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ejs": "^3.1.7",
         "enquirer": "~2.3.6",
@@ -3419,13 +3803,14 @@
       }
     },
     "node_modules/@nx/eslint": {
-      "version": "20.4.0",
-      "resolved": "https://registry.npmjs.org/@nx/eslint/-/eslint-20.4.0.tgz",
-      "integrity": "sha512-w22DzI7ErmFlSyxdmUdUkz1+zCbLAaG3iId/6Jt27JO1jL/u/AoCGm3XlAMsRn+6EbOxu4IQQ/poxyYomHZNMQ==",
+      "version": "20.4.6",
+      "resolved": "https://registry.npmjs.org/@nx/eslint/-/eslint-20.4.6.tgz",
+      "integrity": "sha512-lPVvUrRYaQqkwY0kg4hO0B6GJt+zihmp+zNppbHllq/v5uHZRm0+3RrmJhAdmxlubuR7A49jdQe4fHOlFySpAw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@nx/devkit": "20.4.0",
-        "@nx/js": "20.4.0",
+        "@nx/devkit": "20.4.6",
+        "@nx/js": "20.4.6",
         "semver": "^7.5.3",
         "tslib": "^2.3.0",
         "typescript": "~5.7.2"
@@ -3441,13 +3826,14 @@
       }
     },
     "node_modules/@nx/eslint-plugin": {
-      "version": "20.4.0",
-      "resolved": "https://registry.npmjs.org/@nx/eslint-plugin/-/eslint-plugin-20.4.0.tgz",
-      "integrity": "sha512-uyN4zxdjh/O3RzCvSgMErzs2PESSucvct6rpkXr/D6tkp5UYkAz6QbtnJXf4fbeCYE2hvChGWP4D/1CjcH3nvw==",
+      "version": "20.4.6",
+      "resolved": "https://registry.npmjs.org/@nx/eslint-plugin/-/eslint-plugin-20.4.6.tgz",
+      "integrity": "sha512-CsR7aiDKIBqhk5v+6m+Qmlob9CipRx7DvvbCa5tPqFvXCQjjD5/wqisxydd9VAuz84DxjlrXcbA4dqlP8ZF5Lw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@nx/devkit": "20.4.0",
-        "@nx/js": "20.4.0",
+        "@nx/devkit": "20.4.6",
+        "@nx/js": "20.4.6",
         "@typescript-eslint/type-utils": "^8.0.0",
         "@typescript-eslint/utils": "^8.0.0",
         "chalk": "^4.1.0",
@@ -3468,15 +3854,16 @@
       }
     },
     "node_modules/@nx/jest": {
-      "version": "20.4.0",
-      "resolved": "https://registry.npmjs.org/@nx/jest/-/jest-20.4.0.tgz",
-      "integrity": "sha512-Em0MT1QnoM0GeSR+Oahr3kqeoVJmpJ0e+V5QqOk760nRBd20uObPf5f+MMZ5crugnVG3iEuTrQioqn5vGLCbKg==",
+      "version": "20.4.6",
+      "resolved": "https://registry.npmjs.org/@nx/jest/-/jest-20.4.6.tgz",
+      "integrity": "sha512-yZOZJOQFtpdY3Fu/WYNoDx81TwvF9yfwvalFpLD19bz+2YGl7B89l0S1ZrtSRXFfKXA/w7gb0gmKwthJtQhx9Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jest/reporters": "^29.4.1",
         "@jest/test-result": "^29.4.1",
-        "@nx/devkit": "20.4.0",
-        "@nx/js": "20.4.0",
+        "@nx/devkit": "20.4.6",
+        "@nx/js": "20.4.6",
         "@phenomnomnominal/tsquery": "~5.0.1",
         "identity-obj-proxy": "3.0.0",
         "jest-config": "^29.4.1",
@@ -3491,10 +3878,11 @@
       }
     },
     "node_modules/@nx/js": {
-      "version": "20.4.0",
-      "resolved": "https://registry.npmjs.org/@nx/js/-/js-20.4.0.tgz",
-      "integrity": "sha512-7ly4gdJlP+yLA2FSANv86qrdiQSf64zTLVZj7Xu9KrSsrHr3OCX1DfzzcLgUVisumRkLxqvUrz7pzspooWdS/Q==",
+      "version": "20.4.6",
+      "resolved": "https://registry.npmjs.org/@nx/js/-/js-20.4.6.tgz",
+      "integrity": "sha512-wHO6tXJNVIW0Z9zKLL/g6qee7K92XJNS4D8irpJB9sOg25fqAzKjwgcK0bPtnRhYsIjLkjh0FsTKIcznxTGnkA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.23.2",
         "@babel/plugin-proposal-decorators": "^7.22.7",
@@ -3503,8 +3891,8 @@
         "@babel/preset-env": "^7.23.2",
         "@babel/preset-typescript": "^7.22.5",
         "@babel/runtime": "^7.22.6",
-        "@nx/devkit": "20.4.0",
-        "@nx/workspace": "20.4.0",
+        "@nx/devkit": "20.4.6",
+        "@nx/workspace": "20.4.6",
         "@zkochan/js-yaml": "0.0.7",
         "babel-plugin-const-enum": "^1.0.1",
         "babel-plugin-macros": "^3.1.0",
@@ -3537,33 +3925,35 @@
       }
     },
     "node_modules/@nx/module-federation": {
-      "version": "20.4.0",
-      "resolved": "https://registry.npmjs.org/@nx/module-federation/-/module-federation-20.4.0.tgz",
-      "integrity": "sha512-fG6JyJVhMVj20wFMdOHOmNal1oKfZhsw8hpNBhv7qPjQMxcYa6BD7YpGRBcojAuLYnAQFUCxDX8Hb9S65C5nHA==",
+      "version": "20.4.6",
+      "resolved": "https://registry.npmjs.org/@nx/module-federation/-/module-federation-20.4.6.tgz",
+      "integrity": "sha512-Vs2UpZgzfQZSGtZPZjnFTZncGcOgqW3l94Tia8EqFDDcOg5sl5YRHILowXSs2HVj+wMLqTq1R06JQBazFvpB0Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@module-federation/enhanced": "^0.8.8",
         "@module-federation/node": "^2.6.21",
         "@module-federation/sdk": "^0.8.8",
-        "@nx/devkit": "20.4.0",
-        "@nx/js": "20.4.0",
-        "@nx/web": "20.4.0",
+        "@nx/devkit": "20.4.6",
+        "@nx/js": "20.4.6",
+        "@nx/web": "20.4.6",
         "@rspack/core": "^1.1.5",
         "express": "^4.21.2",
         "http-proxy-middleware": "^3.0.3",
         "picocolors": "^1.1.0",
         "tslib": "^2.3.0",
-        "webpack": "5.88.0"
+        "webpack": "^5.88.0"
       }
     },
     "node_modules/@nx/nx-darwin-arm64": {
-      "version": "20.4.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-20.4.0.tgz",
-      "integrity": "sha512-w07StYKNUIiH1koqBZY9Ew57d0wACyNdKpX96og4oiuSFYTTb+QhL4+vX2GOIYyEDfX7A97mA4lXcYUvN6R4zQ==",
+      "version": "20.4.6",
+      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-20.4.6.tgz",
+      "integrity": "sha512-yYBkXCqx9XDS88IKlbXQUMKAmNE6OA7AwmreDabL0zKCeB5x9qit5iaGwQOYCA7PSdjFQTYvPdKK+S3ytKCJ2w==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -3573,13 +3963,14 @@
       }
     },
     "node_modules/@nx/nx-darwin-x64": {
-      "version": "20.4.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-20.4.0.tgz",
-      "integrity": "sha512-HS9SfQs9BKZm3mXnOggmDrsVPTdJOr4RYa0k8zhXd0GKOdAOmgvWYsCAFxHB1BV4FGq7wfc4YskXRYHra4Ornw==",
+      "version": "20.4.6",
+      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-20.4.6.tgz",
+      "integrity": "sha512-YeGCTQPmZmWYSJ3Km8rsx3YhohbQNp8grclyEp4KA7GXrPY+AKA9hcy0e5KwF4hPP41EEYkju2Xpl0XdmOfdBQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -3589,13 +3980,14 @@
       }
     },
     "node_modules/@nx/nx-freebsd-x64": {
-      "version": "20.4.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-20.4.0.tgz",
-      "integrity": "sha512-5Ex4dV9YKbmO+4ZNI7qXOPvVD7A0t/guPUMcye/Rk/vJVx3Ixr/PZlc2SpBDXDLXye4quiTqICV92VrOrVBj8Q==",
+      "version": "20.4.6",
+      "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-20.4.6.tgz",
+      "integrity": "sha512-49Ad0ysTWrNARmZxc02bmWfrGT5XKEnb5+Nms+RGzQVs+5WI6yqKx2iuLGrx2CDY0FEY11Z0zFpwvrZPGnnLXw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
@@ -3605,13 +3997,14 @@
       }
     },
     "node_modules/@nx/nx-linux-arm-gnueabihf": {
-      "version": "20.4.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-20.4.0.tgz",
-      "integrity": "sha512-mWu0QPZ4WQS39NuFOhbKy6Dwiytgn4SCzadZs/raXs/Sl9A1JtXIojMe5vy49rZocjhbpDuXCuKzHeFOi24TpA==",
+      "version": "20.4.6",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-20.4.6.tgz",
+      "integrity": "sha512-+SMu0xYf2Qim2AC4eYn2SKLXd94UwudMIdPiwbHQUtqRnX88T8rGQKxtINdEAEmIt/KkHyceyJ7lpHGRKmFfbw==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -3621,13 +4014,14 @@
       }
     },
     "node_modules/@nx/nx-linux-arm64-gnu": {
-      "version": "20.4.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-20.4.0.tgz",
-      "integrity": "sha512-5ZOMKtEPoAQfSXgWYgQvMt+8JreWfnHC1rHBhQznb/66DyimKlPFv5TprzKCTqg2ElrYMe5NT5usU5fO94NDnA==",
+      "version": "20.4.6",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-20.4.6.tgz",
+      "integrity": "sha512-1u+qawDO4R8w6op2mqIECzJ8YEViPhpqyq3RiRyAchPodUgrd1rnYnYj+xgQeED4d+L+djeZfhN6000WDhZ5oA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -3637,13 +4031,14 @@
       }
     },
     "node_modules/@nx/nx-linux-arm64-musl": {
-      "version": "20.4.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-20.4.0.tgz",
-      "integrity": "sha512-RBF3KoBYEs0q9YZ1yBidKhcszI8x4znAfcZI+RQ1zWa/kT/GlnQKamdxinri4ov8/bEo9E4YTx4ITLg4RuVHLg==",
+      "version": "20.4.6",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-20.4.6.tgz",
+      "integrity": "sha512-8sFM3Z8k2iojXpL1E/ynlp+BPD8YWCs12cc+qk/4Ke5uOILcpDQ7XZSmzYoNIxp/0fcbZ1bosE+o7Lx4sbpfjQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -3653,13 +4048,14 @@
       }
     },
     "node_modules/@nx/nx-linux-x64-gnu": {
-      "version": "20.4.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-20.4.0.tgz",
-      "integrity": "sha512-RSYAfAmulCatDIKXXbWDhLU/fm03YrAMTD5FtS5IeEvMGEHkQ3scmXEXTxkOF4q5LuqSrutjdb3s8wHkbFRVqw==",
+      "version": "20.4.6",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-20.4.6.tgz",
+      "integrity": "sha512-9t8jPREQN8a2j09O9q9aQI4cP6UXn7tOD+UVYhlQ9EO+EsHKCcaTzszeLoatySVxzeG0RB3vutMgaa8AiS4qcA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -3669,13 +4065,14 @@
       }
     },
     "node_modules/@nx/nx-linux-x64-musl": {
-      "version": "20.4.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-20.4.0.tgz",
-      "integrity": "sha512-0eup79jxSzHoYEGl6OU3wb02wWQbEt4ZfOA58fiZ7c5mvCpKXQV9kg7Tu38zIA8nkcEXGb8JaR1R9TgMiAIZsw==",
+      "version": "20.4.6",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-20.4.6.tgz",
+      "integrity": "sha512-4EO71ND0OJcvinYNc+enB3ouFeKWjCcb73xG2RdjF5s8A9/RFFK6Z3zasYTmGWR06nSLm3mi6xiyiNXWvIdZMA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -3685,13 +4082,14 @@
       }
     },
     "node_modules/@nx/nx-win32-arm64-msvc": {
-      "version": "20.4.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-20.4.0.tgz",
-      "integrity": "sha512-EeHJL9YPVqi3ad9hXVCr1xDM2/PNgZIJvOlJ/ND6r9dVZ+UWw2Kk7G2r13zz4j4QAhrhQJ+kzrvXYkQlhiSH6g==",
+      "version": "20.4.6",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-20.4.6.tgz",
+      "integrity": "sha512-o8Vurr2c9SMP+a2jrBD3VUkQqmHXqi1yC+NJHMzO7GiVPaCFoJR1IizAECXIiKUXv5dB+WFQow7yzVkQQAjk6g==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -3701,13 +4099,14 @@
       }
     },
     "node_modules/@nx/nx-win32-x64-msvc": {
-      "version": "20.4.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-20.4.0.tgz",
-      "integrity": "sha512-IUeCeLdehVocLML6Wub7OZVM96Sk97AshiWmeNnozI6/OYdS34hQ2+thH7ETUZas9nkC2nNkJ5jLwuAHm+5/vw==",
+      "version": "20.4.6",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-20.4.6.tgz",
+      "integrity": "sha512-PtBlsTJHsHeAEawt2HrWkSEsHbwu7MlqFIrw8cS+tg7ZblpesUWva1L3Ylx0hEcQrY7UjMGDR0RVo2DKAUvKZA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -3717,16 +4116,17 @@
       }
     },
     "node_modules/@nx/react": {
-      "version": "20.4.0",
-      "resolved": "https://registry.npmjs.org/@nx/react/-/react-20.4.0.tgz",
-      "integrity": "sha512-SD9GGY95Y2JMqbOZobu6d34VW0S9+/MoUNh/mPbT/2AxYHf8uSCdfbOsxFDhOPXdCkeeWWj/037BwI3qY0sSqA==",
+      "version": "20.4.6",
+      "resolved": "https://registry.npmjs.org/@nx/react/-/react-20.4.6.tgz",
+      "integrity": "sha512-t9RI3bU5IoJr3yhfjzTVik0/m/cGV40gxRdwC/QNkBc2RvU0bnVU25LbortifB9zFQHEBOjGi09T9zn4LjUk8A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@nx/devkit": "20.4.0",
-        "@nx/eslint": "20.4.0",
-        "@nx/js": "20.4.0",
-        "@nx/module-federation": "20.4.0",
-        "@nx/web": "20.4.0",
+        "@nx/devkit": "20.4.6",
+        "@nx/eslint": "20.4.6",
+        "@nx/js": "20.4.6",
+        "@nx/module-federation": "20.4.6",
+        "@nx/web": "20.4.6",
         "@phenomnomnominal/tsquery": "~5.0.1",
         "@svgr/webpack": "^8.0.1",
         "express": "^4.21.2",
@@ -3739,13 +4139,14 @@
       }
     },
     "node_modules/@nx/web": {
-      "version": "20.4.0",
-      "resolved": "https://registry.npmjs.org/@nx/web/-/web-20.4.0.tgz",
-      "integrity": "sha512-hoo01G7e1BYHAPbwlaFoZXD0x6l+e3k+hmz41J1590mZ5tueU2sZdIfzhFEHmfJga8UcAGNmHPTjejlvEhH08w==",
+      "version": "20.4.6",
+      "resolved": "https://registry.npmjs.org/@nx/web/-/web-20.4.6.tgz",
+      "integrity": "sha512-MKV4f8MHoAwo6G0ambu9DqRRjcp0xiMtv1Ijj6GWkD7Xru4IEsHWrDUjTSdl3yKg8zKqMY2Bw+UArxa1Xborkg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@nx/devkit": "20.4.0",
-        "@nx/js": "20.4.0",
+        "@nx/devkit": "20.4.6",
+        "@nx/js": "20.4.6",
         "detect-port": "^1.5.1",
         "http-server": "^14.1.0",
         "picocolors": "^1.1.0",
@@ -3753,15 +4154,16 @@
       }
     },
     "node_modules/@nx/workspace": {
-      "version": "20.4.0",
-      "resolved": "https://registry.npmjs.org/@nx/workspace/-/workspace-20.4.0.tgz",
-      "integrity": "sha512-UFSCl2ZXGW96er+VC8xpytzxmZ4mBHASIeQwk1RpIgB3h/Iif2T7OnnIFFg32Ag667TfXZhAPZ4P0pBNGdBeSA==",
+      "version": "20.4.6",
+      "resolved": "https://registry.npmjs.org/@nx/workspace/-/workspace-20.4.6.tgz",
+      "integrity": "sha512-1rRRN4MJjghDvZSfCNpTn0IDkNJrU6W3VLn8cGjmJXJj8OXxbi3bYc1Ykk+zC99UmSRQ/8+SLorkX+FgTC1ODQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@nx/devkit": "20.4.0",
+        "@nx/devkit": "20.4.6",
         "chalk": "^4.1.0",
         "enquirer": "~2.3.6",
-        "nx": "20.4.0",
+        "nx": "20.4.6",
         "tslib": "^2.3.0",
         "yargs-parser": "21.1.1"
       }
@@ -3783,19 +4185,6 @@
         "hurlfmt": "hurlfmt.js"
       }
     },
-    "node_modules/@oxc-resolver/binding-darwin-arm64": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-arm64/-/binding-darwin-arm64-1.12.0.tgz",
-      "integrity": "sha512-wYe+dlF8npM7cwopOOxbdNjtmJp17e/xF5c0K2WooQXy5VOh74icydM33+Uh/SZDgwyum09/U1FVCX5GdeQk+A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
     "node_modules/@oxc-resolver/binding-darwin-x64": {
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-x64/-/binding-darwin-x64-1.12.0.tgz",
@@ -3807,126 +4196,6 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
-    },
-    "node_modules/@oxc-resolver/binding-freebsd-x64": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-freebsd-x64/-/binding-freebsd-x64-1.12.0.tgz",
-      "integrity": "sha512-BZi0iU6IEOnXGSkqt1OjTTkN9wfyaK6kTpQwL/axl8eCcNDc7wbv1vloHgILf7ozAY1TP75nsLYlASYI4B5kGA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
-    },
-    "node_modules/@oxc-resolver/binding-linux-arm-gnueabihf": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.12.0.tgz",
-      "integrity": "sha512-L2qnMEnZAqxbG9b1J3di/w/THIm+1fMVfbbTMWIQNMMXdMeqqDN6ojnOLDtuP564rAh4TBFPdLyEfGhMz6ipNA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@oxc-resolver/binding-linux-arm64-gnu": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.12.0.tgz",
-      "integrity": "sha512-otVbS4zeo3n71zgGLBYRTriDzc0zpruC0WI3ICwjpIk454cLwGV0yzh4jlGYWQJYJk0BRAmXFd3ooKIF+bKBHw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@oxc-resolver/binding-linux-arm64-musl": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.12.0.tgz",
-      "integrity": "sha512-IStQDjIT7Lzmqg1i9wXvPL/NsYsxF24WqaQFS8b8rxra+z0VG7saBOsEnOaa4jcEY8MVpLYabFhTV+fSsA2vnA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@oxc-resolver/binding-linux-x64-gnu": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.12.0.tgz",
-      "integrity": "sha512-SipT7EVORz8pOQSFwemOm91TpSiBAGmOjG830/o+aLEsvQ4pEy223+SAnCfITh7+AahldYsJnVoIs519jmIlKQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@oxc-resolver/binding-linux-x64-musl": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-musl/-/binding-linux-x64-musl-1.12.0.tgz",
-      "integrity": "sha512-mGh0XfUzKdn+WFaqPacziNraCWL5znkHRfQVxG9avGS9zb2KC/N1EBbPzFqutDwixGDP54r2gx4q54YCJEZ4iQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@oxc-resolver/binding-wasm32-wasi": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-wasm32-wasi/-/binding-wasm32-wasi-1.12.0.tgz",
-      "integrity": "sha512-SZN6v7apKmQf/Vwiqb6e/s3Y2Oacw8uW8V2i1AlxtyaEFvnFE0UBn89zq6swEwE3OCajNWs0yPvgAXUMddYc7Q==",
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "@napi-rs/wasm-runtime": "^0.2.4"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@oxc-resolver/binding-win32-arm64-msvc": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.12.0.tgz",
-      "integrity": "sha512-GRe4bqCfFsyghruEn5bv47s9w3EWBdO2q72xCz5kpQ0LWbw+enPHtTjw3qX5PUcFYpKykM55FaO0hFDs1yzatw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@oxc-resolver/binding-win32-x64-msvc": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.12.0.tgz",
-      "integrity": "sha512-Z3llHH0jfJP4mlWq3DT7bK6qV+/vYe0+xzCgfc67+Tc/U3eYndujl880bexeGdGNPh87JeYznpZAOJ44N7QVVQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
       ]
     },
     "node_modules/@phenomnomnominal/tsquery": {
@@ -4109,147 +4378,158 @@
       }
     },
     "node_modules/@rspack/binding": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@rspack/binding/-/binding-1.2.2.tgz",
-      "integrity": "sha512-GCZwpGFYlLTdJ2soPLwjw9z4LSZ+GdpbHNfBt3Cm/f/bAF8n6mZc7dHUqN893RFh7MPU17HNEL3fMw7XR+6pHg==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rspack/binding/-/binding-1.2.5.tgz",
+      "integrity": "sha512-q9vQmGDFZyFVMULwOFL7488WNSgn4ue94R/njDLMMIPF4K0oEJP2QT02elfG4KVGv2CbP63D7vEFN4ZNreo/Rw==",
       "dev": true,
+      "license": "MIT",
       "optionalDependencies": {
-        "@rspack/binding-darwin-arm64": "1.2.2",
-        "@rspack/binding-darwin-x64": "1.2.2",
-        "@rspack/binding-linux-arm64-gnu": "1.2.2",
-        "@rspack/binding-linux-arm64-musl": "1.2.2",
-        "@rspack/binding-linux-x64-gnu": "1.2.2",
-        "@rspack/binding-linux-x64-musl": "1.2.2",
-        "@rspack/binding-win32-arm64-msvc": "1.2.2",
-        "@rspack/binding-win32-ia32-msvc": "1.2.2",
-        "@rspack/binding-win32-x64-msvc": "1.2.2"
+        "@rspack/binding-darwin-arm64": "1.2.5",
+        "@rspack/binding-darwin-x64": "1.2.5",
+        "@rspack/binding-linux-arm64-gnu": "1.2.5",
+        "@rspack/binding-linux-arm64-musl": "1.2.5",
+        "@rspack/binding-linux-x64-gnu": "1.2.5",
+        "@rspack/binding-linux-x64-musl": "1.2.5",
+        "@rspack/binding-win32-arm64-msvc": "1.2.5",
+        "@rspack/binding-win32-ia32-msvc": "1.2.5",
+        "@rspack/binding-win32-x64-msvc": "1.2.5"
       }
     },
     "node_modules/@rspack/binding-darwin-arm64": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-arm64/-/binding-darwin-arm64-1.2.2.tgz",
-      "integrity": "sha512-h23F8zEkXWhwMeScm0ZnN78Zh7hCDalxIWsm7bBS0eKadnlegUDwwCF8WE+8NjWr7bRzv0p3QBWlS5ufkcL4eA==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-arm64/-/binding-darwin-arm64-1.2.5.tgz",
+      "integrity": "sha512-ou0NXMLp6RxY9Bx8P9lA8ArVjz/WAI/gSu5kKrdKKtMs6WKutl4vvP9A4HHZnISd9Tn00dlvDwNeNSUR7fjoDQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ]
     },
     "node_modules/@rspack/binding-darwin-x64": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-x64/-/binding-darwin-x64-1.2.2.tgz",
-      "integrity": "sha512-vG5s7FkEvwrGLfksyDRHwKAHUkhZt1zHZZXJQn4gZKjTBonje8ezdc7IFlDiWpC4S+oBYp73nDWkUzkGRbSdcQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-x64/-/binding-darwin-x64-1.2.5.tgz",
+      "integrity": "sha512-RdvH9YongQlDE9+T2Xh5D2+dyiLHx2Gz38Af1uObyBRNWjF1qbuR51hOas0f2NFUdyA03j1+HWZCbE7yZrmI3w==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ]
     },
     "node_modules/@rspack/binding-linux-arm64-gnu": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.2.tgz",
-      "integrity": "sha512-VykY/kiYOzO8E1nYzfJ9+gQEHxb5B6lt5wa8M6xFi5B6jEGU+OsaGskmAZB9/GFImeFDHxDPvhUalI4R9p8O2Q==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.5.tgz",
+      "integrity": "sha512-jznk/CI/wN93fr8I1j3la/CAiGf8aG7ZHIpRBtT4CkNze0c5BcF3AaJVSBHVNQqgSv0qddxMt3SADpzV8rWZ6g==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rspack/binding-linux-arm64-musl": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.2.tgz",
-      "integrity": "sha512-Z5vAC4wGfXi8XXZ6hs8Q06TYjr3zHf819HB4DI5i4C1eQTeKdZSyoFD0NHFG23bP4NWJffp8KhmoObcy9jBT5Q==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.5.tgz",
+      "integrity": "sha512-oYzcaJ0xjb1fWbbtPmjjPXeehExEgwJ8fEGYQ5TikB+p9oCLkAghnNjsz9evUhgjByxi+NTZ1YmUNwxRuQDY1Q==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rspack/binding-linux-x64-gnu": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.2.tgz",
-      "integrity": "sha512-o3pDaL+cH5EeRbDE9gZcdZpBgp5iXvYZBBhe8vZQllYgI4zN5MJEuleV7WplG3UwTXlgZg3Kht4RORSOPn96vg==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.5.tgz",
+      "integrity": "sha512-dzEKs8oi86Vi+TFRCPpgmfF5ANL0VmlZN45e1An7HipeI2C5B1xrz/H8V43vPy8XEvQuMmkXO6Sp82A0zlHvIA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rspack/binding-linux-x64-musl": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.2.tgz",
-      "integrity": "sha512-RE3e0xe4DdchHssttKzryDwjLkbrNk/4H59TkkWeGYJcLw41tmcOZVFQUOwKLUvXWVyif/vjvV/w1SMlqB4wQg==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.5.tgz",
+      "integrity": "sha512-4ENeVPVSD97rRRGr6kJSm4sIPf1tKJ8vlr9hJi4sSvF7eMLWipSwIVmqRXJ2riVMRjYD2einmJ9KzI8rqQ2OwA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rspack/binding-win32-arm64-msvc": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.2.tgz",
-      "integrity": "sha512-R+PKBYn6uzTaDdVqTHvjqiJPBr5ZHg1wg5UmFDLNH9OklzVFyQh1JInSdJRb7lzfzTRz6bEkkwUFBPQK/CGScw==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.5.tgz",
+      "integrity": "sha512-WUoJvX/z43MWeW1JKAQIxdvqH02oLzbaGMCzIikvniZnakQovYLPH6tCYh7qD3p7uQsm+IafFddhFxTtogC3pg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ]
     },
     "node_modules/@rspack/binding-win32-ia32-msvc": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.2.2.tgz",
-      "integrity": "sha512-dBqz3sRAGZ2f31FgzKLDvIRfq2haRP3X3XVCT0PsiMcvt7QJng+26aYYMy2THatd/nM8IwExYeitHWeiMBoruw==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.2.5.tgz",
+      "integrity": "sha512-YzPvmt/gpiacE6aAacz4dxgEbNWwoKYPaT4WYy/oITobnAui++iCFXC4IICSmlpoA1y7O8K3Qb9jbaB/lLhbwA==",
       "cpu": [
         "ia32"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ]
     },
     "node_modules/@rspack/binding-win32-x64-msvc": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.2.tgz",
-      "integrity": "sha512-eeAvaN831KG553cMSHkVldyk6YQn4ujgRHov6r1wtREq7CD3/ka9LMkJUepCN85K7XtwYT0N4KpFIQyf5GTGoA==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.5.tgz",
+      "integrity": "sha512-QDDshfteMZiglllm7WUh/ITemFNuexwn1Yul7cHBFGQu6HqtqKNAR0kGR8J3e15MPMlinSaygVpfRE4A0KPmjQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ]
     },
     "node_modules/@rspack/core": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@rspack/core/-/core-1.2.2.tgz",
-      "integrity": "sha512-EeHAmY65Uj62hSbUKesbrcWGE7jfUI887RD03G++Gj8jS4WPHEu1TFODXNOXg6pa7zyIvs2BK0Bm16Kwz8AEaQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rspack/core/-/core-1.2.5.tgz",
+      "integrity": "sha512-x/riOl05gOVGgGQFimBqS5i8XbUpBxPIKUC+tDX4hmNNkzxRaGpspZfNtcL+1HBMyYuoM6fOWGyCp2R290Uy6g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@module-federation/runtime-tools": "0.8.4",
-        "@rspack/binding": "1.2.2",
+        "@rspack/binding": "1.2.5",
         "@rspack/lite-tapable": "1.0.1",
         "caniuse-lite": "^1.0.30001616"
       },
@@ -4273,13 +4553,15 @@
       "version": "0.8.4",
       "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-0.8.4.tgz",
       "integrity": "sha512-55LYmrDdKb4jt+qr8qE8U3al62ZANp3FhfVaNPOaAmdTh0jHdD8M3yf5HKFlr5xVkVO4eV/F/J2NCfpbh+pEXQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@rspack/core/node_modules/@module-federation/runtime": {
       "version": "0.8.4",
       "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-0.8.4.tgz",
       "integrity": "sha512-yZeZ7z2Rx4gv/0E97oLTF3V6N25vglmwXGgoeju/W2YjsFvWzVtCDI7zRRb0mJhU6+jmSM8jP1DeQGbea/AiZQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@module-federation/error-codes": "0.8.4",
         "@module-federation/sdk": "0.8.4"
@@ -4290,6 +4572,7 @@
       "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-0.8.4.tgz",
       "integrity": "sha512-fjVOsItJ1u5YY6E9FnS56UDwZgqEQUrWFnouRiPtK123LUuqUI9FH4redZoKWlE1PB0ir1Z3tnqy8eFYzPO38Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@module-federation/runtime": "0.8.4",
         "@module-federation/webpack-bundler-runtime": "0.8.4"
@@ -4300,6 +4583,7 @@
       "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.8.4.tgz",
       "integrity": "sha512-waABomIjg/5m1rPDBWYG4KUhS5r7OUUY7S+avpaVIY/tkPWB3ibRDKy2dNLLAMaLKq0u+B1qIdEp4NIWkqhqpg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "isomorphic-rslog": "0.0.6"
       }
@@ -4309,6 +4593,7 @@
       "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-0.8.4.tgz",
       "integrity": "sha512-HggROJhvHPUX7uqBD/XlajGygMNM1DG0+4OAkk8MBQe4a18QzrRNzZt6XQbRTSG4OaEoyRWhQHvYD3Yps405tQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@module-federation/runtime": "0.8.4",
         "@module-federation/sdk": "0.8.4"
@@ -4319,6 +4604,7 @@
       "resolved": "https://registry.npmjs.org/isomorphic-rslog/-/isomorphic-rslog-0.0.6.tgz",
       "integrity": "sha512-HM0q6XqQ93psDlqvuViNs/Ea3hAyGDkIdVAHlrEocjjAwGrs1fZ+EdQjS9eUPacnYB7Y8SoDdSY3H8p3ce205A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=14.17.6"
       }
@@ -4328,6 +4614,7 @@
       "resolved": "https://registry.npmjs.org/@rspack/lite-tapable/-/lite-tapable-1.0.1.tgz",
       "integrity": "sha512-VynGOEsVw2s8TAlLf/uESfrgfrq2+rcXB1muPJYBWbsm1Oa6r5qVQhjA5ggM6z/coYPrsVMgovl3Ff7Q7OCp1w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=16.0.0"
       }
@@ -4738,22 +5025,6 @@
         }
       }
     },
-    "node_modules/@swc/core-darwin-arm64": {
-      "version": "1.10.12",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.10.12.tgz",
-      "integrity": "sha512-pOANQegUTAriW7jq3SSMZGM5l89yLVMs48R0F2UG6UZsH04SiViCnDctOGlA/Sa++25C+rL9MGMYM1jDLylBbg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@swc/core-darwin-x64": {
       "version": "1.10.12",
       "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.10.12.tgz",
@@ -4765,134 +5036,6 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-linux-arm-gnueabihf": {
-      "version": "1.10.12",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.10.12.tgz",
-      "integrity": "sha512-OY9LcupgqEu8zVK+rJPes6LDJJwPDmwaShU96beTaxX2K6VrXbpwm5WbPS/8FfQTsmpnuA7dCcMPUKhNgmzTrQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-linux-arm64-gnu": {
-      "version": "1.10.12",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.10.12.tgz",
-      "integrity": "sha512-nJD587rO0N4y4VZszz3xzVr7JIiCzSMhEMWnPjuh+xmPxDBz0Qccpr8xCr1cSxpl1uY7ERkqAGlKr6CwoV5kVg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-linux-arm64-musl": {
-      "version": "1.10.12",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.10.12.tgz",
-      "integrity": "sha512-oqhSmV+XauSf0C//MoQnVErNUB/5OzmSiUzuazyLsD5pwqKNN+leC3JtRQ/QVzaCpr65jv9bKexT9+I2Tt3xDw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-linux-x64-gnu": {
-      "version": "1.10.12",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.10.12.tgz",
-      "integrity": "sha512-XldSIHyjD7m1Gh+/8rxV3Ok711ENLI420CU2EGEqSe3VSGZ7pHJvJn9ZFbYpWhsLxPqBYMFjp3Qw+J6OXCPXCA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-linux-x64-musl": {
-      "version": "1.10.12",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.10.12.tgz",
-      "integrity": "sha512-wvPXzJxzPgTqhyp1UskOx1hRTtdWxlyFD1cGWOxgLsMik0V9xKRgqKnMPv16Nk7L9xl6quQ6DuUHj9ID7L3oVw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-win32-arm64-msvc": {
-      "version": "1.10.12",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.10.12.tgz",
-      "integrity": "sha512-TUYzWuu1O7uyIcRfxdm6Wh1u+gNnrW5M1DUgDOGZLsyQzgc2Zjwfh2llLhuAIilvCVg5QiGbJlpibRYJ/8QGsg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-win32-ia32-msvc": {
-      "version": "1.10.12",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.10.12.tgz",
-      "integrity": "sha512-4Qrw+0Xt+Fe2rz4OJ/dEPMeUf/rtuFWWAj/e0vL7J5laUHirzxawLRE5DCJLQTarOiYR6mWnmadt9o3EKzV6Xg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-win32-x64-msvc": {
-      "version": "1.10.12",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.10.12.tgz",
-      "integrity": "sha512-YiloZXLW7rUxJpALwHXaGjVaAEn+ChoblG7/3esque+Y7QCyheoBUJp2DVM1EeVA43jBfZ8tvYF0liWd9Tpz1A==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
       ],
       "engines": {
         "node": ">=10"
@@ -5483,10 +5626,11 @@
       }
     },
     "node_modules/@types/http-proxy": {
-      "version": "1.17.15",
-      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.15.tgz",
-      "integrity": "sha512-25g5atgiVNTIv0LBDTg1H74Hvayx0ajtJPLLcYE3whFv75J0pWNtOBzaXJQgDTmrX1bx5U9YC2w/n65BN1HwRQ==",
+      "version": "1.17.16",
+      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.16.tgz",
+      "integrity": "sha512-sdWoUajOB1cd0A8cRRQ1cfyWNbmFKLAqBB89Y8x5iYyG/mkJHc0YUH8pdWBy2omi9qtCpiIgGjuwO0dQST2l5w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -5649,7 +5793,8 @@
       "version": "7.5.8",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
       "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/sinonjs__fake-timers": {
       "version": "8.1.1",
@@ -6124,6 +6269,7 @@
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
       "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "mime-types": "~2.1.34",
         "negotiator": "0.6.3"
@@ -6152,16 +6298,6 @@
       "dependencies": {
         "acorn": "^8.1.0",
         "acorn-walk": "^8.0.2"
-      }
-    },
-    "node_modules/acorn-import-assertions": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
-      "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
-      "deprecated": "package has been renamed to acorn-import-attributes",
-      "dev": true,
-      "peerDependencies": {
-        "acorn": "^8"
       }
     },
     "node_modules/acorn-jsx": {
@@ -6199,6 +6335,7 @@
       "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
       "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12.0"
       }
@@ -6423,7 +6560,8 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/array-includes": {
       "version": "3.1.8",
@@ -7013,6 +7151,7 @@
       "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
       "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "safe-buffer": "5.1.2"
       },
@@ -7024,7 +7163,8 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -7084,6 +7224,7 @@
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
       "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "bytes": "3.1.2",
         "content-type": "~1.0.5",
@@ -7108,6 +7249,7 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -7117,6 +7259,7 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
       },
@@ -7128,13 +7271,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/body-parser/node_modules/qs": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
       "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.0.6"
       },
@@ -7230,6 +7375,7 @@
       "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
       "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==",
       "dev": true,
+      "license": "(MIT OR Apache-2.0)",
       "bin": {
         "btoa": "bin/btoa.js"
       },
@@ -7281,6 +7427,7 @@
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -7290,6 +7437,7 @@
       "resolved": "https://registry.npmjs.org/cache-content-type/-/cache-content-type-1.0.1.tgz",
       "integrity": "sha512-IKufZ1o4Ut42YUrZSo8+qnMTrFuKkvyoLXUywKz9GJ5BrhOFGhLdkx9sG4KAnVvbY6kEcSFjLQul+DVmBm2bgA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "mime-types": "^2.1.18",
         "ylru": "^1.2.0"
@@ -7803,6 +7951,7 @@
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
       "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "safe-buffer": "5.2.1"
       },
@@ -7815,6 +7964,7 @@
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -7830,6 +7980,7 @@
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
       "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -7838,13 +7989,15 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cookies": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.9.1.tgz",
       "integrity": "sha512-TG2hpqe4ELx54QER/S3HQ9SRVnQnGBtKUz5bLQWtYAQ+o6GpgMs6sYUvaiJjVxb+UXwhRhAEP3m7LbsIZ77Hmw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "depd": "~2.0.0",
         "keygrip": "~1.1.0"
@@ -7899,6 +8052,7 @@
       "resolved": "https://registry.npmjs.org/corser/-/corser-2.0.1.tgz",
       "integrity": "sha512-utCYNzRSQIZNPIcGZdQc92UVJYAhtGAteCFg0yRaFm8f0P+CPtyGyHXJcGXnffjCybUCEx3FQ2G7U3/o9eIkVQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
       }
@@ -7973,6 +8127,7 @@
       "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-4.9.0.tgz",
       "integrity": "sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "luxon": "^3.2.1"
       },
@@ -8379,6 +8534,7 @@
       "resolved": "https://registry.npmjs.org/date-format/-/date-format-4.0.14.tgz",
       "integrity": "sha512-39BOQLs9ZjKh0/patS9nrT8wc3ioX3/eA/zgbKNopnF2wCqJEoxywwwElATYvRsXdnOxA/OQeQoFZ3rFjVajhg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       }
@@ -8452,7 +8608,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
       "integrity": "sha512-bHtC0iYvWhyaTzvV3CZgPeZQqCOBGyGsVV7v4eevpdkLHfiSrXUdBG+qAuSz4RI70sszvjQ1QSZ98An1yNwpSw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -8546,13 +8703,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -8571,6 +8730,7 @@
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
       "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
@@ -8816,7 +8976,8 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ejs": {
       "version": "3.1.10",
@@ -8871,6 +9032,7 @@
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -8880,6 +9042,7 @@
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "iconv-lite": "^0.6.2"
       }
@@ -9130,7 +9293,8 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -9845,6 +10009,7 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -9859,7 +10024,8 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/events": {
       "version": "3.3.0",
@@ -9953,6 +10119,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
       "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -9999,6 +10166,7 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -10007,13 +10175,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/express/node_modules/qs": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
       "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.0.6"
       },
@@ -10282,6 +10452,7 @@
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
       "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
         "encodeurl": "~2.0.0",
@@ -10300,6 +10471,7 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -10308,13 +10480,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/find-file-up": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/find-file-up/-/find-file-up-2.0.1.tgz",
       "integrity": "sha512-qVdaUhYO39zmh28/JLQM5CoYN9byEOKEH4qfa8K1eNV17W0UUMJ9WgbR/hHFH+t5rcl+6RTb5UC7ck/I+uRkpQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "resolve-dir": "^1.0.1"
       },
@@ -10327,6 +10501,7 @@
       "resolved": "https://registry.npmjs.org/find-pkg/-/find-pkg-2.0.0.tgz",
       "integrity": "sha512-WgZ+nKbELDa6N3i/9nrHeNznm+lY3z4YfhDDWgW+5P0pdmMj26bxaxU11ookgY3NyP9GC7HvZ9etp0jRFqGEeQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "find-file-up": "^2.0.1"
       },
@@ -10530,6 +10705,7 @@
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -10539,6 +10715,7 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -11245,6 +11422,7 @@
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "he": "bin/he"
       }
@@ -11336,6 +11514,7 @@
       "resolved": "https://registry.npmjs.org/http-assert/-/http-assert-1.5.0.tgz",
       "integrity": "sha512-uPpH7OKX4H25hBmU6G1jWNaqJGpTXxey+YOUizJUAgu0AjLUeC8D73hTrhvDS5D+GJN1DN1+hhc/eF/wpxtp0w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "deep-equal": "~1.0.1",
         "http-errors": "~1.8.0"
@@ -11349,6 +11528,7 @@
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
       "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -11358,6 +11538,7 @@
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
       "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "depd": "~1.1.2",
         "inherits": "2.0.4",
@@ -11374,6 +11555,7 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -11383,6 +11565,7 @@
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
       "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "depd": "2.0.0",
         "inherits": "2.0.4",
@@ -11399,6 +11582,7 @@
       "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
       "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "eventemitter3": "^4.0.0",
         "follow-redirects": "^1.0.0",
@@ -11427,6 +11611,7 @@
       "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-3.0.3.tgz",
       "integrity": "sha512-usY0HG5nyDUwtqpiZdETNbmKtw3QQ1jwYFZ9wi5iHzX2BcILwQKtYDJPo7XHTsu5Z0B2Hj3W9NNnbd+AjFWjqg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/http-proxy": "^1.17.15",
         "debug": "^4.3.6",
@@ -11444,6 +11629,7 @@
       "resolved": "https://registry.npmjs.org/http-server/-/http-server-14.1.1.tgz",
       "integrity": "sha512-+cbxadF40UXd9T01zUHgA+rlo2Bg1Srer4+B4NwIHdaGxAGGv59nYRnGGDJ9LBk7alpS0US+J+bLLdQOOkJq4A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "basic-auth": "^2.0.1",
         "chalk": "^4.1.2",
@@ -11702,6 +11888,7 @@
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.10"
       }
@@ -12347,6 +12534,7 @@
       "resolved": "https://registry.npmjs.org/isomorphic-rslog/-/isomorphic-rslog-0.0.7.tgz",
       "integrity": "sha512-n6/XnKnZ5eLEj6VllG4XmamXG7/F69nls8dcynHyhcTpsPUYgcgx4ifEaCo4lQJ2uzwfmIT+F0KBGwBcMKmt5g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=14.17.6"
       }
@@ -12356,6 +12544,7 @@
       "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
       "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
       "dev": true,
+      "license": "MIT",
       "peerDependencies": {
         "ws": "*"
       }
@@ -13514,6 +13703,7 @@
       "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz",
       "integrity": "sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "tsscmp": "1.0.6"
       },
@@ -13544,6 +13734,7 @@
       "resolved": "https://registry.npmjs.org/koa/-/koa-2.15.3.tgz",
       "integrity": "sha512-j/8tY9j5t+GVMLeioLaxweJiKUayFhlGqNTzf2ZGwL0ZCQijd2RLHK0SLW5Tsko8YyyqCZC2cojIb0/s62qTAg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "accepts": "^1.3.5",
         "cache-content-type": "^1.0.0",
@@ -13577,13 +13768,15 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-4.1.0.tgz",
       "integrity": "sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/koa-convert": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/koa-convert/-/koa-convert-2.0.0.tgz",
       "integrity": "sha512-asOvN6bFlSnxewce2e/DK3p4tltyfC4VM7ZwuTuepI7dEQVcvpyFuBcEARu1+Hxg8DIwytce2n7jrZtRlPrARA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "co": "^4.6.0",
         "koa-compose": "^4.1.0"
@@ -13597,6 +13790,7 @@
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -13606,6 +13800,7 @@
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
       "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "depd": "~1.1.2",
         "inherits": "2.0.4",
@@ -13622,6 +13817,7 @@
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
       "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -13631,6 +13827,7 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -13801,7 +13998,8 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeepwith/-/lodash.clonedeepwith-4.5.0.tgz",
       "integrity": "sha512-QRBRSxhbtsX1nc0baxSkkK5WlVTTm/s48DSukcGcWZwIyI8Zz+lB+kFiELJXtzfH4Aj6kMWQ1VWW4U5uUDgZMA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
@@ -13897,6 +14095,7 @@
       "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.9.1.tgz",
       "integrity": "sha512-1somDdy9sChrr9/f4UlzhdaGfDR2c/SaD2a4T7qEkG4jTS57/B3qmnjLYePwQ8cqWnUHZI0iAKxMBpCZICiZ2g==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "date-format": "^4.0.14",
         "debug": "^4.3.4",
@@ -13912,7 +14111,8 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/long-timeout/-/long-timeout-0.1.1.tgz",
       "integrity": "sha512-BFRuQUqc7x2NWxfJBCyUrN8iYUYznzL9JROmRz1gZ6KlOIgmoD+njPVbb+VNn2nGMKggMsK79iUNErillsrx7w==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/longest-streak": {
       "version": "3.1.0",
@@ -13979,6 +14179,7 @@
       "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.5.0.tgz",
       "integrity": "sha512-rh+Zjr6DNfUYR3bPwJEnuwDdqMbxZW7LOQfUN4B54+Cl+0o5zaU9RJ6bcidfDtC1cWCZXQ+nvX8bf6bAji37QQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       }
@@ -14334,6 +14535,7 @@
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -14343,6 +14545,7 @@
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
       "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
       "dev": true,
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
@@ -14367,6 +14570,7 @@
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -14952,6 +15156,7 @@
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
       "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "mime": "cli.js"
       },
@@ -15121,6 +15326,7 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -15146,6 +15352,7 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -15165,19 +15372,22 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/node-fetch/node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true
+      "dev": true,
+      "license": "BSD-2-Clause"
     },
     "node_modules/node-fetch/node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -15206,6 +15416,7 @@
       "resolved": "https://registry.npmjs.org/node-schedule/-/node-schedule-2.1.1.tgz",
       "integrity": "sha512-OXdegQq03OmXEjt2hZP33W2YPs/E5BcFQks46+G2gAxs4gHOIVD1u7EqlYLYSKsaIpyKCK9Gbk0ta1/gjRSMRQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "cron-parser": "^4.2.0",
         "long-timeout": "0.1.1",
@@ -15282,11 +15493,12 @@
       "dev": true
     },
     "node_modules/nx": {
-      "version": "20.4.0",
-      "resolved": "https://registry.npmjs.org/nx/-/nx-20.4.0.tgz",
-      "integrity": "sha512-barpwhq8noc30U0d5j2bSp9x/HDL33TCYsP2fl6FvpssbL64PwLOSBqIdZ9ATxVxAE/xAc/s+z72cYDkaYouPA==",
+      "version": "20.4.6",
+      "resolved": "https://registry.npmjs.org/nx/-/nx-20.4.6.tgz",
+      "integrity": "sha512-gXRw3urAq4glK6B1+jxHjzXRyuNrFFI7L3ggNg34UmQ46AyT7a6FgjZp2OZ779urwnoQSTvxNfBuD4+RrB31MQ==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "@napi-rs/wasm-runtime": "0.2.4",
         "@yarnpkg/lockfile": "^1.1.0",
@@ -15328,16 +15540,16 @@
         "nx-cloud": "bin/nx-cloud.js"
       },
       "optionalDependencies": {
-        "@nx/nx-darwin-arm64": "20.4.0",
-        "@nx/nx-darwin-x64": "20.4.0",
-        "@nx/nx-freebsd-x64": "20.4.0",
-        "@nx/nx-linux-arm-gnueabihf": "20.4.0",
-        "@nx/nx-linux-arm64-gnu": "20.4.0",
-        "@nx/nx-linux-arm64-musl": "20.4.0",
-        "@nx/nx-linux-x64-gnu": "20.4.0",
-        "@nx/nx-linux-x64-musl": "20.4.0",
-        "@nx/nx-win32-arm64-msvc": "20.4.0",
-        "@nx/nx-win32-x64-msvc": "20.4.0"
+        "@nx/nx-darwin-arm64": "20.4.6",
+        "@nx/nx-darwin-x64": "20.4.6",
+        "@nx/nx-freebsd-x64": "20.4.6",
+        "@nx/nx-linux-arm-gnueabihf": "20.4.6",
+        "@nx/nx-linux-arm64-gnu": "20.4.6",
+        "@nx/nx-linux-arm64-musl": "20.4.6",
+        "@nx/nx-linux-x64-gnu": "20.4.6",
+        "@nx/nx-linux-x64-musl": "20.4.6",
+        "@nx/nx-win32-arm64-msvc": "20.4.6",
+        "@nx/nx-win32-x64-msvc": "20.4.6"
       },
       "peerDependencies": {
         "@swc-node/register": "^1.8.0",
@@ -15516,6 +15728,7 @@
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
       "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ee-first": "1.1.1"
       },
@@ -15575,6 +15788,7 @@
       "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
       "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
       "dev": true,
+      "license": "(WTFPL OR MIT)",
       "bin": {
         "opener": "bin/opener-bin.js"
       }
@@ -15842,6 +16056,7 @@
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -15926,7 +16141,8 @@
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -16011,6 +16227,7 @@
       "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.32.tgz",
       "integrity": "sha512-on2ZJVVDXRADWE6jnQaX0ioEylzgBpQk8r55NE4wjXW1ZxO+BgDlY6DXwj20i0V8eB4SenDQ00WEaxfiIQPcxg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "async": "^2.6.4",
         "debug": "^3.2.7",
@@ -16025,6 +16242,7 @@
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
       "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.14"
       }
@@ -16034,6 +16252,7 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
       "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
       }
@@ -16043,6 +16262,7 @@
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -16203,6 +16423,7 @@
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
       "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
@@ -16315,7 +16536,8 @@
       "version": "9.4.2",
       "resolved": "https://registry.npmjs.org/rambda/-/rambda-9.4.2.tgz",
       "integrity": "sha512-++euMfxnl7OgaEKwXh9QqThOjMeta2HH001N1v4mYQzBjJBnmXBh2BCK6dZAbICFVXOFUVD3xFG0R3ZPU0mxXw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
@@ -16331,6 +16553,7 @@
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -16340,6 +16563,7 @@
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
       "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "bytes": "3.1.2",
         "http-errors": "2.0.0",
@@ -16355,6 +16579,7 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
       },
@@ -17280,7 +17505,8 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/secure-compare/-/secure-compare-3.0.1.tgz",
       "integrity": "sha512-AckIIV90rPDcBcglUwXPF3kg0P0qmPsPXAj6BBEENQE1p5yA1xfmDJzfi1Tappj37Pv2mVbKpL3Z1T+Nn7k1Qw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.6.3",
@@ -17311,6 +17537,7 @@
       "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
       "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -17335,6 +17562,7 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -17343,13 +17571,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/send/node_modules/encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -17368,6 +17598,7 @@
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
       "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
@@ -17437,7 +17668,8 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -17591,7 +17823,8 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/sorted-array-functions/-/sorted-array-functions-1.3.0.tgz",
       "integrity": "sha512-2sqgzeFlid6N4Z2fUQ1cvFmTOLRi/sEDzSQ0OKYchqgoPmQBVyM3959qYx3fpS6Esef80KjmpgPeEr028dP3OA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/source-map": {
       "version": "0.6.1",
@@ -17748,6 +17981,7 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -17772,6 +18006,7 @@
       "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-3.1.5.tgz",
       "integrity": "sha512-KFxaM7XT+irxvdqSP1LGLgNWbYN7ay5owZ3r/8t77p+EtSUAfUgtl7be3xtqtOmGUl9K9YPO2ca8133RlTjvKw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "date-format": "^4.0.14",
         "debug": "^4.3.4",
@@ -17786,6 +18021,7 @@
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
       "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^4.0.0",
@@ -17800,6 +18036,7 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
       "dev": true,
+      "license": "MIT",
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -17809,6 +18046,7 @@
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -18606,6 +18844,7 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.6"
       }
@@ -18837,6 +19076,7 @@
       "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
       "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.6.x"
       }
@@ -18888,6 +19128,7 @@
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
       "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
@@ -19218,6 +19459,7 @@
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -19236,6 +19478,7 @@
       "resolved": "https://registry.npmjs.org/upath/-/upath-2.0.1.tgz",
       "integrity": "sha512-1uEe95xksV1O0CYKXo8vQvN1JEbtJp7lb7C5U9HMsIp6IVwntkH/oNUzyVNQSd4S1sYk2FpSSW44FqMc8qee5w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4",
         "yarn": "*"
@@ -19284,7 +19527,8 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
       "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/url-parse": {
       "version": "1.5.10",
@@ -19316,6 +19560,7 @@
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
       }
@@ -19381,6 +19626,7 @@
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -19586,34 +19832,34 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.88.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.88.0.tgz",
-      "integrity": "sha512-O3jDhG5e44qIBSi/P6KpcCcH7HD+nYIHVBhdWFxcLOcIGN8zGo5nqF3BjyNCxIh4p1vFdNnreZv2h2KkoAw3lw==",
+      "version": "5.98.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.98.0.tgz",
+      "integrity": "sha512-UFynvx+gM44Gv9qFgj0acCQK2VE1CtdfwFdimkapco3hlPCJ/zeq73n2yVKimVbtm+TnApIugGhLJnkU6gjYXA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@types/eslint-scope": "^3.7.3",
-        "@types/estree": "^1.0.0",
-        "@webassemblyjs/ast": "^1.11.5",
-        "@webassemblyjs/wasm-edit": "^1.11.5",
-        "@webassemblyjs/wasm-parser": "^1.11.5",
-        "acorn": "^8.7.1",
-        "acorn-import-assertions": "^1.9.0",
-        "browserslist": "^4.14.5",
+        "@types/eslint-scope": "^3.7.7",
+        "@types/estree": "^1.0.6",
+        "@webassemblyjs/ast": "^1.14.1",
+        "@webassemblyjs/wasm-edit": "^1.14.1",
+        "@webassemblyjs/wasm-parser": "^1.14.1",
+        "acorn": "^8.14.0",
+        "browserslist": "^4.24.0",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.15.0",
+        "enhanced-resolve": "^5.17.1",
         "es-module-lexer": "^1.2.1",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
         "glob-to-regexp": "^0.4.1",
-        "graceful-fs": "^4.2.9",
+        "graceful-fs": "^4.2.11",
         "json-parse-even-better-errors": "^2.3.1",
         "loader-runner": "^4.2.0",
         "mime-types": "^2.1.27",
         "neo-async": "^2.6.2",
-        "schema-utils": "^3.2.0",
+        "schema-utils": "^4.3.0",
         "tapable": "^2.1.1",
-        "terser-webpack-plugin": "^5.3.7",
-        "watchpack": "^2.4.0",
+        "terser-webpack-plugin": "^5.3.11",
+        "watchpack": "^2.4.1",
         "webpack-sources": "^3.2.3"
       },
       "bin": {
@@ -19641,6 +19887,36 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/webpack/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/webpack/node_modules/ajv-keywords": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3"
+      },
+      "peerDependencies": {
+        "ajv": "^8.8.2"
+      }
+    },
     "node_modules/webpack/node_modules/eslint-scope": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
@@ -19661,6 +19937,33 @@
       "dev": true,
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/webpack/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/webpack/node_modules/schema-utils": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.0.tgz",
+      "integrity": "sha512-Gf9qqc58SpCA/xdziiHz35F4GNIWYWZrEshUc/G/r5BnLph6xpKuLeoJoQuj5WfBIx/eQLf+hmVPYHaxJu7V2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "ajv": "^8.9.0",
+        "ajv-formats": "^2.1.1",
+        "ajv-keywords": "^5.1.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/whatwg-encoding": {
@@ -20010,6 +20313,7 @@
       "resolved": "https://registry.npmjs.org/ylru/-/ylru-1.4.0.tgz",
       "integrity": "sha512-2OQsPNEmBCvXuFlIni/a+Rn+R2pHW9INm0BxXJ4hVDA8TirqMj+J/Rp9ItLatT/5pZqWwefVrTQcHpixsxnVlA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 4.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -58,13 +58,13 @@
     "@fullcalendar/timegrid": "^6.1.15",
     "@monaco-editor/react": "^4.6.0",
     "@nx-go/nx-go": "^3.3.1",
-    "@nx/cypress": "20.4.0",
-    "@nx/eslint": "20.4.0",
-    "@nx/eslint-plugin": "20.4.0",
-    "@nx/jest": "20.4.0",
-    "@nx/js": "20.4.0",
-    "@nx/react": "20.4.0",
-    "@nx/workspace": "20.4.0",
+    "@nx/cypress": "20.4.6",
+    "@nx/eslint": "20.4.6",
+    "@nx/eslint-plugin": "20.4.6",
+    "@nx/jest": "20.4.6",
+    "@nx/js": "20.4.6",
+    "@nx/react": "20.4.6",
+    "@nx/workspace": "20.4.6",
     "@orangeopensource/hurl": "^6.0.0",
     "@react-hook/resize-observer": "^2.0.2",
     "@reduxjs/toolkit": "^2.5.1",
@@ -105,7 +105,7 @@
     "jest-environment-jsdom": "^29.7.0",
     "lodash": "^4.17.21",
     "monaco-editor": "0.50.0",
-    "nx": "20.4.0",
+    "nx": "20.4.6",
     "papaparse": "^5.5.2",
     "prettier": "^3.4.2",
     "react": "^18.3.1",
@@ -129,6 +129,6 @@
     "yaml": "^2.7.0"
   },
   "overrides": {
-    "typescript": "$typescript"
+    "typescript": "^5.7.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -124,11 +124,11 @@
     "ts-jest": "^29.2.5",
     "ts-json-schema-generator": "^2.3.0",
     "tslib": "^2.8.1",
-    "typescript": "^5.7.3",
+    "typescript": "5.7.3",
     "typescript-eslint": "^8.22.0",
     "yaml": "^2.7.0"
   },
   "overrides": {
-    "typescript": "^5.7.3"
+    "typescript": "$typescript"
   }
 }


### PR DESCRIPTION
# What does this PR do?

updates nx to 20.4.6

I was trying to remove some vulnerabilities from npm install, but it seems like nx still has some work to do to fix those.

https://github.com/nrwl/nx/issues/30016

Also, I had to change the overrides on typescript from `$typescript` to the version of typescript because of some kind of bug in npm. I updated my npm to the latest version and then started getting the error.

https://github.com/npm/cli/issues/5730
