### PR TITLE
Upgrade monaco and turn off sticky scroll

### DIFF
--- a/README.md
+++ b/README.md
@@ -613,15 +613,10 @@ For Go **package naming**, we follow this [guideline](https://blog.golang.org/pa
 
 ## Managing Dependencies
 
-1. We're pinning monaco to version 0.50.0 for now because of this [bug](https://github.com/microsoft/monaco-editor/issues/4654).
-   - The issue only seems to occur when running the Cypress tests (haven't been able to reproduce in a live browser when using builder) and only [builder.cy.ts](./apps/platform-e2e/cypress/e2e/builder.cy.ts) tests fail (believe this is the only test that uses the code panel but not 100% sure).
-   - Given the issue is intermittent, it is likely some type of race condition either in the browser and/or in cypress.
-   - Only experienced the failure on @humandad machine (2019 Intel-based MacBook Pro)which does seem to run perf tests slower than other machines so possibly the slower execution/latency is the key to encountering the issue.
-   - Need to continue to monitor the monaco-editor issue along with eventually updating to cypress 14 when nx supports it (see #5 below).
-2. `nx` and its plugins need to be pinned to specific versions as the version of all of them must match [per their docs](https://nx.dev/recipes/tips-n-tricks/keep-nx-versions-in-sync). Running [npx nx migrate](https://nx.dev/nx-api/nx/documents/migrate) will ensure that all are kept in-sync.
-3. When running `npm install` there are errors related to `inflight@1.0.6`, `abab@2.0.6`, `glob@7.2.3`, `domexception@4.0.0` that all are dependencies of jest and its related tooling. There is a jest@next package (currently v30.0.0-alpha.6) that should address most (and hopefully) all of these. See:
+1. `nx` and its plugins need to be pinned to specific versions as the version of all of them must match [per their docs](https://nx.dev/recipes/tips-n-tricks/keep-nx-versions-in-sync). Running [npx nx migrate](https://nx.dev/nx-api/nx/documents/migrate) will ensure that all are kept in-sync.
+2. When running `npm install` there are errors related to `inflight@1.0.6`, `abab@2.0.6`, `glob@7.2.3`, `domexception@4.0.0` that all are dependencies of jest and its related tooling. There is a jest@next package (currently v30.0.0-alpha.6) that should address most (and hopefully) all of these. See:
    - https://github.com/jestjs/jest/issues/15173
    - https://github.com/jestjs/jest/issues/15236
    - https://github.com/jestjs/jest/issues/15325
-4. Unable to update to `eslint-config-prettier` v10 due to `@nx/eslint-plugin` not supporting it yet (https://github.com/nrwl/nx/blob/master/packages/eslint-plugin/package.json#L29). See https://github.com/nrwl/nx/issues/30145.
-5. Unable to update to `cypress` v14 due to `@nx/cypress` not supporting it yet (https://github.com/nrwl/nx/blob/master/packages/cypress/package.json#L47). See https://github.com/nrwl/nx/issues/30097.
+3. Unable to update to `eslint-config-prettier` v10 due to `@nx/eslint-plugin` not supporting it yet (https://github.com/nrwl/nx/blob/master/packages/eslint-plugin/package.json#L29). See https://github.com/nrwl/nx/issues/30145.
+4. Unable to update to `cypress` v14 due to `@nx/cypress` not supporting it yet (https://github.com/nrwl/nx/blob/master/packages/cypress/package.json#L47). See https://github.com/nrwl/nx/issues/30097.

--- a/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/codefield/codefield.tsx
+++ b/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/codefield/codefield.tsx
@@ -171,6 +171,12 @@ const CodeField: definition.UtilityComponent<CodeFieldUtilityProps> = (
         value={value}
         loading={loadingNode}
         options={{
+          stickyScroll: {
+            // Disabling for now because of a bug in monaco editor 0.52.2
+            // where we get an intermittent "illegal value for lineNumber"
+            // error with this enabled.
+            enabled: false,
+          },
           scrollBeyondLastLine: false,
           automaticLayout: true,
           readOnly: mode === "READ",

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
         "lodash": "^4.17.21",
-        "monaco-editor": "0.50.0",
+        "monaco-editor": "0.52.2",
         "nx": "20.4.6",
         "papaparse": "^5.5.2",
         "prettier": "^3.5.3",
@@ -15678,10 +15678,11 @@
       }
     },
     "node_modules/monaco-editor": {
-      "version": "0.50.0",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.50.0.tgz",
-      "integrity": "sha512-8CclLCmrRRh+sul7C08BmPBP3P8wVWfBHomsTcndxg5NRCEPfu/mc2AGU8k37ajjDVXcXFc12ORAMUkmk+lkFA==",
-      "dev": true
+      "version": "0.52.2",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
+      "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "lodash": "^4.17.21",
-    "monaco-editor": "0.50.0",
+    "monaco-editor": "0.52.2",
     "nx": "20.4.6",
     "papaparse": "^5.5.2",
     "prettier": "^3.5.3",


### PR DESCRIPTION
# What does this PR do?

This is one option for upgrading monaco to 0.52.2. If I turn off the sticky scroll option, I no longer get the test failures I was experiencing before.