### PR TITLE
chore: return non-zero exit code in cli & platform on failure

### DIFF
--- a/apps/cli/pkg/cmd/app.go
+++ b/apps/cli/pkg/cmd/app.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"fmt"
-	"os"
-
 	"github.com/spf13/cobra"
 	"github.com/thecloudmasters/cli/pkg/command/app"
 )
@@ -19,25 +16,28 @@ func init() {
 	}
 
 	appInitCommand := &cobra.Command{
-		Use:   "init",
-		Short: "Scaffolds a new Uesio app locally",
-		Long:  "Scaffolds a new Uesio app in the current directory",
-		Run:   appInit,
+		Use:          "init",
+		Short:        "Scaffolds a new Uesio app locally",
+		Long:         "Scaffolds a new Uesio app in the current directory",
+		RunE:         appInit,
+		SilenceUsage: true,
 	}
 
 	appCloneCommand := &cobra.Command{
-		Use:   "clone",
-		Short: "Fetches an app's metadata from the Uesio studio",
-		Long:  "Fetches an app's metadata from the Uesio studio and sets up a local project",
-		Run:   appClone,
+		Use:          "clone",
+		Short:        "Fetches an app's metadata from the Uesio studio",
+		Long:         "Fetches an app's metadata from the Uesio studio and sets up a local project",
+		RunE:         appClone,
+		SilenceUsage: true,
 	}
 	appCloneCommand.Flags().StringVarP(&targetDir, "dir", "d", "", "Directory to clone into. Defaults to current directory")
 
 	appDeleteCmd := &cobra.Command{
-		Use:   "delete",
-		Short: "Deletes an app from the selected uesio server",
-		Long:  "Deletes an app, and all data in all workspaces in the specified app",
-		Run:   appDelete,
+		Use:          "delete",
+		Short:        "Deletes an app from the selected uesio server",
+		Long:         "Deletes an app, and all data in all workspaces in the specified app",
+		RunE:         appDelete,
+		SilenceUsage: true,
 	}
 	appDeleteCmd.Flags().StringVarP(&name, "name", "n", "", "Name of app to delete")
 
@@ -47,27 +47,14 @@ func init() {
 
 }
 
