### PR TITLE
chore: support unminified build

### DIFF
--- a/apps/cli/pkg/command/pack.go
+++ b/apps/cli/pkg/command/pack.go
@@ -51,6 +51,16 @@ func Pack(options *PackOptions) error {
 		return nil
 	}
 
+	// NOTE - if NODE_ENV is undefined, esbuild will set NODE_ENV to "production" when all minify options
+	// are true, otherwise set it to "development".  If NODE_ENV is specifically set to development prior
+	// to calling esbuild, we do not want to minify.
+	isDev := os.Getenv("NODE_ENV") == "development"
+	minify := !isDev
+	var logLevel api.LogLevel = api.LogLevelWarning // defaults to "silent" if not set
+	if isDev {
+		logLevel = api.LogLevelDebug
+	}
+
 	for packName, entryPoint := range entryPoints {
 
 		buildOptions := &api.BuildOptions{
@@ -63,9 +73,10 @@ func Pack(options *PackOptions) error {
 			Write:             true,
 			Plugins:           []api.Plugin{pack.GetGlobalsPlugin(globalsMap)},
 			TsconfigRaw:       "{}",
-			MinifyWhitespace:  true,
-			MinifyIdentifiers: true,
-			MinifySyntax:      true,
+			MinifyWhitespace:  minify,
+			MinifyIdentifiers: minify,
+			MinifySyntax:      minify,
+			LogLevel:          logLevel,
 			Metafile:          true,
 			Sourcemap:         api.SourceMapLinked,
 			// This fixes a bug where the monaco amd loader was polluting

--- a/libs/ui/build.mjs
+++ b/libs/ui/build.mjs
@@ -1,6 +1,11 @@
 import * as esbuild from "esbuild"
 import fs from "node:fs"
 
+// NOTE - if NODE_ENV is undefined, esbuild will set NODE_ENV to "production" when all minify options
+// are true, otherwise set it to "development".  If NODE_ENV is specifically set to development prior
+// to calling esbuild, we do not want to minify.
+const isDev = process.env.NODE_ENV === "development"
+
 const result = await esbuild.build({
   entryPoints: ["./src/index.ts"],
   bundle: true,
@@ -8,9 +13,9 @@ const result = await esbuild.build({
   allowOverwrite: true,
   write: true,
   tsconfigRaw: {},
-  minify: true,
+  minify: !isDev,
   format: "esm",
-  logLevel: "debug",
+  logLevel: isDev ? "debug" : "warning", // defaults to "warning" if not set https://esbuild.github.io/api/#log-level
   metafile: true,
   sourcemap: true,
 })

--- a/libs/vendor/gulpfile.js
+++ b/libs/vendor/gulpfile.js
@@ -2,7 +2,7 @@ const gulp = require("gulp")
 const fs = require("fs")
 const packageLock = require("../../package-lock.json")
 const distVendor = "../../dist/vendor"
-
+//const isDev = process.env.NODE_ENV === "development" // use "dev" files if/when needed
 ////////////////////////////
 // BEGIN EDITABLE REGION
 


### PR DESCRIPTION
# What does this PR do?

Adds support for producing "unminified" builds which can be helpful when debugging.  To produce "unminified" build, ensure that `NODE_ENV` environment variable is set to `development` prior to building (e.g. `NODE_ENV=development` in `.env` file).  If NODE_ENV is anything other than "development", prior build behavior is not changed.

NOTE - Outside of vendor project, we use esbuild to build everything (via pack CLI command and build.sh for ui project).  If NODE_ENV is undefined, esbuild will automatically set NODE_ENV to "production" when all minify options are true, else "development" (see https://esbuild.github.io/api/#platform re: NODE_ENV when using build api).

# Testing

manual testing confirms unminified build when NODE_ENV=development.
