### PR TITLE
chore: update sonner major to 2.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -80,7 +80,7 @@
         "react-use": "^17.6.0",
         "reactflow": "^11.11.4",
         "remark-gfm": "^4.0.1",
-        "sonner": "^1.7.4",
+        "sonner": "^2.0.1",
         "tailwind-merge": "^2.6.0",
         "ts-jest": "^29.2.5",
         "ts-json-schema-generator": "^2.3.0",
@@ -18228,10 +18228,11 @@
       }
     },
     "node_modules/sonner": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/sonner/-/sonner-1.7.4.tgz",
-      "integrity": "sha512-DIS8z4PfJRbIyfVFDVnK9rO3eYDtse4Omcm6bt0oEr5/jtLgysmjuBl1frJ9E/EQZrFmKx2A8m/s5s9CRXIzhw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.1.tgz",
+      "integrity": "sha512-FRBphaehZ5tLdLcQ8g2WOIRE+Y7BCfWi5Zyd8bCvBjiW8TxxAyoWZIxS661Yz6TGPqFQ4VLzOF89WEYhfynSFQ==",
       "dev": true,
+      "license": "MIT",
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
         "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "react-use": "^17.6.0",
     "reactflow": "^11.11.4",
     "remark-gfm": "^4.0.1",
-    "sonner": "^1.7.4",
+    "sonner": "^2.0.1",
     "tailwind-merge": "^2.6.0",
     "ts-jest": "^29.2.5",
     "ts-json-schema-generator": "^2.3.0",


### PR DESCRIPTION
# What does this PR do?

Updates `sonner` major to 2.0.1

# Testing

Manual testing appears to work as expected.
