### PR TITLE
Refactor: Base Definition Types Cleanup

### DIFF
--- a/apps/platform-integration-tests/generated/@types/@uesio/index.d.ts
+++ b/apps/platform-integration-tests/generated/@types/@uesio/index.d.ts
@@ -817,14 +817,14 @@ export type Definition =
   | DefinitionMap
   | DefinitionValue[]
   | DefinitionMap[]
-export type BaseDefinition = {
+export type BaseDefinition<T = DefinitionMap> = {
   "uesio.id"?: string
   "uesio.styleTokens"?: Record<string, string[]>
   "uesio.variant"?: MetadataKey
   "uesio.classes"?: string
-}
+} & T
 export type BaseProps<T = DefinitionMap> = {
-  definition: T & BaseDefinition
+  definition: BaseDefinition<T>
   path: string
   componentType?: MetadataKey
   context: Context
@@ -920,7 +920,7 @@ export namespace component {
 //
 export namespace definition {
   export type BaseProps<T = DefinitionMap> = {
-    definition: T & BaseDefinition
+    definition: BaseDefinition<T>
     path: string
     componentType?: MetadataKey
     context: Context

--- a/libs/apps/uesio/builder/bundle/componentpacks/main/src/components/mainwrapper/propertiespanel/tablecolumns.tsx
+++ b/libs/apps/uesio/builder/bundle/componentpacks/main/src/components/mainwrapper/propertiespanel/tablecolumns.tsx
@@ -24,7 +24,7 @@ export type ColumnDefinition = {
   label?: string
   components?: definition.DefinitionList
   type?: "" | "custom"
-} & definition.BaseDefinition
+}
 
 const columnTypeProperty: ComponentProperty = {
   name: "type",

--- a/libs/apps/uesio/builder/bundle/componentpacks/main/src/components/mainwrapper/propertiespanel/wire/conditionsproperties.tsx
+++ b/libs/apps/uesio/builder/bundle/componentpacks/main/src/components/mainwrapper/propertiespanel/wire/conditionsproperties.tsx
@@ -254,11 +254,7 @@ const getItemPropertiesFunction =
   (itemState: wire.PlainWireRecord): ComponentProperty[] => {
     const fieldMetadata =
       itemState.field && wireName
-        ? getFieldMetadata(
-            context,
-            wireName as string,
-            itemState.field as string,
-          )
+        ? getFieldMetadata(context, wireName, itemState.field as string)
         : undefined
 
     const fieldDisplayType = fieldMetadata?.getType() || undefined

--- a/libs/apps/uesio/builder/bundle/componentpacks/main/src/components/mainwrapper/propertiespanel/wire/wireproperties.tsx
+++ b/libs/apps/uesio/builder/bundle/componentpacks/main/src/components/mainwrapper/propertiespanel/wire/wireproperties.tsx
@@ -204,7 +204,7 @@ const WireProperties: definition.UtilityComponent = (props) => {
                 value: "onChange",
                 operator: "EQUALS",
               },
-            ] as component.DisplayCondition[],
+            ],
           },
         ],
       },

--- a/libs/apps/uesio/builder/bundle/componentpacks/main/src/components/paramsfield/paramsfield.tsx
+++ b/libs/apps/uesio/builder/bundle/componentpacks/main/src/components/paramsfield/paramsfield.tsx
@@ -13,7 +13,7 @@ type ParamsFieldDefinition = {
 
 type ViewComponentDefinition = {
   view: string
-} & definition.BaseDefinition
+}
 
 const ParamsField: definition.UC<ParamsFieldDefinition> = (props) => {
   const MapField = component.getUtility("uesio/io.mapfield")

--- a/libs/apps/uesio/io/bundle/componentpacks/chart/src/shared/definitions.ts
+++ b/libs/apps/uesio/io/bundle/componentpacks/chart/src/shared/definitions.ts
@@ -1,4 +1,3 @@
-import { definition } from "@uesio/ui"
 import { LabelsDefinition } from "./labels"
 import { SeriesDefinition } from "./aggregate"
 
@@ -7,8 +6,24 @@ export type ChartProps = {
   type: "line" | "bar"
 }
 
+type TicksOptions = {
+  count?: number
+}
+
+type ScaleOptions = {
+  beginAtZero?: boolean
+  ticks?: TicksOptions
+  suggestedMax?: number
+}
+
+type ScalesOptions = {
+  y?: ScaleOptions
+  x?: ScaleOptions
+}
+
 export type ChartDefinition = {
   labels: LabelsDefinition
   title?: string
   series: SeriesDefinition[]
-} & definition.BaseDefinition
+  scales?: ScalesOptions
+}

