### PR TITLE
fix: eliminate default variant magic string

### DIFF
--- a/libs/apps/uesio/io/bundle/components/field.yaml
+++ b/libs/apps/uesio/io/bundle/components/field.yaml
@@ -8,6 +8,7 @@ defaultDefinition: {}
 discoverable: true
 category: DATA
 icon: select_check_box
+defaultVariant: uesio/io.default
 variants:
   - uesio/io.avatar:uesio/io.default
   - uesio/io.checkboxfield:uesio/io.default

--- a/libs/apps/uesio/io/bundle/components/group.yaml
+++ b/libs/apps/uesio/io/bundle/components/group.yaml
@@ -7,6 +7,7 @@ entrypoint: components/group/group
 discoverable: true
 variants:
   - uesio/io.group:uesio/io.default
+defaultVariant: uesio/io.default
 slots:
   - name: components
     label: Group Contents

--- a/libs/apps/uesio/io/bundle/components/iconlabel.yaml
+++ b/libs/apps/uesio/io/bundle/components/iconlabel.yaml
@@ -3,5 +3,6 @@ pack: main
 entrypoint: components/iconlabel/iconlabel
 variants:
   - uesio/io.iconlabel:uesio/io.default
+defaultVariant: uesio/io.default
 utilities:
   - uesio/io.iconlabel

--- a/libs/apps/uesio/io/bundle/components/link.yaml
+++ b/libs/apps/uesio/io/bundle/components/link.yaml
@@ -9,6 +9,7 @@ discoverable: true
 defaultDefinition:
   text: Text Goes Here
   link: https://ues.io
+defaultVariant: uesio/io.default
 properties:
   - name: text
     label: Text

--- a/libs/apps/uesio/io/bundle/components/markdown.yaml
+++ b/libs/apps/uesio/io/bundle/components/markdown.yaml
@@ -8,6 +8,7 @@ icon: format_list_numbered
 discoverable: true
 defaultDefinition:
   markdown: markdown Goes Here
+defaultVariant: uesio/io.markdownfield:uesio/io.default
 properties:
   - name: file
     type: METADATA

--- a/libs/apps/uesio/io/bundle/components/metric.yaml
+++ b/libs/apps/uesio/io/bundle/components/metric.yaml
@@ -7,6 +7,7 @@ pack: main
 entrypoint: components/metric/metric
 variants:
   - uesio/io.metric:uesio/io.default
+defaultVariant: uesio/io.default
 defaultDefinition:
   title: New metric
   value: 100

--- a/libs/apps/uesio/io/bundle/components/scrollpanel.yaml
+++ b/libs/apps/uesio/io/bundle/components/scrollpanel.yaml
@@ -4,6 +4,7 @@ description: A scrollable area for long content
 category: LAYOUT
 pack: main
 entrypoint: components/scrollpanel/scrollpanel
+defaultVariant: uesio/io.default
 slots:
   - name: content
     label: Content

--- a/libs/apps/uesio/io/bundle/components/searchbox.yaml
+++ b/libs/apps/uesio/io/bundle/components/searchbox.yaml
@@ -36,5 +36,6 @@ sections:
   - type: DISPLAY
 variants:
   - uesio/io.field:uesio/io.search
+defaultVariant: uesio/io.default
 styleRegions:
   root:

--- a/libs/apps/uesio/io/bundle/components/tablabels.yaml
+++ b/libs/apps/uesio/io/bundle/components/tablabels.yaml
@@ -3,3 +3,4 @@ title: Tab Labels
 description: Labels area for tabs component
 pack: main
 entrypoint: components/tablabels/tablabels
+defaultVariant: uesio/io.default

--- a/libs/apps/uesio/io/bundle/components/table.yaml
+++ b/libs/apps/uesio/io/bundle/components/table.yaml
@@ -18,6 +18,7 @@ variants:
   - uesio/io.customselectfield:uesio/io.default
   - uesio/io.listmenu:uesio/io.default
   - uesio/io.group:uesio/io.default
+defaultVariant: uesio/io.default
 category: DATA
 discoverable: true
 slots:

--- a/libs/apps/uesio/io/bundle/components/tile.yaml
+++ b/libs/apps/uesio/io/bundle/components/tile.yaml
@@ -12,6 +12,7 @@ slots:
 variants:
   - uesio/io.text:uesio/io.icon
   - uesio/io.text:uesio/io.iconoutline
+defaultVariant: uesio/io.default
 properties:
   - type: COMPONENT_ID
     name: uesio.id

