### PR TITLE
fix: clone workspace from bundle failure

### DIFF
--- a/libs/apps/uesio/studio/bundle/views/workspace_new.yaml
+++ b/libs/apps/uesio/studio/bundle/views/workspace_new.yaml
@@ -123,14 +123,14 @@ definition:
                                             selectedConditions:
                                               - type: hasNoValue
                                                 wire: app
-                                                value: ${uesio/studio.clonefrombundle}
+                                                value: ${clonefrombundle}
                                             content:
                                               - uesio/io.text:
                                                   text: Start with a completely empty workspace.
                                             signals:
                                               - signal: wire/UPDATE_RECORD
                                                 wire: newworkspace
-                                                field: uesio/studio.clonefrombundle
+                                                field: clonefrombundle
                                                 value: false
                                         - uesio/io.card:
                                             title: Clone from an Existing Bundle
@@ -138,14 +138,14 @@ definition:
                                             selectedConditions:
                                               - type: hasValue
                                                 wire: app
-                                                value: ${uesio/studio.clonefrombundle}
+                                                value: ${clonefrombundle}
                                             content:
                                               - uesio/io.text:
                                                   text: Use an existing bundle as a starting point.
                                             signals:
                                               - signal: wire/UPDATE_RECORD
                                                 wire: newworkspace
-                                                field: uesio/studio.clonefrombundle
+                                                field: clonefrombundle
                                                 value: true
                                 note:
                                   - uesio/appkit.note:
@@ -154,7 +154,7 @@ definition:
                                 uesio.display:
                                   - type: hasValue
                                     wire: app
-                                    value: ${uesio/studio.clonefrombundle}
+                                    value: ${clonefrombundle}
                                 components:
                                   - uesio/io.titlebar:
                                       title: Source Bundle


### PR DESCRIPTION
# What does this PR do?

Fixes HTTP 500 that was generating the server side error `No metadata provided for field: uesio/studio.clonefrombundle in collection: workspace` when attempting to create a workspace that was cloned from an existing bundle.

Based on the history of workspace_new.yaml, it's not 100% clear how the clone from feature worked previously (if ever??).  What was occurring is that when view only fields are [removed](https://github.com/ues-io/uesio/blob/main/libs/ui/src/bands/wire/operations/save.ts#L16) from "changes" prior to sending to server, the [viewOnlyMetadata.fields](https://github.com/ues-io/uesio/blob/main/libs/ui/src/bands/wire/operations/save.ts#L20) contained an entry for `clonefrombundle` but the key in the [change](https://github.com/ues-io/uesio/blob/main/libs/ui/src/bands/wire/operations/save.ts#L22) object was `uesio/studio.clonefrombundle`.  This resulted in the field not being removed and being sent to server which doesn't have metadata in the collection for a wire based view only field.

It's possible that #4583 modified the metadata returned behavior that introduced this (although nothing jumped out that would have) or its possible that cloning from a bundle never worked although that seems unlikely.

Resolves #4651

# Testing

Manual testing.