--- a/libs/apps/uesio/io/bundle/componentpacks/chart/src/utilities/chart/chart.tsx
+++ b/libs/apps/uesio/io/bundle/componentpacks/chart/src/utilities/chart/chart.tsx
@@ -2,8 +2,8 @@ import { styles, api, definition } from "@uesio/ui"
 
 import { Line, Bar } from "react-chartjs-2"
 import { Chart, registerables } from "chart.js"
-import { LabelsDefinition } from "../../shared/labels"
-import { aggregate, SeriesDefinition } from "../../shared/aggregate"
+import { aggregate } from "../../shared/aggregate"
+import { ChartDefinition } from "../../shared/definitions"
 
 Chart.register(...registerables)
 
@@ -11,28 +11,6 @@ export type ChartProps = {
   definition: ChartDefinition
   type: "line" | "bar"
 }
-
-type TicksOptions = {
-  count?: number
-}
-
-type ScaleOptions = {
-  beginAtZero?: boolean
-  ticks?: TicksOptions
-  suggestedMax?: number
-}
-
-type ScalesOptions = {
-  y?: ScaleOptions
-  x?: ScaleOptions
-}
-
-export type ChartDefinition = {
-  labels: LabelsDefinition
-  title?: string
-  series: SeriesDefinition[]
-  scales?: ScalesOptions
-} & definition.BaseDefinition
 
 const StyleDefaults = Object.freeze({
   root: [],

--- a/libs/apps/uesio/io/bundle/componentpacks/main/src/components/accordion/accordion.tsx
+++ b/libs/apps/uesio/io/bundle/componentpacks/main/src/components/accordion/accordion.tsx
@@ -82,10 +82,7 @@ const Accordion: definition.UC<AccordionDefinition> = (props) => {
   )
   const selectedIndex = foundIndex === -1 ? 0 : foundIndex
   const selectedItem = indexedItems[selectedIndex]
-  const allVisibleItems = component.useShouldFilter<AccordionItemWithIndex>(
-    indexedItems,
-    context,
-  )
+  const allVisibleItems = component.useShouldFilter(indexedItems, context)
   const shouldDisplaySelectedItem =
     allVisibleItems.findIndex((item) => item.id === selectedItem.id) > -1
   const firstVisibleItemToDisplay = !shouldDisplaySelectedItem

--- a/libs/apps/uesio/io/bundle/componentpacks/main/src/components/box/box.tsx
+++ b/libs/apps/uesio/io/bundle/componentpacks/main/src/components/box/box.tsx
@@ -2,6 +2,7 @@ import { component, styles, api, signal, definition } from "@uesio/ui"
 
 type BoxDefinition = {
   signals?: signal.SignalDefinition[]
+  components?: definition.DefinitionList
 }
 
 const StyleDefaults = Object.freeze({

--- a/libs/apps/uesio/io/bundle/componentpacks/main/src/components/dialog/dialog.tsx
+++ b/libs/apps/uesio/io/bundle/componentpacks/main/src/components/dialog/dialog.tsx
@@ -8,8 +8,8 @@ type DialogDefinition = {
   height?: string
   id?: string
   afterClose?: signal.SignalDefinition[]
-  actions?: definition.DefinitionList[]
-  components?: definition.DefinitionList[]
+  actions?: definition.DefinitionList
+  components?: definition.DefinitionList
   closeOnOutsideClick?: boolean
   closed?: boolean
 }
@@ -35,9 +35,9 @@ const Dialog: definition.UC<DialogDefinition> = (props) => {
       onClose={onClose}
       context={context}
       closed={definition.closed}
-      width={definition.width as string}
-      height={definition.height as string}
-      title={definition.title as string}
+      width={definition.width}
+      height={definition.height}
+      title={definition.title}
       closeOnOutsideClick={definition.closeOnOutsideClick}
       actions={
         definition.actions && (

--- a/libs/apps/uesio/io/bundle/componentpacks/main/src/components/field/field.tsx
+++ b/libs/apps/uesio/io/bundle/componentpacks/main/src/components/field/field.tsx
@@ -48,7 +48,7 @@ type FieldDefinition = {
   wrapperVariant: metadata.MetadataKey
   applyChanges?: ApplyChanges
   applyDelay?: number
-} & definition.BaseDefinition
+}
 
 type FieldValueSetter = (value: wire.FieldValue) => void
 

--- a/libs/apps/uesio/io/bundle/componentpacks/main/src/components/grid/grid.tsx
+++ b/libs/apps/uesio/io/bundle/componentpacks/main/src/components/grid/grid.tsx
@@ -1,7 +1,11 @@
 import { component, definition } from "@uesio/ui"
 import { default as IOGrid } from "../../utilities/grid/grid"
 
-const Grid: definition.UC = (props) => {
+type GridDefinition = {
+  items: definition.DefinitionList | undefined
+}
+
+const Grid: definition.UC<GridDefinition> = (props) => {
   const { definition, context, componentType } = props
 
   return (

--- a/libs/apps/uesio/io/bundle/componentpacks/main/src/components/griditem/griditem.tsx
+++ b/libs/apps/uesio/io/bundle/componentpacks/main/src/components/griditem/griditem.tsx
@@ -1,10 +1,14 @@
 import { component, styles, definition } from "@uesio/ui"
 
+type GridItemDefinition = {
+  components?: definition.DefinitionList
+}
+
 const StyleDefaults = Object.freeze({
   root: [],
 })
 
-const GridItem: definition.UC = (props) => {
+const GridItem: definition.UC<GridItemDefinition> = (props) => {
   const { definition, context, path, componentType } = props
   if (!definition) return <div />
   const classes = styles.useStyleTokens(StyleDefaults, props)

--- a/libs/apps/uesio/io/bundle/componentpacks/main/src/components/table/table.tsx
+++ b/libs/apps/uesio/io/bundle/componentpacks/main/src/components/table/table.tsx
@@ -70,7 +70,8 @@ type ColumnDefinition = {
   readonly?: boolean
   components: definition.DefinitionList
   [component.COMPONENT_CONTEXT]?: definition.DefinitionMap
-} & definition.BaseDefinition
+  [component.DISPLAY_CONDITIONS]?: component.DisplayCondition[]
+}
 
 type RecordContext = component.ItemContext<wire.WireRecord>
 

--- a/libs/apps/uesio/io/bundle/componentpacks/main/src/components/tabs/tabs.tsx
+++ b/libs/apps/uesio/io/bundle/componentpacks/main/src/components/tabs/tabs.tsx
@@ -45,7 +45,7 @@ const Tabs: definition.UC<TabsDefinition> = (props) => {
   const foundIndex = tabs.findIndex((tab) => tab.id === selectedTabId)
   const selectedIndex = foundIndex === -1 ? 0 : foundIndex
   const selectedTab = tabs[selectedIndex]
-  const allVisibleTabs = component.useShouldFilter<TabDefinition>(tabs, context)
+  const allVisibleTabs = component.useShouldFilter(tabs, context)
   const shouldDisplaySelectedTab =
     allVisibleTabs.findIndex((tab) => tab.id === selectedTab.id) > -1
   useEffect(() => {

--- a/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/tablabels/tablabels.tsx
+++ b/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/tablabels/tablabels.tsx
@@ -56,37 +56,33 @@ const TabLabels: definition.UtilityComponent<TabsUtilityProps> = (props) => {
 
   return (
     <div ref={target} className={classes.root}>
-      {component
-        .useShouldFilter<TabDefinition>(tabs, context)
-        .map((tab, index) => {
-          currentLabelWidth += sizes.childSizes[index]
-          const isLast = index === tabs.length - 1
-          const isFirst = index === 0
-          const menuWidth = isLast ? 0 : MENU_WIDTH
-          const isVisible =
-            isFirst || currentLabelWidth < sizes.fullWidth - menuWidth
-          if (!isVisible) overflowTabs.push(tab)
-          return (
-            <Button
-              context={context}
-              onClick={() => {
-                setSelectedTab(tab.id)
-              }}
-              key={tab.id}
-              classes={{
-                root: styles.cx(!isVisible && classes.hidden, classes.tab),
-                selected: classes.tabSelected,
-              }}
-              isSelected={tab.id === selectedTab}
-              label={tab.label}
-              icon={
-                tab.icon ? (
-                  <Icon context={context} icon={tab.icon} />
-                ) : undefined
-              }
-            />
-          )
-        })}
+      {component.useShouldFilter(tabs, context).map((tab, index) => {
+        currentLabelWidth += sizes.childSizes[index]
+        const isLast = index === tabs.length - 1
+        const isFirst = index === 0
+        const menuWidth = isLast ? 0 : MENU_WIDTH
+        const isVisible =
+          isFirst || currentLabelWidth < sizes.fullWidth - menuWidth
+        if (!isVisible) overflowTabs.push(tab)
+        return (
+          <Button
+            context={context}
+            onClick={() => {
+              setSelectedTab(tab.id)
+            }}
+            key={tab.id}
+            classes={{
+              root: styles.cx(!isVisible && classes.hidden, classes.tab),
+              selected: classes.tabSelected,
+            }}
+            isSelected={tab.id === selectedTab}
+            label={tab.label}
+            icon={
+              tab.icon ? <Icon context={context} icon={tab.icon} /> : undefined
+            }
+          />
+        )
+      })}
       {!!overflowTabs.length && (
         <div className={classes.menuWrapper}>
           <MenuButton

--- a/libs/ui/src/component/component.spec.tsx
+++ b/libs/ui/src/component/component.spec.tsx
@@ -1,5 +1,4 @@
 import { Context } from "../context/context"
-import { BaseDefinition } from "../definition/definition"
 import {
   addDefaultPropertyAndSlotValues,
   resolveDeclarativeComponentDefinition,
@@ -387,7 +386,7 @@ describe("addDefaultPropertyAndSlotValues", () => {
   addDefaultPropertyAndSlotValuesTests.forEach((tc) => {
     test(tc.name, () => {
       const actual = addDefaultPropertyAndSlotValues(
-        tc.inputDefinition as BaseDefinition,
+        tc.inputDefinition,
         tc.componentDef.properties,
         tc.componentDef.slots,
         "",

--- a/libs/ui/src/component/component.tsx
+++ b/libs/ui/src/component/component.tsx
@@ -179,7 +179,7 @@ function addDefaultPropertyAndSlotValues(
     slotsWithDefaults && slotsWithDefaults.length > 0
   // Shortcut - if we have no defaults, we are done
   if (!havePropsWithDefaults && !haveSlotsWithDefaults) return def
-  const defaults = {} as DefinitionMap
+  const defaults: DefinitionMap = {}
   if (havePropsWithDefaults) {
     propsWithDefaults.forEach((prop: ComponentProperty) => {
       const { defaultValue, name } = prop
@@ -191,12 +191,7 @@ function addDefaultPropertyAndSlotValues(
   }
 
   if (haveSlotsWithDefaults) {
-    context = context.addPropsFrame(
-      def as Record<string, FieldValue>,
-      path,
-      componentType,
-      slots,
-    )
+    context = context.addPropsFrame(def, path, componentType, slots)
     slotsWithDefaults.forEach((slot: SlotDef) => {
       const { defaultContent, name } = slot
       if (typeof def[name] === "undefined" || def[name] === null) {

--- a/libs/ui/src/context/context.ts
+++ b/libs/ui/src/context/context.ts
@@ -24,6 +24,7 @@ import { SiteState } from "../bands/site"
 import { handlers, MergeOptions, MergeType } from "./merge"
 import { getCollection } from "../bands/collection/selectors"
 import { SlotDef } from "../definition/component"
+import { BaseDefinition } from "../definition/definition"
 
 const ERROR = "ERROR",
   COMPONENT = "COMPONENT",
@@ -111,7 +112,7 @@ interface ComponentContext {
 
 interface PropsContext {
   componentType: string
-  data: Record<string, FieldValue>
+  data: BaseDefinition
   path: string
   slots: SlotDef[] | undefined
 }
@@ -495,7 +496,6 @@ class Context {
 
   getParam = (param: string) => this.getParams()?.[param]
 
-  getProp = (prop: string) => this.stack.find(isPropsContextFrame)?.data[prop]
   getPropsFrame = () => this.stack.find(isPropsContextFrame)
 
   getParentComponentDef = (path: string) =>
@@ -721,7 +721,7 @@ class Context {
     })
 
   addPropsFrame = (
-    data: Record<string, FieldValue>,
+    data: BaseDefinition,
     path: string,
     componentType: string,
     slots?: SlotDef[],

--- a/libs/ui/src/context/merge.ts
+++ b/libs/ui/src/context/merge.ts
@@ -1,5 +1,5 @@
 import { getURLFromFullName, getUserFileURL } from "../hooks/fileapi"
-import { PlainFieldValue, PlainWireRecord } from "../bands/wirerecord/types"
+import { FieldValue, PlainWireRecord } from "../bands/wirerecord/types"
 import { ID_FIELD, UPDATED_AT_FIELD } from "../collectionexports"
 import { Context } from "./context"
 import { getStaticAssetsPath } from "../hooks/platformapi"
@@ -373,12 +373,15 @@ const handlers: Record<MergeType, MergeHandler> = {
     if (!errors?.length) return ""
     return errors[0]
   },
-  Prop: (expression, context) => context.getProp(expression),
+  Prop: (expression, context) => {
+    const frame = context.getPropsFrame()
+    if (!frame) return undefined
+    return frame.data[expression] as FieldValue
+  },
   Region: (expression, context) => {
-    const styleTokens = context.getProp("uesio.styleTokens") as Record<
-      string,
-      PlainFieldValue[]
-    >
+    const frame = context.getPropsFrame()
+    if (!frame) return []
+    const styleTokens = frame.data["uesio.styleTokens"]
     return styleTokens?.[expression] || []
   },
   Slot: (expression, context) => {
@@ -388,7 +391,7 @@ const handlers: Record<MergeType, MergeHandler> = {
       return {}
     }
     const allSlotContents = propsFrame.data
-    const slotContents = allSlotContents[expression]
+    const slotContents = allSlotContents[expression] as FieldValue
     const allSlotDefs = propsFrame.slots
     const slotDef = allSlotDefs?.find((def) => def.name === expression)
     if (!slotDef) {

--- a/libs/ui/src/definition/definition.ts
+++ b/libs/ui/src/definition/definition.ts
@@ -81,7 +81,7 @@ export type Definition =
   | DefinitionMap[]
 
 export type ViewDefinition = {
-  components: DefinitionList | undefined
+  components: DefinitionList | null | undefined
   wires?: WireDefinitionMap | null
   panels?: PanelDefinitionMap | null
   events?: ViewEventsDef

--- a/libs/ui/src/definition/definition.ts
+++ b/libs/ui/src/definition/definition.ts
@@ -9,13 +9,13 @@ import { ViewEventsDef } from "./view"
 import { ViewParamDefinition } from "./param"
 import { SlotDef } from "./component"
 
-export type BaseDefinition = {
+export type BaseDefinition<T = DefinitionMap> = {
   "uesio.id"?: string
   "uesio.styleTokens"?: Record<string, string[]>
   "uesio.variant"?: MetadataKey
   "uesio.display"?: DisplayCondition[]
   "uesio.classes"?: Record<string, DisplayCondition[]>
-}
+} & T
 
 export type ImportMapping = {
   type: "IMPORT" | "VALUE"
@@ -45,7 +45,7 @@ export type UploadSpec = {
 }
 
 export type BaseProps<T = DefinitionMap> = {
-  definition: T & BaseDefinition
+  definition: BaseDefinition<T>
   path: string
   componentType?: MetadataKey
   context: Context
@@ -81,7 +81,7 @@ export type Definition =
   | DefinitionMap[]
 
 export type ViewDefinition = {
-  components: DefinitionList | null
+  components: DefinitionList | undefined
   wires?: WireDefinitionMap | null
   panels?: PanelDefinitionMap | null
   events?: ViewEventsDef

--- a/libs/ui/src/public_types/client/index.d.ts
+++ b/libs/ui/src/public_types/client/index.d.ts
@@ -185,14 +185,14 @@ export type Definition =
   | DefinitionMap
   | DefinitionValue[]
   | DefinitionMap[]
-export type BaseDefinition = {
+export type BaseDefinition<T = DefinitionMap> = {
   "uesio.id"?: string
   "uesio.styleTokens"?: Record<string, string[]>
   "uesio.variant"?: MetadataKey
   "uesio.classes"?: string
-}
+} & T
 export type BaseProps<T = DefinitionMap> = {
-  definition: T & BaseDefinition
+  definition: BaseDefinition<T>
   path: string
   componentType?: MetadataKey
   context: Context


### PR DESCRIPTION
# What does this PR do?

Just some minor types improvements I did while attempting to fix something else.

1. Includes `DefinitionMap` with every `BaseDefinition`
2. Removes unnecessary type definitions.
