### PR TITLE
chore: use appkit detail form for the file detail page

### DIFF
--- a/libs/apps/uesio/appkit/bundle/components/form_detail.yaml
+++ b/libs/apps/uesio/appkit/bundle/components/form_detail.yaml
@@ -142,10 +142,13 @@ definition:
                     - type: hasNoValue
                       value: $Prop{initials}
                   text: $If{[$Prop{avataricon}][$Prop{avataricon}][$Collection{icon}]}
+                  color: $Prop{avatariconcolor}
                   uesio.variant: uesio/io.icon
         - $Slot{content}
         - uesio/appkit.section_audit_info:
         - uesio/appkit.section_delete:
+            confirm: $Prop{deleteconfirm}
+            signals: $Prop{deletesignals}
 title: Detail Form Component
 discoverable: true
 description: A component for a record detail form.

--- a/libs/apps/uesio/studio/bundle/collections/file.yaml
+++ b/libs/apps/uesio/studio/bundle/collections/file.yaml
@@ -5,5 +5,5 @@ uniqueKey:
 nameField: uesio/studio.name
 access: protected
 accessField: uesio/studio.workspace
-label: file
-pluralLabel: files
+label: File
+pluralLabel: Files

--- a/libs/apps/uesio/studio/bundle/views/file.yaml
+++ b/libs/apps/uesio/studio/bundle/views/file.yaml
@@ -78,34 +78,17 @@ definition:
         content:
           - uesio/appkit.layout_detail_split:
               main:
-                - uesio/io.list:
-                    uesio.id: filesList
+                - uesio/appkit.form_detail:
                     wire: files
-                    mode: READ
-                    components:
-                      - uesio/io.titlebar:
-                          uesio.variant: uesio/appkit.main
-                          title: ${uesio/studio.name}
-                          subtitle: File
-                          avatar:
-                            - uesio/io.text:
-                                uesio.variant: uesio/io.icon
-                                text: ${uesio/studio.appicon}
-                                color: ${uesio/studio.appcolor}
-                          actions:
-                            - uesio/io.group:
-                                components:
-                                  - uesio/io.button:
-                                      uesio.variant: uesio/appkit.secondary
-                                      text: $Label{uesio/io.delete}
-                                      signals:
-                                        - signal: panel/TOGGLE
-                                          panel: deleteFile
-                                      uesio.display:
-                                        - type: paramValue
-                                          param: app
-                                          operator: EQUALS
-                                          value: $Param{namespace}
+                    avataricon: ${uesio/studio.appicon}
+                    avatariconcolor: ${uesio/studio.appcolor}
+                    deleteconfirm: true
+                    deletesignals:
+                      - signal: wire/MARK_FOR_DELETE
+                      - signal: wire/SAVE
+                      - signal: route/NAVIGATE
+                        path: app/$Param{app}/workspace/$Param{workspacename}/files
+                    content:
                       - uesio/io.box:
                           uesio.variant: uesio/appkit.primarysection
                           components:
@@ -116,6 +99,9 @@ definition:
                                       fieldId: uesio/studio.name
                                   - uesio/io.field:
                                       fieldId: uesio/studio.path
+                      - uesio/io.box:
+                          uesio.variant: uesio/appkit.section
+                          components:
                             - uesio/io.titlebar:
                                 title: Contents
                                 uesio.variant: uesio/appkit.sub
@@ -215,36 +201,3 @@ definition:
                                                         - workspaces
                                                         - files
                                                         - attachments
-                      - uesio/appkit.section_audit_info:
-  panels:
-    deleteFile:
-      uesio.type: uesio/io.dialog
-      title: Delete File
-      width: 400px
-      height: 300px
-      components:
-        - uesio/io.text:
-            text: Are you sure you want to delete this file?
-            element: div
-            uesio.variant: uesio/io.smalltitle
-        - uesio/io.text:
-            text: You will never be able to access the information associated with this file again.
-            element: div
-            uesio.variant: uesio/io.smallcontent
-      actions:
-        - uesio/io.button:
-            text: $Label{uesio/io.delete}
-            uesio.variant: uesio/appkit.primary
-            signals:
-              - signal: wire/MARK_FOR_DELETE
-              - signal: wire/SAVE
-                wires:
-                  - files
-              - signal: route/NAVIGATE
-                path: app/$Param{app}/workspace/$Param{workspacename}/files
-        - uesio/io.button:
-            text: $Label{uesio/io.cancel}
-            uesio.variant: uesio/appkit.secondary
-            signals:
-              - signal: panel/TOGGLE
-                panel: deleteFile


### PR DESCRIPTION
# What does this PR do?

Switches to using the more standardized appkit form detail component for the file detail page. (we should switch other detail pages to use this as well)