### PR TITLE
Remove id prop from base definition

### DIFF
--- a/apps/platform-integration-tests/bundle/views/animals_queue_view.yaml
+++ b/apps/platform-integration-tests/bundle/views/animals_queue_view.yaml
@@ -60,7 +60,7 @@ definition:
                       - uesio/io.titlebar:
                           title: Animal Details
                       - uesio/core.view:
-                          id: detailview
+                          uesio.id: detailview
                           view: view_with_param_condition
                           params:
                             genus: ${uesio/tests.genus}

--- a/libs/apps/uesio/builder/bundle/componentpacks/main/src/helpers/propertiesform.tsx
+++ b/libs/apps/uesio/builder/bundle/componentpacks/main/src/helpers/propertiesform.tsx
@@ -179,9 +179,11 @@ const PropertiesForm: definition.UtilityComponent<Props> = (props) => {
   )
   const { content, properties } = getPropertiesAndContent(props, selectedTab)
 
-  const propSections = component
-    .useShouldFilter(sections, context)
-    ?.map((section) => getPropertyTabForSection(section))
+  const propSections = sections
+    .filter((section) =>
+      component.shouldAll(section.displayConditions, context),
+    )
+    .map((section) => getPropertyTabForSection(section))
 
   return (
     <PropertiesWrapper

--- a/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/dynamicform/dynamicform.tsx
+++ b/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/dynamicform/dynamicform.tsx
@@ -1,5 +1,5 @@
-import { api, wire, definition } from "@uesio/ui"
-import { MutableRefObject } from "react"
+import { api, wire, definition, component } from "@uesio/ui"
+import { RefObject } from "react"
 import List from "../../components/list/list"
 import { useDeepCompareEffect } from "react-use"
 
@@ -13,7 +13,7 @@ interface FormProps {
     record: wire.WireRecord,
   ) => void
   initialValue?: wire.PlainWireRecord
-  wireRef?: MutableRefObject<wire.Wire | undefined>
+  wireRef?: RefObject<wire.Wire | undefined>
   events?: wire.WireEvent[]
 }
 
@@ -81,7 +81,7 @@ const DynamicForm: definition.UtilityComponent<FormProps> = (props) => {
       definition={{
         mode: "EDIT",
         wire: wireId,
-        id,
+        [component.COMPONENT_ID]: id,
         components:
           content ||
           wire.getFields().map((field) => ({

--- a/libs/ui/src/component/display.ts
+++ b/libs/ui/src/component/display.ts
@@ -551,7 +551,9 @@ export const getWiresForConditions = (
   return Array.from(uniqueWires.values())
 }
 
-const useShouldFilter = <T extends BaseDefinition>(
+const useShouldFilter = <
+  T extends Pick<BaseDefinition, typeof DISPLAY_CONDITIONS>,
+>(
   items: T[] | undefined = [],
   context: Context,
 ) => {

--- a/libs/ui/src/components/view.tsx
+++ b/libs/ui/src/components/view.tsx
@@ -80,10 +80,7 @@ const View: UC<ViewComponentDefinition> = (props) => {
   const { params, slots = {}, view: localViewDefId } = definition
   const viewDefId = getFullyQualifiedKey(localViewDefId, context.getNamespace())
 
-  // Backwards compatibility for definition.id
-  // TODO: Remove when all instances of this are fixed
-  const uesioId =
-    definition[COMPONENT_ID] || definition.id || (path && hash(path)) || "$root"
+  const uesioId = definition[COMPONENT_ID] || (path && hash(path)) || "$root"
   const viewId = makeViewId(viewDefId, uesioId)
 
   const isSubView = !!path

--- a/libs/ui/src/definition/definition.ts
+++ b/libs/ui/src/definition/definition.ts
@@ -10,8 +10,6 @@ import { ViewParamDefinition } from "./param"
 import { SlotDef } from "./component"
 
 export type BaseDefinition = {
-  // "id" here is TEMPORARY - for backwards compatibility on components like Table/List/Deck that initially had "id"
-  // Once morandi / timetracker / etc. are migrated to using "uesio.id" in their metadata, we can remove this affordance.
   "uesio.id"?: string
   "uesio.styleTokens"?: Record<string, string[]>
   "uesio.variant"?: MetadataKey

--- a/libs/ui/src/definition/definition.ts
+++ b/libs/ui/src/definition/definition.ts
@@ -12,7 +12,6 @@ import { SlotDef } from "./component"
 export type BaseDefinition = {
   // "id" here is TEMPORARY - for backwards compatibility on components like Table/List/Deck that initially had "id"
   // Once morandi / timetracker / etc. are migrated to using "uesio.id" in their metadata, we can remove this affordance.
-  id?: string
   "uesio.id"?: string
   "uesio.styleTokens"?: Record<string, string[]>
   "uesio.variant"?: MetadataKey

--- a/libs/ui/src/hooks/componentapi.ts
+++ b/libs/ui/src/hooks/componentapi.ts
@@ -30,11 +30,7 @@ import { hash } from "@twind/core"
 
 const getComponentIdFromProps = (props: BaseProps) => {
   const { componentType, context, definition, path } = props
-  // "props.definition.id" here is TEMPORARY - for backwards compatibility
-  // on components like Table/List/Deck that initially had "id"
-  // Once morandi / timetracker / etc. are migrated to using "uesio.id"
-  // in their metadata, we can remove this affordance.
-  let userDefinedId = definition[COMPONENT_ID] || definition.id
+  let userDefinedId = definition[COMPONENT_ID]
   // Optimization --- IF and only if we KNOW that the id for this component is user-defined (vs the path)
   // then run mergeString() to resolve any merge variables that may be present in the id
   if (userDefinedId) {


### PR DESCRIPTION
# What does this PR do?

Removes a backwards-compat hack we put in a while ago to support the Morandi app. I just went through the morandi app and fixed all this, so I think we can go ahead and remove the hack.

We no longer support the `id` property on uesio components. You have to use `uesio.id` to provide the id.