### PR TITLE
Fix: Defaults should override explicit undefined definition

### DIFF
--- a/libs/ui/src/component/component.spec.tsx
+++ b/libs/ui/src/component/component.spec.tsx
@@ -364,6 +364,23 @@ const addDefaultPropertyAndSlotValuesTests = [
       title: "We provided our own title",
     },
   },
+  {
+    name: "value provided for props but not slots, however, the props are explicitly set to undefined",
+    inputDefinition: {
+      title: undefined,
+    },
+    componentDef: componentTypeWithSlotAndPropertyDefaults,
+    expected: {
+      header: [
+        {
+          "uesio/io.titlebar": {
+            title: "Merge:  This is a title: ${uesio/core.uniquekey}",
+          },
+        },
+      ],
+      title: "Hello $User{email}!",
+    },
+  },
 ]
 
 describe("addDefaultPropertyAndSlotValues", () => {

--- a/libs/ui/src/component/component.tsx
+++ b/libs/ui/src/component/component.tsx
@@ -213,8 +213,8 @@ function addDefaultPropertyAndSlotValues(
   if (Object.keys(defaults).length === 0) return def
   // Merge defaults into definition
   return {
-    ...defaults,
     ...def,
+    ...defaults,
   }
 }
 


### PR DESCRIPTION
# What does this PR do?

This fixes our implementation of defaultValues for props and defaultContent for slots. Before we were spreading the defaults before the definition. Now we spread them after the definition.

This fixes the case where the definition could have included an explicit undefined value like

```
{
  myprop: undefined
}
```

Although a default would be generated for this property, the spread operation would actually override it back to the undefined value.

# Testing

Added a failing test for this case.
