### PR TITLE
chore: add nx issue links to npm deps issue tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -619,5 +619,5 @@ For Go **package naming**, we follow this [guideline](https://blog.golang.org/pa
    - https://github.com/jestjs/jest/issues/15173
    - https://github.com/jestjs/jest/issues/15236
    - https://github.com/jestjs/jest/issues/15325
-4. Unable to update to `eslint-config-prettier` v10 due to `@nx/eslint-plugin` not supporting it yet (https://github.com/nrwl/nx/blob/master/packages/eslint-plugin/package.json#L29)
-5. Unable to update to `cypress` v14 due to `@nx/cypress` not supporting it yet (https://github.com/nrwl/nx/blob/master/packages/cypress/package.json#L47)
+4. Unable to update to `eslint-config-prettier` v10 due to `@nx/eslint-plugin` not supporting it yet (https://github.com/nrwl/nx/blob/master/packages/eslint-plugin/package.json#L29). See https://github.com/nrwl/nx/issues/30145.
+5. Unable to update to `cypress` v14 due to `@nx/cypress` not supporting it yet (https://github.com/nrwl/nx/blob/master/packages/cypress/package.json#L47). See https://github.com/nrwl/nx/issues/30097.


### PR DESCRIPTION
# What does this PR do?

Adds links to `nx` issues that track outdated dependencies in `nx` that limit ability to update `uesio` deps.

# Testing

Doc update, no testing.
