### PR TITLE
chore: update go 1.24.1

### DIFF
--- a/apps/cli/go.mod
+++ b/apps/cli/go.mod
@@ -1,6 +1,6 @@
 module github.com/thecloudmasters/cli
 
-go 1.23.5
+go 1.24.1
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7

--- a/apps/platform/Dockerfile
+++ b/apps/platform/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23-alpine AS multistage
+FROM golang:1.24.1-alpine AS multistage
 
 WORKDIR /src
 RUN go env -w GOMODCACHE=/root/.cache/go-build

--- a/apps/platform/go.mod
+++ b/apps/platform/go.mod
@@ -1,6 +1,6 @@
 module github.com/thecloudmasters/uesio
 
-go 1.23.5
+go 1.24.1
 
 require (
 	github.com/NYTimes/gziphandler v1.1.1

--- a/go.work
+++ b/go.work
@@ -3,7 +3,7 @@
 // externally.  The general guidance on this, although unofficial, is that is is OK to commit these files
 // to version control.  See https://github.com/golang/go/issues/53502
 
-go 1.23.5
+go 1.24.1
 
 use (
 	./apps/cli


### PR DESCRIPTION
# What does this PR do?

Update go to v1.24.1

# Testing

ci & e2e will cover.