-func appInit(cmd *cobra.Command, args []string) {
-	err := app.AppInit()
-	if err != nil {
-		fmt.Println("Error: " + err.Error())
-		return
-	}
+func appInit(cmd *cobra.Command, args []string) error {
+	return app.AppInit()
 }
 
-func appClone(cmd *cobra.Command, args []string) {
-	err := app.AppClone(targetDir)
-	if err != nil {
-		fmt.Println("Error: " + err.Error())
-		return
-	}
+func appClone(cmd *cobra.Command, args []string) error {
+	return app.AppClone(targetDir)
 }
 
-func appDelete(cmd *cobra.Command, args []string) {
-	err := app.Delete(name)
-	if err != nil {
-		fmt.Println("Error: " + err.Error())
-		os.Exit(1)
-		return
-	}
+func appDelete(cmd *cobra.Command, args []string) error {
+	return app.Delete(name)
 }

--- a/apps/cli/pkg/cmd/bundle.go
+++ b/apps/cli/pkg/cmd/bundle.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 	"github.com/thecloudmasters/cli/pkg/command/bundle"
 )
@@ -17,9 +15,10 @@ func init() {
 	}
 
 	createBundleCommand := &cobra.Command{
-		Use:   "create",
-		Short: "Create a new bundle using the contents of the current workspace",
-		Run:   createBundle,
+		Use:          "create",
+		Short:        "Create a new bundle using the contents of the current workspace",
+		RunE:         createBundle,
+		SilenceUsage: true,
 	}
 	createBundleCommand.Flags().StringVarP(&bundleDescription, "description", "d", "", "Text describing this bundle")
 	createBundleCommand.Flags().StringVarP(&releaseType, "type", "t", "", "The release type, one of ['major','minor','patch','custom']")
@@ -33,10 +32,6 @@ func init() {
 
 }
 
-func createBundle(cmd *cobra.Command, args []string) {
-	err := bundle.CreateBundle(releaseType, majorVersion, minorVersion, patchVersion, bundleDescription)
-	if err != nil {
-		fmt.Println("Error: " + err.Error())
-		return
-	}
+func createBundle(cmd *cobra.Command, args []string) error {
+	return bundle.CreateBundle(releaseType, majorVersion, minorVersion, patchVersion, bundleDescription)
 }

--- a/apps/cli/pkg/cmd/generate.go
+++ b/apps/cli/pkg/cmd/generate.go
@@ -15,18 +15,18 @@ import (
 func init() {
 
 	generateCommand := &cobra.Command{
-		Use:   "generate",
-		Short: "Create new metadata using a guided wizard",
-		Run:   generate,
+		Use:          "generate",
+		Short:        "Create new metadata using a guided wizard",
+		RunE:         generate,
+		SilenceUsage: true,
 	}
 
 	rootCmd.AddCommand(generateCommand)
 
 }
 
-func generate(cmd *cobra.Command, args []string) {
+func generate(cmd *cobra.Command, args []string) error {
 	var generatorName string
-	var err error
 	if len(args) >= 1 {
 		generatorName = args[0]
 	}
@@ -35,16 +35,14 @@ func generate(cmd *cobra.Command, args []string) {
 		generatorName = promptForGenerator()
 	}
 	if generatorName == "" {
-		fmt.Println("no generator provided")
-		return
+		return fmt.Errorf("no generator name provided")
 	}
 
-	if err = command.Generate(generatorName); err != nil {
-		fmt.Println("Error: " + err.Error())
-		return
-	}
+	return command.Generate(generatorName)
 }
 
+// TODO: Improve error handling vs. just returning empty string so
+// something meaningful can be displayed to the user in failure cases
 func promptForGenerator() string {
 	// Make sure we are authed
 	userMergeData, err := auth.Check()

--- a/apps/cli/pkg/cmd/login.go
+++ b/apps/cli/pkg/cmd/login.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 	"github.com/thecloudmasters/cli/pkg/command"
 )
@@ -10,19 +8,16 @@ import (
 func init() {
 
 	loginCommand := &cobra.Command{
-		Use:   "login",
-		Short: "uesio login",
-		Run:   login,
+		Use:          "login",
+		Short:        "uesio login",
+		RunE:         login,
+		SilenceUsage: true,
 	}
 
 	rootCmd.AddCommand(loginCommand)
 
 }
 
-func login(cmd *cobra.Command, args []string) {
-	err := command.Login()
-	if err != nil {
-		fmt.Println("Error: " + err.Error())
-		return
-	}
+func login(cmd *cobra.Command, args []string) error {
+	return command.Login()
 }

--- a/apps/cli/pkg/cmd/logout.go
+++ b/apps/cli/pkg/cmd/logout.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 	"github.com/thecloudmasters/cli/pkg/command"
 )
@@ -10,19 +8,16 @@ import (
 func init() {
 
 	logoutCommand := &cobra.Command{
-		Use:   "logout",
-		Short: "uesio logout",
-		Run:   logout,
+		Use:          "logout",
+		Short:        "uesio logout",
+		RunE:         logout,
+		SilenceUsage: true,
 	}
 
 	rootCmd.AddCommand(logoutCommand)
 
 }
 
-func logout(cmd *cobra.Command, args []string) {
-	err := command.Logout()
-	if err != nil {
-		fmt.Println("Error: " + err.Error())
-		return
-	}
+func logout(cmd *cobra.Command, args []string) error {
+	return command.Logout()
 }

--- a/apps/cli/pkg/cmd/pack.go
+++ b/apps/cli/pkg/cmd/pack.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 	"github.com/thecloudmasters/cli/pkg/command"
 )
@@ -10,9 +8,10 @@ import (
 func init() {
 
 	packCommand := &cobra.Command{
-		Use:   "pack",
-		Short: "uesio pack",
-		Run:   packer,
+		Use:          "pack",
+		Short:        "uesio pack",
+		RunE:         packer,
+		SilenceUsage: true,
 	}
 	packCommand.PersistentFlags().BoolP("zip", "z", false, "Also gzip packed resources")
 	packCommand.PersistentFlags().BoolP("watch", "w", false, "Watch for filechanges and repack")
@@ -20,15 +19,11 @@ func init() {
 
 }
 
-func packer(cmd *cobra.Command, args []string) {
+func packer(cmd *cobra.Command, args []string) error {
 	doZip, _ := cmd.Flags().GetBool("zip")
 	watch, _ := cmd.Flags().GetBool("watch")
-	err := command.Pack(&command.PackOptions{
+	return command.Pack(&command.PackOptions{
 		Zip:   doZip,
 		Watch: watch,
 	})
-	if err != nil {
-		fmt.Println("Error: " + err.Error())
-		return
-	}
 }

--- a/apps/cli/pkg/cmd/root.go
+++ b/apps/cli/pkg/cmd/root.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"os"
-
 	"github.com/spf13/cobra"
 )
 
@@ -13,8 +11,6 @@ var rootCmd = &cobra.Command{
 }
 
 // Execute is used as entrypoint to the cobra commands
-func Execute() {
-	if err := rootCmd.Execute(); err != nil {
-		os.Exit(-1)
-	}
+func Execute() error {
+	return rootCmd.Execute()
 }

--- a/apps/cli/pkg/cmd/sethost.go
+++ b/apps/cli/pkg/cmd/sethost.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 	"github.com/thecloudmasters/cli/pkg/command"
 )
@@ -10,19 +8,16 @@ import (
 func init() {
 
 	setHostCommand := &cobra.Command{
-		Use:   "sethost",
-		Short: "uesio sethost",
-		Run:   sethost,
+		Use:          "sethost",
+		Short:        "uesio sethost",
+		RunE:         sethost,
+		SilenceUsage: true,
 	}
 
 	rootCmd.AddCommand(setHostCommand)
 
 }
 
-func sethost(cmd *cobra.Command, args []string) {
-	err := command.SetHost()
-	if err != nil {
-		fmt.Println("Error: " + err.Error())
-		return
-	}
+func sethost(cmd *cobra.Command, args []string) error {
+	return command.SetHost()
 }

--- a/apps/cli/pkg/cmd/siteadmin.go
+++ b/apps/cli/pkg/cmd/siteadmin.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 	"github.com/thecloudmasters/cli/pkg/command"
 )
@@ -10,10 +8,11 @@ import (
 func init() {
 
 	siteAdminCommand := &cobra.Command{
-		Use:   "siteadmin",
-		Short: "Set the name of the context site",
-		Long:  "Updates your local configuration to set name of the context site",
-		Run:   siteAdminCmd,
+		Use:          "siteadmin",
+		Short:        "Set the name of the context site",
+		Long:         "Updates your local configuration to set name of the context site",
+		RunE:         siteAdminCmd,
+		SilenceUsage: true,
 	}
 	siteAdminCommand.Flags().StringVarP(&name, "name", "n", "", "Name of the site to be set")
 
@@ -21,10 +20,6 @@ func init() {
 
 }
 
-func siteAdminCmd(cmd *cobra.Command, args []string) {
-	err := command.SiteAdmin(name)
-	if err != nil {
-		fmt.Println("Error: " + err.Error())
-		return
-	}
+func siteAdminCmd(cmd *cobra.Command, args []string) error {
+	return command.SiteAdmin(name)
 }

--- a/apps/cli/pkg/cmd/status.go
+++ b/apps/cli/pkg/cmd/status.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 	"github.com/thecloudmasters/cli/pkg/command"
 )
@@ -10,19 +8,16 @@ import (
 func init() {
 
 	statusCommand := &cobra.Command{
-		Use:   "status",
-		Short: "uesio status",
-		Run:   status,
+		Use:          "status",
+		Short:        "uesio status",
+		RunE:         status,
+		SilenceUsage: true,
 	}
 
 	rootCmd.AddCommand(statusCommand)
 
 }
 
-func status(cmd *cobra.Command, args []string) {
-	err := command.Status()
-	if err != nil {
-		fmt.Println("Error: " + err.Error())
-		return
-	}
+func status(cmd *cobra.Command, args []string) error {
+	return command.Status()
 }

--- a/apps/cli/pkg/cmd/upsert.go
+++ b/apps/cli/pkg/cmd/upsert.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 	"github.com/thecloudmasters/cli/pkg/command"
 )
@@ -11,9 +9,10 @@ func init() {
 
 	// Deprecated - use uesio workspace upsert instead
 	upsertCommand := &cobra.Command{
-		Use:   "upsert",
-		Short: "uesio upsert",
-		Run:   workspaceUpsert,
+		Use:          "upsert",
+		Short:        "uesio upsert",
+		RunE:         workspaceUpsert,
+		SilenceUsage: true,
 	}
 	upsertCommand.PersistentFlags().StringP("spec", "s", "", "Filename of upsert specification")
 	upsertCommand.PersistentFlags().StringP("file", "f", "", "Filename of data to upsert")
@@ -23,18 +22,14 @@ func init() {
 
 }
 
-func workspaceUpsert(cmd *cobra.Command, args []string) {
+func workspaceUpsert(cmd *cobra.Command, args []string) error {
 	spec, _ := cmd.Flags().GetString("spec")
 	file, _ := cmd.Flags().GetString("file")
 	collection, _ := cmd.Flags().GetString("collection")
 
-	err := command.UpsertToWorkspace(&command.UpsertOptions{
+	return command.UpsertToWorkspace(&command.UpsertOptions{
 		SpecFile:   spec,
 		DataFile:   file,
 		Collection: collection,
 	})
-	if err != nil {
-		fmt.Println("Error: " + err.Error())
-		return
-	}
 }

--- a/apps/cli/pkg/cmd/work.go
+++ b/apps/cli/pkg/cmd/work.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 	"github.com/thecloudmasters/cli/pkg/command"
 )
@@ -10,9 +8,10 @@ import (
 func init() {
 
 	workCommand := &cobra.Command{
-		Use:   "work",
-		Short: "uesio work",
-		Run:   work,
+		Use:          "work",
+		Short:        "uesio work",
+		RunE:         work,
+		SilenceUsage: true,
 	}
 	workCommand.Flags().StringVarP(&name, "name", "n", "", "Name of the workspace to be set")
 
@@ -20,10 +19,6 @@ func init() {
 
 }
 
-func work(cmd *cobra.Command, args []string) {
-	err := command.Work(name)
-	if err != nil {
-		fmt.Println("Error: " + err.Error())
-		return
-	}
+func work(cmd *cobra.Command, args []string) error {
+	return command.Work(name)
 }

--- a/apps/cli/pkg/cmd/workspace.go
+++ b/apps/cli/pkg/cmd/workspace.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"fmt"
-	"os"
-
 	"github.com/spf13/cobra"
 
 	"github.com/thecloudmasters/cli/pkg/command/workspace"
@@ -21,40 +18,45 @@ func init() {
 
 	// Add sub-commands
 	workspaceRetrieveCmd := &cobra.Command{
-		Use:   "retrieve",
-		Short: "Retrieves all workspace metadata",
-		Long:  "Retrieves all metadata from a remote workspace to the local directory",
-		Run:   workspaceRetrieve,
+		Use:          "retrieve",
+		Short:        "Retrieves all workspace metadata",
+		Long:         "Retrieves all metadata from a remote workspace to the local directory",
+		RunE:         workspaceRetrieve,
+		SilenceUsage: true,
 	}
 	workspaceRetrieveCmd.Flags().Bool("onlyTypes", false, "Only retrieve types")
 
 	workspaceDeployCmd := &cobra.Command{
-		Use:   "deploy",
-		Short: "Deploys all metadata to a workspace",
-		Long:  "Deploys all local metadata to a remote workspace",
-		Run:   workspaceDeploy,
+		Use:          "deploy",
+		Short:        "Deploys all metadata to a workspace",
+		Long:         "Deploys all local metadata to a remote workspace",
+		RunE:         workspaceDeploy,
+		SilenceUsage: true,
 	}
 
 	workspaceCreateCmd := &cobra.Command{
-		Use:   "create",
-		Short: "Create a new workspace",
-		Long:  "Creates a new workspace in the Uesio studio for the context app",
-		Run:   workspaceCreate,
+		Use:          "create",
+		Short:        "Create a new workspace",
+		Long:         "Creates a new workspace in the Uesio studio for the context app",
+		RunE:         workspaceCreate,
+		SilenceUsage: true,
 	}
 	workspaceCreateCmd.Flags().StringVarP(&name, "name", "n", "", "Name for new workspace")
 
 	workspaceTruncateCmd := &cobra.Command{
-		Use:   "truncate",
-		Short: "Delete all data in the workspace",
-		Long:  "Deletes all data from all collections in the current workspace",
-		Run:   workspaceTruncate,
+		Use:          "truncate",
+		Short:        "Delete all data in the workspace",
+		Long:         "Deletes all data from all collections in the current workspace",
+		RunE:         workspaceTruncate,
+		SilenceUsage: true,
 	}
 
 	workspaceDeleteCmd := &cobra.Command{
-		Use:   "delete",
-		Short: "Deletes a workspace",
-		Long:  "Deletes a workspace, and all data in all collections in the specified workspace",
-		Run:   workspaceDelete,
+		Use:          "delete",
+		Short:        "Deletes a workspace",
+		Long:         "Deletes a workspace, and all data in all collections in the specified workspace",
+		RunE:         workspaceDelete,
+		SilenceUsage: true,
 	}
 	workspaceDeleteCmd.Flags().StringVarP(&name, "name", "n", "", "Name of workspace to delete")
 
@@ -64,14 +66,16 @@ func init() {
 	// convenience aliases for retrieve and deploy
 	//
 	oldDeployCommand := &cobra.Command{
-		Use:   "deploy",
-		Short: "uesio deploy",
-		Run:   workspaceDeploy,
+		Use:          "deploy",
+		Short:        "uesio deploy",
+		RunE:         workspaceDeploy,
+		SilenceUsage: true,
 	}
 	oldRetrieveCommand := &cobra.Command{
-		Use:   "retrieve",
-		Short: "uesio retrieve",
-		Run:   workspaceRetrieve,
+		Use:          "retrieve",
+		Short:        "uesio retrieve",
+		RunE:         workspaceRetrieve,
+		SilenceUsage: true,
 	}
 	oldRetrieveCommand.Flags().Bool("onlyTypes", false, "Only retrieve types")
 
@@ -79,50 +83,25 @@ func init() {
 
 }
 
-func workspaceRetrieve(cmd *cobra.Command, args []string) {
+func workspaceRetrieve(cmd *cobra.Command, args []string) error {
 	onlyTypes, _ := cmd.Flags().GetBool("onlyTypes")
-	err := workspace.Retrieve(&workspace.RetrieveOptions{
+	return workspace.Retrieve(&workspace.RetrieveOptions{
 		OnlyTypes: onlyTypes,
 	})
-	if err != nil {
-		fmt.Println("Error: " + err.Error())
-		os.Exit(1)
-		return
-	}
 }
 
-func workspaceDeploy(cmd *cobra.Command, args []string) {
-	err := workspace.Deploy()
-	if err != nil {
-		fmt.Println("Error: " + err.Error())
-		os.Exit(1)
-		return
-	}
+func workspaceDeploy(cmd *cobra.Command, args []string) error {
+	return workspace.Deploy()
 }
 
-func workspaceCreate(cmd *cobra.Command, args []string) {
-	err := workspace.Create(name)
-	if err != nil {
-		fmt.Println("Error: " + err.Error())
-		os.Exit(1)
-		return
-	}
+func workspaceCreate(cmd *cobra.Command, args []string) error {
+	return workspace.Create(name)
 }
 
-func workspaceTruncate(cmd *cobra.Command, args []string) {
-	err := workspace.Truncate()
-	if err != nil {
-		fmt.Println("Error: " + err.Error())
-		os.Exit(1)
-		return
-	}
+func workspaceTruncate(cmd *cobra.Command, args []string) error {
+	return workspace.Truncate()
 }
 
-func workspaceDelete(cmd *cobra.Command, args []string) {
-	err := workspace.Delete(name)
-	if err != nil {
-		fmt.Println("Error: " + err.Error())
-		os.Exit(1)
-		return
-	}
+func workspaceDelete(cmd *cobra.Command, args []string) error {
+	return workspace.Delete(name)
 }

--- a/apps/cli/uesio.go
+++ b/apps/cli/uesio.go
@@ -1,9 +1,14 @@
 package main
 
 import (
+	"os"
+
 	"github.com/thecloudmasters/cli/pkg/cmd"
 )
 
 func main() {
-	cmd.Execute()
+	if err := cmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+	os.Exit(0)
 }

--- a/apps/platform/main.go
+++ b/apps/platform/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"log/slog"
 	"mime"
 	"os"
 
@@ -91,5 +92,9 @@ func init() {
 }
 
 func main() {
-	cmd.Execute()
+	if err := cmd.Execute(); err != nil {
+		slog.Error(err.Error())
+		os.Exit(1)
+	}
+	os.Exit(0)
 }

--- a/apps/platform/pkg/cmd/migrate.go
+++ b/apps/platform/pkg/cmd/migrate.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"strconv"
 
@@ -16,9 +17,10 @@ import (
 
 func init() {
 	rootCmd.AddCommand(&cobra.Command{
-		Use:   "migrate",
-		Short: "Run database migrations",
-		Run:   migrate,
+		Use:          "migrate",
+		Short:        "Run database migrations",
+		RunE:         migrate,
+		SilenceUsage: true,
 	})
 }
 
@@ -45,10 +47,12 @@ func parseMigrateOptions(args []string) (*migrations.MigrateOptions, error) {
 	return &opts, nil
 }
 
-func migrate(cmd *cobra.Command, args []string) {
+func migrate(cmd *cobra.Command, args []string) error {
 
 	opts, err := parseMigrateOptions(args)
-	cobra.CheckErr(err)
+	if err != nil {
+		return err
+	}
 
 	ctx := context.Background()
 
@@ -58,11 +62,9 @@ func migrate(cmd *cobra.Command, args []string) {
 		return conn.Migrate(opts)
 	})
 	if err != nil {
-		slog.Error("Migrations failed: " + err.Error())
-		cobra.CheckErr(err)
-		return
+		return fmt.Errorf("Migrations failed: %w", err)
 	}
 
 	slog.Info("Successfully ran migrations")
-
+	return nil
 }

--- a/apps/platform/pkg/cmd/root.go
+++ b/apps/platform/pkg/cmd/root.go
@@ -1,22 +1,17 @@
 package cmd
 
 import (
-	"log/slog"
-	"os"
-
 	"github.com/spf13/cobra"
 )
 
 // RootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Use:   "Uesio",
-	Short: "User Experience Studio",
+	Use:           "Uesio",
+	Short:         "User Experience Studio",
+	SilenceErrors: true,
 }
 
 // Execute is used as entrypoint to the cobra commands
-func Execute() {
-	if err := rootCmd.Execute(); err != nil {
-		slog.Error(err.Error())
-		os.Exit(-1)
-	}
+func Execute() error {
+	return rootCmd.Execute()
 }

--- a/apps/platform/pkg/cmd/seed.go
+++ b/apps/platform/pkg/cmd/seed.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -20,9 +21,10 @@ import (
 func init() {
 
 	rootCmd.AddCommand(&cobra.Command{
-		Use:   "seed",
-		Short: "Seed Database",
-		Run:   seed,
+		Use:          "seed",
+		Short:        "Seed Database",
+		RunE:         seed,
+		SilenceUsage: true,
 	})
 
 	rootCmd.PersistentFlags().BoolP("ignore-failures", "i", false, "Set to true to ignore seed failures")
@@ -143,7 +145,7 @@ func runSeeds(ctx context.Context, connection wire.Connection) error {
 	}, session, datasource.NewSaveOptions(connection, nil))
 }
 
-func seed(cmd *cobra.Command, args []string) {
+func seed(cmd *cobra.Command, args []string) error {
 
 	slog.Info("Running seeds")
 
@@ -159,13 +161,11 @@ func seed(cmd *cobra.Command, args []string) {
 	if err != nil {
 		if ignoreSeedFailures {
 			slog.Info("Ignoring seed failures.")
-			return
+			return nil
 		}
-		slog.Error("Seeds failed: " + err.Error())
-		cobra.CheckErr(err)
-		return
+		return fmt.Errorf("Seeds failed: %w", err)
 	}
 
 	slog.Info("Successfully ran seeds")
-
+	return nil
 }

--- a/apps/platform/pkg/cmd/serve.go
+++ b/apps/platform/pkg/cmd/serve.go
@@ -82,7 +82,7 @@ func serve(cmd *cobra.Command, args []string) error {
 
 	cwd, err := os.Getwd()
 	if err != nil {
-		return fmt.Errorf("Failed to obtain working directory", err)
+		return fmt.Errorf("Failed to obtain working directory: %w", err)
 	}
 
 	// If we have BUILD_VERSION, append that to the prefixes to enable us to have versioned assets

--- a/apps/platform/pkg/cmd/serve.go
+++ b/apps/platform/pkg/cmd/serve.go
@@ -27,9 +27,10 @@ import (
 func init() {
 
 	rootCmd.AddCommand(&cobra.Command{
-		Use:   "serve",
-		Short: "Start Webserver",
-		Run:   serve,
+		Use:          "serve",
+		Short:        "Start Webserver",
+		RunE:         serve,
+		SilenceUsage: true,
 	})
 
 }
@@ -74,15 +75,14 @@ var (
 // because they are not expected to change with the version, but are truly static, immutable
 const vendorPrefix = "/static/vendor"
 
-func serve(cmd *cobra.Command, args []string) {
+func serve(cmd *cobra.Command, args []string) error {
 
 	slog.Info("Starting Uesio server")
 	r := mux.NewRouter()
 
 	cwd, err := os.Getwd()
 	if err != nil {
-		slog.Error("Failed to obtain working directory")
-		panic("Failed to obtain working directory")
+		return fmt.Errorf("Failed to obtain working directory", err)
 	}
 
 	// If we have BUILD_VERSION, append that to the prefixes to enable us to have versioned assets
@@ -487,4 +487,5 @@ func serve(cmd *cobra.Command, args []string) {
 
 	<-done
 
+	return nil
 }

--- a/apps/platform/pkg/cmd/worker.go
+++ b/apps/platform/pkg/cmd/worker.go
@@ -10,14 +10,16 @@ import (
 
 func init() {
 	rootCmd.AddCommand(&cobra.Command{
-		Use:   "worker",
-		Short: "Runs Uesio worker jobs",
-		Long:  "Sets up a scheduler to run all Uesio worker jobs as needed, e.g. usage event aggregation every minute, invoicing jobs every day",
-		Run:   runJobs,
+		Use:          "worker",
+		Short:        "Runs Uesio worker jobs",
+		Long:         "Sets up a scheduler to run all Uesio worker jobs as needed, e.g. usage event aggregation every minute, invoicing jobs every day",
+		RunE:         runJobs,
+		SilenceUsage: true,
 	})
 }
 
-func runJobs(*cobra.Command, []string) {
+func runJobs(*cobra.Command, []string) error {
 	slog.Info("Running Uesio worker process")
 	worker.ScheduleJobs()
+	return nil
 }


### PR DESCRIPTION
# What does this PR do?

Ensures that a non-zero exit code is returned from cli & platform when a failure occurs.

Previous code had a few different approaches with only some of them returning non-zero, in most cases, a zero exit code was returned even in failure cases.

This PR focuses on unifying the way the commands handle errors, bubbling them up to `main` and exiting with a 0 (success) or 1 (failure).  

There is still more work to be done on improving the cli & platform:

1. Reduce boilerlate code across commands
2. Improve logging (e.g., use slog in cli)
3. Several situations where functions return empty strings instead of what should be errors
4. etc

# Testing

ci & e2e will cover.
