### PR TITLE
Better scrollbars and variants for home sidebar

### DIFF
--- a/libs/apps/uesio/appkit/bundle/componentvariants/uesio/appkit/item/actionable.yaml
+++ b/libs/apps/uesio/appkit/bundle/componentvariants/uesio/appkit/item/actionable.yaml
@@ -1,0 +1,17 @@
+name: actionable
+label: Actionable Item
+public: true
+definition:
+  uesio.styleTokens:
+    root:
+      - border-r-2
+      - border-l-1
+      - border-b-2
+      - border-t-1
+      - border-transparent
+    content:
+      - overflow-hidden
+      - w-0
+    actionable:
+      - hover:bg-white
+      - hover:border-fontcolor-900

--- a/libs/apps/uesio/studio/bundle/componentvariants/uesio/io/scrollpanel/sidebarinner.yaml
+++ b/libs/apps/uesio/studio/bundle/componentvariants/uesio/io/scrollpanel/sidebarinner.yaml
@@ -1,0 +1,9 @@
+name: sidebarinner
+label: Sidebar Inner
+extends: uesio/io.default
+definition:
+  uesio.styleTokens:
+    header:
+      - px-4
+    inner:
+      - px-4

--- a/libs/apps/uesio/studio/bundle/views/homeleftnav.yaml
+++ b/libs/apps/uesio/studio/bundle/views/homeleftnav.yaml
@@ -47,6 +47,7 @@ definition:
         uesio.styleTokens:
           inner:
             - grid-rows-3
+            - px-0
         header:
           - uesio/io.tile:
               uesio.styleTokens:
@@ -106,94 +107,67 @@ definition:
                       - uesio/studio.name
                       - uesio/studio.description
         content:
-          - uesio/io.box:
+          - uesio/io.scrollpanel:
+              uesio.variant: uesio/studio.sidebarinner
               uesio.styleTokens:
                 root:
                   - row-span-2
-              components:
-                - uesio/io.scrollpanel:
-                    uesio.variant: uesio/io.default
-                    header:
-                      - uesio/io.titlebar:
-                          uesio.variant: uesio/io.nav
-                          title: My Apps
-                          actions:
-                    content:
-                      - uesio/io.list:
-                          uesio.id: appslist
-                          wire: apps
-                          emptyState:
-                            - uesio/io.emptystate:
-                                subtitle: You haven't created any apps.
-                                icon: web
-                          components:
-                            - uesio/appkit.item:
-                                uesio.styleTokens:
-                                  root:
-                                    - border-r-2
-                                    - border-l-1
-                                    - border-b-2
-                                    - border-t-1
-                                    - border-transparent
-                                  content:
-                                    - overflow-hidden
-                                    - w-0
-                                  actionable:
-                                    - hover:bg-white
-                                    - hover:border-fontcolor-900
-                                  avatar:
-                                    - bg-[${uesio/studio.color}]
-                                title: ${uesio/core.uniquekey}
-                                subtitle: ${uesio/studio.description}
-                                icon: ${uesio/studio.icon}
-                                iconcolor: white
-                                signals:
-                                  - signal: "route/NAVIGATE"
-                                    path: "app/${uesio/core.uniquekey}"
-          - uesio/io.box:
-              components:
-                - uesio/io.scrollpanel:
-                    uesio.variant: uesio/io.default
-                    header:
-                      - uesio/io.titlebar:
-                          uesio.variant: uesio/io.nav
-                          title: My Organizations
-                          actions:
-                            - uesio/io.button:
-                                icon: add
-                                uesio.id: add-organization
-                                uesio.variant: uesio/appkit.navicon
-                                signals:
-                                  - signal: panel/TOGGLE
-                                    panel: newOrg
-                    content:
-                      - uesio/io.list:
-                          uesio.id: orglist
-                          wire: orgs
-                          emptyState:
-                            - uesio/io.emptystate:
-                                subtitle: You aren't part of any organizations.
-                                icon: domain
-                          components:
-                            - uesio/appkit.item:
-                                uesio.styleTokens:
-                                  root:
-                                    - border-r-2
-                                    - border-l-1
-                                    - border-b-2
-                                    - border-t-1
-                                    - border-transparent
-                                  content:
-                                    - overflow-hidden
-                                    - w-0
-                                  actionable:
-                                    - hover:bg-white
-                                    - hover:border-fontcolor-900
-                                title: ${uesio/core.uniquekey}
-                                icon: domain
-                                signals:
-                                  - signal: "route/NAVIGATE"
-                                    path: "org/info/${uesio/core.uniquekey}"
+              header:
+                - uesio/io.titlebar:
+                    uesio.variant: uesio/io.nav
+                    title: My Apps
+                    actions:
+              content:
+                - uesio/io.list:
+                    uesio.id: appslist
+                    wire: apps
+                    emptyState:
+                      - uesio/io.emptystate:
+                          subtitle: You haven't created any apps.
+                          icon: web
+                    components:
+                      - uesio/appkit.item:
+                          uesio.variant: uesio/appkit.actionable
+                          uesio.styleTokens:
+                            avatar:
+                              - bg-[${uesio/studio.color}]
+                          title: ${uesio/core.uniquekey}
+                          subtitle: ${uesio/studio.description}
+                          icon: ${uesio/studio.icon}
+                          iconcolor: white
+                          signals:
+                            - signal: "route/NAVIGATE"
+                              path: "app/${uesio/core.uniquekey}"
+          - uesio/io.scrollpanel:
+              uesio.variant: uesio/studio.sidebarinner
+              header:
+                - uesio/io.titlebar:
+                    uesio.variant: uesio/io.nav
+                    title: My Organizations
+                    actions:
+                      - uesio/io.button:
+                          icon: add
+                          uesio.id: add-organization
+                          uesio.variant: uesio/appkit.navicon
+                          signals:
+                            - signal: panel/TOGGLE
+                              panel: newOrg
+              content:
+                - uesio/io.list:
+                    uesio.id: orglist
+                    wire: orgs
+                    emptyState:
+                      - uesio/io.emptystate:
+                          subtitle: You aren't part of any organizations.
+                          icon: domain
+                    components:
+                      - uesio/appkit.item:
+                          uesio.variant: uesio/appkit.actionable
+                          title: ${uesio/core.uniquekey}
+                          icon: domain
+                          signals:
+                            - signal: "route/NAVIGATE"
+                              path: "org/info/${uesio/core.uniquekey}"
         footer:
           - uesio/core.view:
               view: profiletag


### PR DESCRIPTION
# What does this PR do?

1. Removes some duplicated inline styling from the home sidebar.
2. Moves scrollbar to the edge of the container. (This is more apparent when scrollbars are always visible. The scrollbar is now all the way to the right with no padding.
