### PR TITLE
chore: fix eslint warnings

### DIFF
--- a/apps/platform-integration-tests/generated/@types/@uesio/index.d.ts
+++ b/apps/platform-integration-tests/generated/@types/@uesio/index.d.ts
@@ -146,10 +146,6 @@ interface HttpApi {
   ) => BotHttpResponse<ResponseBody>
 }
 
-interface SaveOptionsApi {
-  upsert: boolean
-}
-
 interface IntegrationApi {
   getBaseURL(): string | undefined
 }

--- a/libs/apps/uesio/builder/bundle/componentpacks/main/src/components/mainwrapper/propertiespanel/tablecolumns.tsx
+++ b/libs/apps/uesio/builder/bundle/componentpacks/main/src/components/mainwrapper/propertiespanel/tablecolumns.tsx
@@ -120,12 +120,9 @@ const TableColumns: definition.UC = (props) => {
   const { context } = props
 
   const ListPropertyUtility = component.getUtility("uesio/builder.listproperty")
-  // eslint-disable-next-line react-hooks/rules-of-hooks -- waiting on release of https://github.com/facebook/react/pull/31720
   const anchorEl = useRef<HTMLDivElement>(null)
-  // eslint-disable-next-line react-hooks/rules-of-hooks -- waiting on release of https://github.com/facebook/react/pull/31720
   const [showPopper, setShowPopper] = useState(false)
 
-  // eslint-disable-next-line react-hooks/rules-of-hooks -- waiting on release of https://github.com/facebook/react/pull/31720
   let selectedPath = useSelectedPath(context)
   let localPath
   let tempPath = selectedPath

--- a/libs/ui/src/public_types/server/index.d.ts
+++ b/libs/ui/src/public_types/server/index.d.ts
@@ -145,10 +145,6 @@ interface HttpApi {
   ) => BotHttpResponse<ResponseBody>
 }
 
-interface SaveOptionsApi {
-  upsert: boolean
-}
-
 interface IntegrationApi {
   getBaseURL(): string | undefined
 }


### PR DESCRIPTION
# What does this PR do?

Fix eslint warnings that surfaced after recent npm minor deps bumps (e.g., typescript, eslint-plugin-react-hooks).

1. SaveOptionsApi defined but never used warning - does not seem to be used anywhere so removed 
2. hook warning on while loop - https://github.com/facebook/react/pull/31720 resolved in eslint-plugin-react-hooks 5.2.0

# Testing

ci & e2e will cover.
