### PR TITLE
chore: upgrade monaco-editor to ^0.52.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -613,11 +613,10 @@ For Go **package naming**, we follow this [guideline](https://blog.golang.org/pa
 
 ## Managing Dependencies
 
-1. We're pinning monaco to version 0.50.0 for now because of this [bug](https://github.com/microsoft/monaco-editor/issues/4654)
-2. `nx` and its plugins need to be pinned to specific versions as the version of all of them must match [per their docs](https://nx.dev/recipes/tips-n-tricks/keep-nx-versions-in-sync). Running [npx nx migrate](https://nx.dev/nx-api/nx/documents/migrate) will ensure that all are kept in-sync.
-3. When running `npm install` there are errors related to `inflight@1.0.6`, `abab@2.0.6`, `glob@7.2.3`, `domexception@4.0.0` that all are dependencies of jest and its related tooling. There is a jest@next package (currently v30.0.0-alpha.6) that should address most (and hopefully) all of these. See:
+1. `nx` and its plugins need to be pinned to specific versions as the version of all of them must match [per their docs](https://nx.dev/recipes/tips-n-tricks/keep-nx-versions-in-sync). Running [npx nx migrate](https://nx.dev/nx-api/nx/documents/migrate) will ensure that all are kept in-sync.
+1. When running `npm install` there are errors related to `inflight@1.0.6`, `abab@2.0.6`, `glob@7.2.3`, `domexception@4.0.0` that all are dependencies of jest and its related tooling. There is a jest@next package (currently v30.0.0-alpha.6) that should address most (and hopefully) all of these. See:
    - https://github.com/jestjs/jest/issues/15173
    - https://github.com/jestjs/jest/issues/15236
    - https://github.com/jestjs/jest/issues/15325
-4. Unable to update to `eslint-config-prettier` v10 due to `@nx/eslint-plugin` not supporting it yet (https://github.com/nrwl/nx/blob/master/packages/eslint-plugin/package.json#L29)
-5. Unable to update to `cypress` v14 due to `@nx/cypress` not supporting it yet (https://github.com/nrwl/nx/blob/master/packages/cypress/package.json#L47)
+1. Unable to update to `eslint-config-prettier` v10 due to `@nx/eslint-plugin` not supporting it yet (https://github.com/nrwl/nx/blob/master/packages/eslint-plugin/package.json#L29)
+1. Unable to update to `cypress` v14 due to `@nx/cypress` not supporting it yet (https://github.com/nrwl/nx/blob/master/packages/cypress/package.json#L47)

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
         "lodash": "^4.17.21",
-        "monaco-editor": "0.50.0",
+        "monaco-editor": "^0.52.2",
         "nx": "20.4.6",
         "papaparse": "^5.5.2",
         "prettier": "^3.5.2",
@@ -15670,10 +15670,11 @@
       }
     },
     "node_modules/monaco-editor": {
-      "version": "0.50.0",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.50.0.tgz",
-      "integrity": "sha512-8CclLCmrRRh+sul7C08BmPBP3P8wVWfBHomsTcndxg5NRCEPfu/mc2AGU8k37ajjDVXcXFc12ORAMUkmk+lkFA==",
-      "dev": true
+      "version": "0.52.2",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
+      "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "lodash": "^4.17.21",
-    "monaco-editor": "0.50.0",
+    "monaco-editor": "^0.52.2",
     "nx": "20.4.6",
     "papaparse": "^5.5.2",
     "prettier": "^3.5.2",


### PR DESCRIPTION
# What does this PR do?

Upgrades `monaco-editor` to `0.52.2`.

In d604ef1cb89c14e268c97a4276174c819ef6de84, `monaco-editor` was upgraded to `0.52.2` from `0.50.0`, however this caused issues which appeared similar/same to the issue described in https://github.com/microsoft/monaco-editor/issues/4654 so in 4bfe10596e70023f74680123869583679772e818 we reverted back to `0.50.0` until it that issue was addressed.

In testing this PR with `0.52.2`, I'm no longer able to reproduce the issues that we saw back in d604ef1cb89c14e268c97a4276174c819ef6de84 and I'm also no longer able to reproduce the issue with d604ef1cb89c14e268c97a4276174c819ef6de84 using `0.52.2`.  It's possible there was a change in chrome/edge or it's possible that we didn't have a "clean" build that we were testing with.  Since I'm unable to reproduce the issue with the same code from that time and not able to reproduce with the current code, upgrading to 0.52.2 since it seems like the issue does not occur.  If/When it does occur, we should revert back to `0.50.0` and include specific details on steps to reproduce the issue.  From what I remember, the only thing required to trigger the issue was to open the code panel in a view in the builder.

@humandad - Please review above and let me know if you remember any other specific steps to reproduce the issue and if you are able to see the issue on Mac with this PR (I tested Windows Edge/Chrome/Firefox and Linux Chrome and can't reproduce).

# Testing

Manual testing along with ci & e2e.
