### PR TITLE
chore: pack should fail fast when build error occurs

### DIFF
--- a/apps/cli/pkg/command/pack.go
+++ b/apps/cli/pkg/command/pack.go
@@ -76,9 +76,10 @@ func Pack(options *PackOptions) error {
 		basePath := fmt.Sprintf("bundle/componentpacks/%s/", packName)
 		metaFilePath := fmt.Sprintf("%sdist/meta.json", basePath)
 
+		fmt.Printf("Packing %s...\n", packName)
 		err := Build(buildOptions, metaFilePath, options.Watch)
 		if err != nil {
-			return err
+			return fmt.Errorf("Packing %s failed: %w", packName, err)
 		}
 
 		fmt.Println(fmt.Sprintf("Done Packing %s: %v", packName, time.Since(start)))
@@ -101,10 +102,10 @@ func Build(options *api.BuildOptions, metaFilePath string, watch bool) error {
 	}
 	result := api.Build(*options)
 	if result.Errors != nil {
-		for _, err := range result.Errors {
-			fmt.Println(err)
-			fmt.Println(err.Location)
-		}
+		return fmt.Errorf("Build error(s): %v", result.Errors)
+	}
+	if result.Warnings != nil {
+		fmt.Printf("Build warning(s): %v", result.Warnings)
 	}
 
 	if metaFilePath == "" {


### PR DESCRIPTION
# What does this PR do?

Changes behavior of `pack` CLI command to fail-fast whenever an error is detected during build.  Previously, a failed build could go undetected unless the log output was closely observed manually.

This can be improved/expanded but serves the need/purpose for now

# Testing

ci & e2e will cover.