--- a/libs/apps/uesio/io/bundle/components/titlebar.yaml
+++ b/libs/apps/uesio/io/bundle/components/titlebar.yaml
@@ -14,6 +14,7 @@ slots:
     direction: HORIZONTAL
 defaultDefinition:
   title: New Title
+defaultVariant: uesio/io.default
 properties:
   - name: title
     label: Title

--- a/libs/ui/src/component/component.tsx
+++ b/libs/ui/src/component/component.tsx
@@ -265,19 +265,36 @@ const parseVariantName = (
   fullName: MetadataKey | undefined,
   key: MetadataKey,
 ): [MetadataKey, MetadataKey] | undefined => {
-  const parts = fullName?.split(":")
-  if (parts?.length === 2 && parts[0] && parts[1]) {
+  return fullName ?
+    parseVariantNameFromFullName(fullName, key)
+    : parseVariantNameFromKey(key)
+}
+
+const parseVariantNameFromFullName = (
+  fullName: MetadataKey,
+  key: MetadataKey,
+): [MetadataKey, MetadataKey] | undefined => {
+  const parts = fullName.split(":")
+  if (parts.length === 2 && parts[0] && parts[1]) {
     return [parts[0] as MetadataKey, parts[1] as MetadataKey]
   }
-  if (parts?.length === 1 && parts[0]) {
+  if (parts.length === 1 && parts[0]) {
     return [key, parts[0] as MetadataKey]
   }
+
+  // fullName could be empty or one of the parts could be empty
+  return undefined
+}
+
+const parseVariantNameFromKey = (
+  key: MetadataKey,
+): [MetadataKey, MetadataKey] | undefined => {
   const componentTypeDef = getComponentType(key)
   if (!componentTypeDef || !componentTypeDef.defaultVariant) {
     return undefined
   }
 
-  return [key, componentTypeDef.defaultVariant]
+  return parseVariantNameFromFullName(componentTypeDef.defaultVariant, key)
 }
 
 // This is bad and should eventually go away when we do proper typing

--- a/libs/ui/src/component/component.tsx
+++ b/libs/ui/src/component/component.tsx
@@ -265,8 +265,8 @@ const parseVariantName = (
   fullName: MetadataKey | undefined,
   key: MetadataKey,
 ): [MetadataKey, MetadataKey] | undefined => {
-  return fullName ?
-    parseVariantNameFromFullName(fullName, key)
+  return fullName
+    ? parseVariantNameFromFullName(fullName, key)
     : parseVariantNameFromKey(key)
 }
 

--- a/libs/ui/src/component/component.tsx
+++ b/libs/ui/src/component/component.tsx
@@ -13,7 +13,6 @@ import {
 } from "../context/context"
 import { getRuntimeLoader, getUtilityLoader } from "./registry"
 import NotFound from "../utilities/notfound"
-import { parseKey } from "./path"
 import { ComponentVariant } from "../definition/componentvariant"
 import ErrorBoundary from "../utilities/errorboundary"
 import { mergeDefinitionMaps } from "./merge"
@@ -265,20 +264,17 @@ Component.displayName = "Component"
 const parseVariantName = (
   fullName: MetadataKey | undefined,
   key: MetadataKey,
-): [MetadataKey, MetadataKey] => {
+): [MetadataKey, MetadataKey] | undefined => {
   const parts = fullName?.split(":")
-  if (parts?.length === 2) {
+  if (parts?.length === 2 && parts[0] && parts[1]) {
     return [parts[0] as MetadataKey, parts[1] as MetadataKey]
   }
-  if (parts?.length === 1) {
+  if (parts?.length === 1 && parts[0]) {
     return [key, parts[0] as MetadataKey]
   }
-  const [keyNamespace] = parseKey(key)
   const componentTypeDef = getComponentType(key)
   if (!componentTypeDef || !componentTypeDef.defaultVariant) {
-    // This is bad and should go away at some point. I'm just not sure
-    // how many components are relying on this functionality.
-    return [key, `${keyNamespace}.default` as MetadataKey]
+    return undefined
   }
 
   return [key, componentTypeDef.defaultVariant]

--- a/libs/ui/src/component/component.tsx
+++ b/libs/ui/src/component/component.tsx
@@ -30,6 +30,7 @@ import {
 import { COMPONENT_CONTEXT, DISPLAY_CONDITIONS } from "../componentexports"
 import Slot, { DefaultSlotName } from "../utilities/slot"
 import { FieldValue } from "../bands/wirerecord/types"
+import type { Component as ComponentDef } from "../definition/component"
 
 // A cache of full variant definitions, where all variant extensions have been resolved
 // NOTE: This cache will be persisted across all route navigations, and has no upper bound.
@@ -63,15 +64,26 @@ function getDefinitionFromVariant(
 function mergeContextVariants(
   definition: DefinitionMap | undefined,
   componentType: MetadataKey,
-  isDeclarative: boolean,
+  componentTypeDef: ComponentDef,
   context: Context,
 ): DefinitionMap | undefined {
   if (!definition) return definition
-  const variantName = definition[component.STYLE_VARIANT] as MetadataKey
+  let variantName = definition[component.STYLE_VARIANT] as MetadataKey
+  if (!variantName && componentTypeDef?.defaultVariant) {
+    // update the definition with the default variant to ensure
+    // downstream usage can rely on the definition
+    variantName = componentTypeDef.defaultVariant
+    definition = {
+      ...definition,
+      [component.STYLE_VARIANT]: variantName,
+    }
+  }
   const variant = context.getComponentVariant(componentType, variantName)
   const variantDefinition = getDefinitionFromVariant(variant, context)
   return mergeDefinitionMaps(
-    isDeclarative ? variantDefinition : removeStylesNode(variantDefinition),
+    componentTypeDef?.type === Declarative
+      ? variantDefinition
+      : removeStylesNode(variantDefinition),
     definition,
     undefined,
   )
@@ -219,25 +231,23 @@ const Component: UC<DefinitionMap> = (props) => {
   }
   if (!componentType) return <NotFound {...props} />
 
-  let Loader = getRuntimeLoader(componentType) as UC | undefined
-
   const componentTypeDef = getComponentType(componentType)
-  const isDeclarative = componentTypeDef?.type === Declarative
-
-  if (!Loader) {
-    // Check if this is a declarative component, and if so use the declarative loader
-    if (isDeclarative) {
-      Loader = DeclarativeComponent
-    }
-  }
+  const Loader: UC | undefined =
+    componentTypeDef?.type === Declarative
+      ? DeclarativeComponent
+      : getRuntimeLoader(componentType)
 
   if (!Loader) {
     return <NotFound {...props} />
   }
 
   const mergedDefinition = addDefaultPropertyAndSlotValues(
-    mergeContextVariants(definition, componentType, isDeclarative, context) ||
-      {},
+    mergeContextVariants(
+      definition,
+      componentType,
+      componentTypeDef,
+      context,
+    ) || {},
     componentTypeDef?.properties,
     componentTypeDef?.slots,
     componentType,
@@ -283,6 +293,7 @@ const parseVariantNameFromFullName = (
   }
 
   // fullName could be empty or one of the parts could be empty
+  console.error(`Unable to parse variant name '${fullName}' for key '${key}'`)
   return undefined
 }
 
@@ -290,11 +301,14 @@ const parseVariantNameFromKey = (
   key: MetadataKey,
 ): [MetadataKey, MetadataKey] | undefined => {
   const componentTypeDef = getComponentType(key)
-  if (!componentTypeDef || !componentTypeDef.defaultVariant) {
+  if (!componentTypeDef) {
+    console.error(`Unable to find component type definition for key '${key}'`)
     return undefined
   }
 
-  return parseVariantNameFromFullName(componentTypeDef.defaultVariant, key)
+  return !componentTypeDef.defaultVariant
+    ? undefined
+    : parseVariantNameFromFullName(componentTypeDef.defaultVariant, key)
 }
 
 // This is bad and should eventually go away when we do proper typing

--- a/libs/ui/src/context/context.ts
+++ b/libs/ui/src/context/context.ts
@@ -525,7 +525,10 @@ class Context {
     componentType: MetadataKey,
     variantName: MetadataKey,
   ) => {
-    const [component, variant] = parseVariantName(variantName, componentType)
+    const parsed = parseVariantName(variantName, componentType)
+    if (!parsed) return undefined
+
+    const [component, variant] = parsed
     return componentVariantSelectors.selectById(
       getCurrentState(),
       `${component}:${variant}`,

--- a/libs/ui/src/styles/styles.ts
+++ b/libs/ui/src/styles/styles.ts
@@ -281,23 +281,30 @@ function add(context: Context, value: Parameters<typeof css>[0]) {
   activeStyles.twind(css(value))
 }
 
+
+// This is a slight hack, but necessary for the moment.
+// There is an assumption that utility components without
+// a variant specified should use a variant called "default"
+// in the namespace of the associated defaultVariantComponentType.
+// See:
+//   https://github.com/ues-io/uesio/issues/4632
+//   https://github.com/ues-io/uesio/issues/4433
+function getDefaultVariant(defaultVariantComponentType?: MetadataKey): MetadataKey | undefined {
+  if (!defaultVariantComponentType) return undefined
+
+  const [namespace] = parseKey(defaultVariantComponentType)
+  return `${namespace}.default`
+}
+
 function useUtilityStyleTokens<K extends string>(
   defaults: Record<K, Class[]>,
   props: UtilityProps,
   defaultVariantComponentType?: MetadataKey,
 ) {
-  // This is a slight hack, but necessary for the moment.
-  // There is an assumption that utility components without
-  // a variant specified should use a variant called "default"
-  // in the namespace of the associated defaultVariantComponentType.
-  let defaultVariant = ""
-  if (defaultVariantComponentType) {
-    const [namespace] = parseKey(defaultVariantComponentType)
-    defaultVariant = `${namespace}.default`
-  }
   const variantTokens = getVariantTokens(
     defaultVariantComponentType,
-    props.variant || defaultVariant,
+    // TODO: Eliminate call to getDefaultVariant when https://github.com/ues-io/uesio/issues/4632 is addressed
+    props.variant || getDefaultVariant(defaultVariantComponentType),
     props.context,
   )
   const inlineTokens = props.styleTokens

--- a/libs/ui/src/styles/styles.ts
+++ b/libs/ui/src/styles/styles.ts
@@ -24,6 +24,7 @@ import interpolate from "./interpolate"
 import presetAutoprefix from "@twind/preset-autoprefix"
 import presetTailwind from "@twind/preset-tailwind"
 import { isStandardColorName } from "./colors"
+import { parseKey } from "../component/path"
 
 const processThemeColor = (
   themeFunc: ThemeFunction,
@@ -285,9 +286,18 @@ function useUtilityStyleTokens<K extends string>(
   props: UtilityProps,
   defaultVariantComponentType?: MetadataKey,
 ) {
+  // This is a slight hack, but necessary for the moment.
+  // There is an assumption that utility components without
+  // a variant specified should use a variant called "default"
+  // in the namespace of the associated defaultVariantComponentType.
+  let defaultVariant = ""
+  if (defaultVariantComponentType) {
+    const [namespace] = parseKey(defaultVariantComponentType)
+    defaultVariant = `${namespace}.default`
+  }
   const variantTokens = getVariantTokens(
     defaultVariantComponentType,
-    props.variant,
+    props.variant || defaultVariant,
     props.context,
   )
   const inlineTokens = props.styleTokens

--- a/libs/ui/src/styles/styles.ts
+++ b/libs/ui/src/styles/styles.ts
@@ -241,13 +241,11 @@ function getVariantDefinition(
 ) {
   if (!componentType) return undefined
 
-  const [variantComponentType, variantName] = parseVariantName(
-    variantKey,
-    componentType,
-  )
+  const parsed = parseVariantName(variantKey, componentType)
 
-  if (!variantComponentType || !variantName) return undefined
+  if (!parsed) return undefined
 
+  const [variantComponentType, variantName] = parsed
   const variant = context.getComponentVariant(variantComponentType, variantName)
   if (!variant) return undefined
   return getDefinitionFromVariant(variant, context)

--- a/libs/ui/src/styles/styles.ts
+++ b/libs/ui/src/styles/styles.ts
@@ -281,7 +281,6 @@ function add(context: Context, value: Parameters<typeof css>[0]) {
   activeStyles.twind(css(value))
 }
 
-
 // This is a slight hack, but necessary for the moment.
 // There is an assumption that utility components without
 // a variant specified should use a variant called "default"
@@ -289,7 +288,9 @@ function add(context: Context, value: Parameters<typeof css>[0]) {
 // See:
 //   https://github.com/ues-io/uesio/issues/4632
 //   https://github.com/ues-io/uesio/issues/4433
-function getDefaultVariant(defaultVariantComponentType?: MetadataKey): MetadataKey | undefined {
+function getDefaultVariant(
+  defaultVariantComponentType?: MetadataKey,
+): MetadataKey | undefined {
   if (!defaultVariantComponentType) return undefined
 
   const [namespace] = parseKey(defaultVariantComponentType)


### PR DESCRIPTION
# What does this PR do?

Eliminates the "magic string" for default variants for components as mentioned in #4433.

Resolves #4433

# Testing

Manual testing combined with e2e & ci.
