### PR TITLE
Add agent metadata type

### DIFF
--- a/apps/platform/pkg/deploy/deploy.go
+++ b/apps/platform/pkg/deploy/deploy.go
@@ -54,6 +54,7 @@ var ORDERED_ITEMS = [...]string{
 	"integrationtypes",
 	"integrations",
 	"integrationactions",
+	"agents",
 }
 
 type DeployOptions struct {

--- a/apps/platform/pkg/meta/agent.go
+++ b/apps/platform/pkg/meta/agent.go
@@ -22,7 +22,7 @@ func NewBaseAgent(namespace, name string) *Agent {
 type Agent struct {
 	BuiltIn        `yaml:",inline"`
 	BundleableBase `yaml:",inline"`
-	Description    string `yaml:"description" json:"description"`
+	Description    string `yaml:"description" json:"uesio/studio.description"`
 	ProfileRef     string `yaml:"profile" json:"uesio/studio.profile"`
 }
 

--- a/apps/platform/pkg/meta/agent.go
+++ b/apps/platform/pkg/meta/agent.go
@@ -1,0 +1,74 @@
+package meta
+
+import (
+	"errors"
+	"path"
+
+	"gopkg.in/yaml.v3"
+)
+
+func NewAgent(key string) (*Agent, error) {
+	namespace, name, err := ParseKey(key)
+	if err != nil {
+		return nil, errors.New("Bad Key for Agent: " + key)
+	}
+	return NewBaseAgent(namespace, name), nil
+}
+
+func NewBaseAgent(namespace, name string) *Agent {
+	return &Agent{BundleableBase: NewBase(namespace, name)}
+}
+
+type Agent struct {
+	BuiltIn        `yaml:",inline"`
+	BundleableBase `yaml:",inline"`
+	Description    string `yaml:"description" json:"description"`
+	PromptPath     string `yaml:"promptPath" json:"uesio/studio.prompt_path"`
+	ProfileRef     string `yaml:"profile" json:"uesio/studio.profile"`
+}
+
+type AgentWrapper Agent
+
+func (a *Agent) GetCollectionName() string {
+	return AGENT_COLLECTION_NAME
+}
+
+func (a *Agent) GetCollection() CollectionableGroup {
+	return &AgentCollection{}
+}
+
+func (a *Agent) GetBundleFolderName() string {
+	return AGENT_FOLDER_NAME
+}
+
+func (a *Agent) GetBasePath() string {
+	return a.Name
+}
+
+func (a *Agent) GetPath() string {
+	return path.Join(a.Name, "agent.yaml")
+}
+
+func (a *Agent) SetField(fieldName string, value interface{}) error {
+	return StandardFieldSet(a, fieldName, value)
+}
+
+func (a *Agent) GetField(fieldName string) (interface{}, error) {
+	return StandardFieldGet(a, fieldName)
+}
+
+func (a *Agent) Loop(iter func(string, interface{}) error) error {
+	return StandardItemLoop(a, iter)
+}
+
+func (a *Agent) Len() int {
+	return StandardItemLen(a)
+}
+
+func (a *Agent) UnmarshalYAML(node *yaml.Node) error {
+	err := validateNodeName(node, a.Name)
+	if err != nil {
+		return err
+	}
+	return node.Decode((*AgentWrapper)(a))
+}

--- a/apps/platform/pkg/meta/agent.go
+++ b/apps/platform/pkg/meta/agent.go
@@ -23,7 +23,6 @@ type Agent struct {
 	BuiltIn        `yaml:",inline"`
 	BundleableBase `yaml:",inline"`
 	Description    string `yaml:"description" json:"description"`
-	PromptPath     string `yaml:"promptPath" json:"uesio/studio.prompt_path"`
 	ProfileRef     string `yaml:"profile" json:"uesio/studio.profile"`
 }
 

--- a/apps/platform/pkg/meta/agentcollection.go
+++ b/apps/platform/pkg/meta/agentcollection.go
@@ -1,0 +1,68 @@
+package meta
+
+import (
+	"strconv"
+	"strings"
+)
+
+type AgentCollection []*Agent
+
+var AGENT_COLLECTION_NAME = "uesio/studio.agent"
+var AGENT_FOLDER_NAME = "agents"
+var AGENT_FIELDS = StandardGetFields(&Agent{})
+
+func (ac *AgentCollection) GetName() string {
+	return AGENT_COLLECTION_NAME
+}
+
+func (ac *AgentCollection) GetBundleFolderName() string {
+	return AGENT_FOLDER_NAME
+}
+
+func (ac *AgentCollection) GetFields() []string {
+	return AGENT_FIELDS
+}
+
+func (ac *AgentCollection) NewItem() Item {
+	return &Agent{}
+}
+
+func (ac *AgentCollection) AddItem(item Item) error {
+	*ac = append(*ac, item.(*Agent))
+	return nil
+}
+
+func (ac *AgentCollection) GetItemFromPath(path, namespace string) BundleableItem {
+	parts := strings.Split(path, "/")
+	return NewBaseAgent(namespace, parts[0])
+}
+
+func (ac *AgentCollection) GetItemFromKey(key string) (BundleableItem, error) {
+	return NewAgent(key)
+}
+
+func (ac *AgentCollection) IsDefinitionPath(path string) bool {
+	parts := strings.Split(path, "/")
+	return len(parts) == 2 && parts[1] == "agent.yaml"
+}
+
+func (ac *AgentCollection) FilterPath(path string, conditions BundleConditions, definitionOnly bool) bool {
+	if definitionOnly {
+		return ac.IsDefinitionPath(path)
+	}
+	return true
+}
+
+func (ac *AgentCollection) Loop(iter GroupIterator) error {
+	for index, c := range *ac {
+		err := iter(c, strconv.Itoa(index))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (ac *AgentCollection) Len() int {
+	return len(*ac)
+}

--- a/apps/platform/pkg/meta/metadata.go
+++ b/apps/platform/pkg/meta/metadata.go
@@ -297,6 +297,7 @@ var METADATA_NAME_MAP = map[string]string{
 }
 
 var bundleableGroupMap = map[string]BundleableFactory{
+	(&AgentCollection{}).GetBundleFolderName():                func() BundleableGroup { return &AgentCollection{} },
 	(&SecretCollection{}).GetBundleFolderName():               func() BundleableGroup { return &SecretCollection{} },
 	(&ProfileCollection{}).GetBundleFolderName():              func() BundleableGroup { return &ProfileCollection{} },
 	(&PermissionSetCollection{}).GetBundleFolderName():        func() BundleableGroup { return &PermissionSetCollection{} },

--- a/libs/apps/uesio/core/bundle/bots/generator/agent/bot.js
+++ b/libs/apps/uesio/core/bundle/bots/generator/agent/bot.js
@@ -1,0 +1,14 @@
+function run(botapi) {
+  const params = botapi.params.getAll()
+  const { name, label, description, prompt } = params
+
+  const basePath = `agents/${name}`
+
+  botapi.generateStringFile(`${basePath}/prompt.txt`, prompt)
+
+  botapi.generateFile(
+    `${basePath}/agent.yaml`,
+    { name, label, description },
+    `templates/agent.yaml`,
+  )
+}

--- a/libs/apps/uesio/core/bundle/bots/generator/agent/bot.yaml
+++ b/libs/apps/uesio/core/bundle/bots/generator/agent/bot.yaml
@@ -1,0 +1,21 @@
+name: agent
+dialect: JAVASCRIPT
+label: Agent
+type: GENERATOR
+params:
+  - name: name
+    prompt: Bot Name
+    type: METADATANAME
+    required: true
+  - name: label
+    prompt: Label
+    type: TEXT
+    required: true
+  - name: description
+    prompt: Description
+    type: TEXT
+  - name: prompt
+    prompt: System Prompt
+    type: LONGTEXT
+    required: true
+public: true

--- a/libs/apps/uesio/core/bundle/bots/generator/agent/templates/agent.yaml
+++ b/libs/apps/uesio/core/bundle/bots/generator/agent/templates/agent.yaml
@@ -1,0 +1,3 @@
+name: ${name}
+label: ${label}
+description: ${description}

--- a/libs/apps/uesio/studio/bundle/collections/agent.yaml
+++ b/libs/apps/uesio/studio/bundle/collections/agent.yaml
@@ -1,0 +1,9 @@
+name: agent
+uniqueKey:
+  - uesio/studio.workspace
+  - uesio/studio.name
+nameField: uesio/studio.name
+access: protected
+accessField: uesio/studio.workspace
+label: Agent
+pluralLabel: Agents

--- a/libs/apps/uesio/studio/bundle/featureflags/manage_agents.yaml
+++ b/libs/apps/uesio/studio/bundle/featureflags/manage_agents.yaml
@@ -1,0 +1,4 @@
+name: manage_agents
+label: Manage Agents
+type: CHECKBOX
+defaultValue: false

--- a/libs/apps/uesio/studio/bundle/fields/uesio/studio/agent/description.yaml
+++ b/libs/apps/uesio/studio/bundle/fields/uesio/studio/agent/description.yaml
@@ -1,0 +1,3 @@
+name: description
+type: TEXT
+label: Description

--- a/libs/apps/uesio/studio/bundle/fields/uesio/studio/agent/label.yaml
+++ b/libs/apps/uesio/studio/bundle/fields/uesio/studio/agent/label.yaml
@@ -1,0 +1,3 @@
+name: label
+type: TEXT
+label: Label

--- a/libs/apps/uesio/studio/bundle/fields/uesio/studio/agent/name.yaml
+++ b/libs/apps/uesio/studio/bundle/fields/uesio/studio/agent/name.yaml
@@ -1,0 +1,7 @@
+name: name
+type: TEXT
+label: Name
+required: true
+createOnly: true
+validate:
+  type: METADATA

--- a/libs/apps/uesio/studio/bundle/fields/uesio/studio/agent/profile.yaml
+++ b/libs/apps/uesio/studio/bundle/fields/uesio/studio/agent/profile.yaml
@@ -1,0 +1,5 @@
+name: profile
+type: METADATA
+label: Profile
+metadata:
+  type: PROFILE

--- a/libs/apps/uesio/studio/bundle/fields/uesio/studio/agent/prompt_path.yaml
+++ b/libs/apps/uesio/studio/bundle/fields/uesio/studio/agent/prompt_path.yaml
@@ -1,0 +1,3 @@
+name: prompt_path
+type: TEXT
+label: Prompt Path

--- a/libs/apps/uesio/studio/bundle/fields/uesio/studio/agent/prompt_path.yaml
+++ b/libs/apps/uesio/studio/bundle/fields/uesio/studio/agent/prompt_path.yaml
@@ -1,3 +1,0 @@
-name: prompt_path
-type: TEXT
-label: Prompt Path

--- a/libs/apps/uesio/studio/bundle/fields/uesio/studio/agent/public.yaml
+++ b/libs/apps/uesio/studio/bundle/fields/uesio/studio/agent/public.yaml
@@ -1,0 +1,3 @@
+name: public
+type: CHECKBOX
+label: Public

--- a/libs/apps/uesio/studio/bundle/fields/uesio/studio/agent/workspace.yaml
+++ b/libs/apps/uesio/studio/bundle/fields/uesio/studio/agent/workspace.yaml
@@ -1,0 +1,5 @@
+name: workspace
+type: REFERENCE
+label: Workspace
+reference:
+  collection: workspace

--- a/libs/apps/uesio/studio/bundle/permissionsets/standard.yaml
+++ b/libs/apps/uesio/studio/bundle/permissionsets/standard.yaml
@@ -19,6 +19,8 @@ bots:
   uesio/studio.select_plan: true
 views:
   uesio/appkit.user_detail_content: true
+  uesio/studio.agent: true
+  uesio/studio.agents: true
   uesio/studio.app: true
   uesio/studio.app_new: true
   uesio/studio.appsettings: true
@@ -129,6 +131,8 @@ views:
   uesio/studio.userusage: true
   uesio/studio.userusage_inner: true
 routes:
+  uesio/studio.agent: true
+  uesio/studio.agents: true
   uesio/studio.app_new: true
   uesio/studio.appsettings: true
   uesio/studio.authsources: true
@@ -249,6 +253,7 @@ collections:
     read: true # TODO: Remove/adjust once https://github.com/ues-io/uesio/issues/4554 is addressed
   uesio/core.bulkbatch:
     read: true # TODO: Remove/adjust once https://github.com/ues-io/uesio/issues/4554 is addressed
+  uesio/studio.agent: true
   uesio/studio.app: true
   uesio/studio.bot: true
   uesio/studio.bundledependency: true

--- a/libs/apps/uesio/studio/bundle/routes/agent.yaml
+++ b/libs/apps/uesio/studio/bundle/routes/agent.yaml
@@ -1,0 +1,5 @@
+name: agent
+path: app/{app:\w*\/\w*}/workspace/{workspacename}/agents/{namespace:\w*\/\w*}/{agentname}
+view: agent
+theme: default
+title: "Agent: $Param{agentname}"

--- a/libs/apps/uesio/studio/bundle/routes/agents.yaml
+++ b/libs/apps/uesio/studio/bundle/routes/agents.yaml
@@ -1,0 +1,5 @@
+name: agents
+path: app/{app:\w*\/\w*}/workspace/{workspacename}/agents
+view: agents
+theme: default
+title: Agents

--- a/libs/apps/uesio/studio/bundle/views/agent.yaml
+++ b/libs/apps/uesio/studio/bundle/views/agent.yaml
@@ -1,0 +1,203 @@
+name: agent
+definition:
+  # Wires are how we pull in data
+  wires:
+    workspaces:
+      collection: uesio/studio.workspace
+      fields:
+        uesio/core.id:
+        uesio/studio.name:
+        uesio/studio.app:
+          fields:
+            uesio/studio.color:
+            uesio/studio.icon:
+      conditions:
+        - field: uesio/core.uniquekey
+          value: $Param{app}:$Param{workspacename}
+    agents:
+      collection: uesio/studio.agent
+      conditions:
+        - field: uesio/studio.allmetadata
+          value: true
+        - field: uesio/studio.item
+          value: $Param{namespace}.$Param{agentname}
+    attachments:
+      collection: uesio/core.userfile
+      fields:
+        uesio/core.id:
+        uesio/core.path:
+        uesio/core.recordid:
+        uesio/core.collectionid:
+        uesio/core.data:
+        uesio/core.mimetype:
+        uesio/core.updatedat:
+      conditions:
+        - field: uesio/core.recordid
+          valueSource: LOOKUP
+          lookupWire: agents
+          lookupField: uesio/core.id
+        - field: uesio/core.fieldid
+          operator: IS_BLANK
+  # Components are how we describe the layout of our view
+  components:
+    - uesio/io.viewlayout:
+        uesio.variant: uesio/studio.main
+        left:
+          - uesio/core.view:
+              uesio.context:
+                wire: workspaces
+              view: workspacenav
+              params:
+                selected: agents
+                itemType: agents
+                itemIcon: support_agent
+                itemName: $Param{agentname}
+                itemNameSpace: $Param{namespace}
+                itemNameSpaceIcon: ${agents:uesio/studio.appicon}
+                itemNameSpaceColor: ${agents:uesio/studio.appcolor}
+        content:
+          - uesio/appkit.layout_detail_split:
+              main:
+                - uesio/io.item:
+                    uesio.id: agentsItem
+                    wire: agents
+                    mode: READ
+                    components:
+                      - uesio/io.titlebar:
+                          uesio.variant: uesio/appkit.main
+                          title: ${uesio/studio.name}
+                          subtitle: Agent
+                          avatar:
+                            - uesio/io.text:
+                                uesio.variant: uesio/io.icon
+                                text: ${uesio/studio.appicon}
+                                color: ${uesio/studio.appcolor}
+                          actions:
+                            - uesio/io.group:
+                                uesio.display:
+                                  - type: paramValue
+                                    param: app
+                                    operator: EQUALS
+                                    value: $Param{namespace}
+                                components:
+                                  - uesio/io.button:
+                                      uesio.variant: uesio/appkit.secondary
+                                      text: $Label{uesio/io.edit}
+                                      uesio.display:
+                                        - type: fieldMode
+                                          mode: READ
+                                        - type: wireHasNoChanges
+                                          wire: agents
+                                        - type: wireHasNoChanges
+                                          wire: attachments
+                                      signals:
+                                        - signal: component/CALL
+                                          component: uesio/io.item
+                                          componentsignal: TOGGLE_MODE
+                                          targettype: specific
+                                          target: agentsItem
+                                  - uesio/io.button:
+                                      uesio.variant: uesio/appkit.primary
+                                      text: $Label{uesio/io.save}
+                                      uesio.display:
+                                        - type: group
+                                          conjunction: OR
+                                          conditions:
+                                            - type: fieldMode
+                                              mode: EDIT
+                                            - type: wireHasChanges
+                                              wire: agents
+                                            - type: wireHasChanges
+                                              wire: attachments
+                                      signals:
+                                        - signal: wire/SAVE
+                                          wires:
+                                            - agents
+                                            - attachments
+                                  - uesio/io.button:
+                                      uesio.variant: uesio/appkit.secondary
+                                      text: $Label{uesio/io.cancel}
+                                      uesio.display:
+                                        - type: group
+                                          conjunction: OR
+                                          conditions:
+                                            - type: fieldMode
+                                              mode: EDIT
+                                            - type: wireHasChanges
+                                              wire: agents
+                                            - type: wireHasChanges
+                                              wire: attachments
+                                      signals:
+                                        - signal: wire/CANCEL
+                                          wire: agents
+                                        - signal: wire/CANCEL
+                                          wire: attachments
+                                        - signal: component/CALL
+                                          component: uesio/io.item
+                                          componentsignal: SET_READ_MODE
+                                          targettype: specific
+                                          target: agentsItem
+                                  - uesio/io.button:
+                                      uesio.variant: uesio/appkit.secondary
+                                      text: $Label{uesio/io.delete}
+                                      uesio.display:
+                                        - type: fieldMode
+                                          mode: READ
+                                        - type: wireHasNoChanges
+                                          wire: agents
+                                        - type: wireHasNoChanges
+                                          wire: attachments
+                                      signals:
+                                        - signal: panel/TOGGLE
+                                          panel: deleteAgent
+                      - uesio/io.box:
+                          uesio.variant: uesio/appkit.primarysection
+                          components:
+                            - uesio/io.grid:
+                                uesio.variant: uesio/appkit.two_columns
+                                items:
+                                  - uesio/io.field:
+                                      fieldId: uesio/studio.name
+                                  - uesio/io.field:
+                                      fieldId: uesio/studio.label
+                            - uesio/io.field:
+                                fieldId: uesio/studio.description
+                      - uesio/io.box:
+                          uesio.variant: uesio/appkit.section
+                          components:
+                            - uesio/io.list:
+                                uesio.id: agentAttachmentsList
+                                wire: attachments
+                                mode: EDIT
+                                components:
+                                  - uesio/io.fileattachment:
+                                      displayAs: TEXT
+                                      textOptions:
+                                        language: plaintext
+                      - uesio/appkit.section_audit_info:
+  panels:
+    deleteAgent:
+      uesio.type: uesio/io.dialog
+      title: Delete Agent
+      width: 400px
+      height: 300px
+      components:
+        - uesio/io.text:
+            text: Are you sure you want to delete this agent?
+      actions:
+        - uesio/io.button:
+            text: $Label{uesio/io.delete}
+            uesio.variant: uesio/io.primary
+            signals:
+              - signal: wire/MARK_FOR_DELETE
+              - signal: wire/SAVE
+                wires:
+                  - agents
+              - signal: route/NAVIGATE
+                path: app/$Param{app}/workspace/$Param{workspacename}/agents
+        - uesio/io.button:
+            text: $Label{uesio/io.cancel}
+            uesio.variant: uesio/io.secondary
+            signals:
+              - signal: panel/TOGGLE
+                panel: deleteAgent

--- a/libs/apps/uesio/studio/bundle/views/agents.yaml
+++ b/libs/apps/uesio/studio/bundle/views/agents.yaml
@@ -1,0 +1,100 @@
+name: agents
+definition:
+  # Wires are how we pull in data
+  wires:
+    workspaces:
+      collection: uesio/studio.workspace
+      fields:
+        uesio/core.id:
+        uesio/studio.name:
+        uesio/studio.app:
+          fields:
+            uesio/studio.color:
+            uesio/studio.icon:
+      conditions:
+        - field: uesio/core.uniquekey
+          value: $Param{app}:$Param{workspacename}
+    agents:
+      collection: uesio/studio.agent
+      conditions:
+        - field: uesio/studio.allmetadata
+          value: true
+        - field: uesio/studio.namespace
+          operator: EQ
+          inactive: false
+          id: localMetadataOnly
+          valueSource: PARAM
+          param: app
+  # Components are how we describe the layout of our view
+  components:
+    - uesio/io.viewlayout:
+        uesio.variant: uesio/studio.main
+        left:
+          - uesio/core.view:
+              uesio.context:
+                wire: workspaces
+              view: workspacenav
+              params:
+                selected: agents
+                itemType: agents
+                itemIcon: support_agent
+        content:
+          - uesio/appkit.layout_detail_split:
+              main:
+                - uesio/io.titlebar:
+                    uesio.variant: uesio/appkit.main
+                    title: Agents
+                    subtitle: If you're not part of the solution, you're part of the precipitate.
+                    avatar:
+                      - uesio/io.text:
+                          uesio.variant: uesio/io.icon
+                          text: support_agent
+                    actions:
+                      - uesio/io.group:
+                          components:
+                            - uesio/studio.generatorbutton:
+                                uesio.context:
+                                  workspace:
+                                    name: $Param{workspacename}
+                                    app: $Param{app}
+                                buttonVariant: uesio/appkit.secondary
+                                icon: add
+                                hotkey: "n"
+                                label: New Agent
+                                generator: uesio/core.agent
+                - uesio/io.box:
+                    uesio.variant: uesio/appkit.primarysection
+                    components:
+                      - uesio/studio.listheader:
+                          wire: agents
+                          searchFields:
+                            - uesio/studio.name
+                      - uesio/io.table:
+                          uesio.id: agentsTable
+                          wire: agents
+                          uesio.variant: uesio/appkit.main
+                          columns:
+                            - label: Agent
+                              components:
+                                - uesio/studio.item_metadata:
+                              width: 200px
+                            - field: uesio/core.updatedby
+                              user:
+                                subtitle: $Time{uesio/core.updatedat}
+                              width: 200px
+                            - field: uesio/core.createdby
+                              user:
+                                subtitle: $Time{uesio/core.createdat}
+                              width: 200px
+                          rowactions:
+                            - text: Details
+                              type: DEFAULT
+                              uesio.display:
+                                - type: paramValue
+                                  param: app
+                                  operator: EQUALS
+                                  value: ${uesio/studio.namespace}
+                              signals:
+                                - signal: route/NAVIGATE
+                                  path: app/$Param{app}/workspace/$Param{workspacename}/agents/${uesio/studio.namespace}/${uesio/studio.name}
+                          pagesize: 10

--- a/libs/apps/uesio/studio/bundle/views/workspacenav.yaml
+++ b/libs/apps/uesio/studio/bundle/views/workspacenav.yaml
@@ -64,18 +64,6 @@ definition:
               content:
                 - uesio/appkit.icontile:
                     tileVariant: uesio/io.nav
-                    uesio.display:
-                      - type: featureFlag
-                        name: manage_bots
-                    uesio.id: bots
-                    title: Bots
-                    icon: smart_toy
-                    selectedid: $Param{selected}
-                    signals:
-                      - signal: "route/NAVIGATE"
-                        path: app/${uesio/studio.app->uesio/core.uniquekey}/workspace/${uesio/studio.name}/bots
-                - uesio/appkit.icontile:
-                    tileVariant: uesio/io.nav
                     uesio.id: collections
                     title: Collections
                     icon: list
@@ -83,30 +71,6 @@ definition:
                     signals:
                       - signal: "route/NAVIGATE"
                         path: app/${uesio/studio.app->uesio/core.uniquekey}/workspace/${uesio/studio.name}/collections
-                - uesio/appkit.icontile:
-                    tileVariant: uesio/io.nav
-                    uesio.display:
-                      - type: featureFlag
-                        name: manage_integrations
-                    uesio.id: integrations
-                    title: Integrations
-                    icon: electrical_services
-                    selectedid: $Param{selected}
-                    signals:
-                      - signal: "route/NAVIGATE"
-                        path: app/${uesio/studio.app->uesio/core.uniquekey}/workspace/${uesio/studio.name}/integrations
-                - uesio/appkit.icontile:
-                    tileVariant: uesio/io.nav
-                    uesio.display:
-                      - type: featureFlag
-                        name: manage_integration_types
-                    uesio.id: integrationtypes
-                    title: Integration Types
-                    icon: code
-                    selectedid: $Param{selected}
-                    signals:
-                      - signal: "route/NAVIGATE"
-                        path: app/${uesio/studio.app->uesio/core.uniquekey}/workspace/${uesio/studio.name}/integrationtypes
                 - uesio/appkit.icontile:
                     tileVariant: uesio/io.nav
                     uesio.id: selectlists
@@ -168,6 +132,69 @@ definition:
                       - signal: "route/NAVIGATE"
                         path: app/${uesio/studio.app->uesio/core.uniquekey}/workspace/${uesio/studio.name}/themes
           - uesio/io.navsection:
+              title: Automation & Integration
+              uesio.display:
+                - type: group
+                  conjunction: OR
+                  conditions:
+                    - type: featureFlag
+                      name: manage_agents
+                    - type: featureFlag
+                      name: manage_bots
+                    - type: featureFlag
+                      name: manage_integrations
+                    - type: featureFlag
+                      name: manage_integration_types
+              content:
+                - uesio/appkit.icontile:
+                    tileVariant: uesio/io.nav
+                    uesio.display:
+                      - type: featureFlag
+                        name: manage_agents
+                    uesio.id: agents
+                    title: Agents
+                    icon: support_agent
+                    selectedid: $Param{selected}
+                    signals:
+                      - signal: "route/NAVIGATE"
+                        path: app/${uesio/studio.app->uesio/core.uniquekey}/workspace/${uesio/studio.name}/agents
+                - uesio/appkit.icontile:
+                    tileVariant: uesio/io.nav
+                    uesio.display:
+                      - type: featureFlag
+                        name: manage_bots
+                    uesio.id: bots
+                    title: Bots
+                    icon: smart_toy
+                    selectedid: $Param{selected}
+                    signals:
+                      - signal: "route/NAVIGATE"
+                        path: app/${uesio/studio.app->uesio/core.uniquekey}/workspace/${uesio/studio.name}/bots
+                - uesio/appkit.icontile:
+                    tileVariant: uesio/io.nav
+                    uesio.display:
+                      - type: featureFlag
+                        name: manage_integrations
+                    uesio.id: integrations
+                    title: Integrations
+                    icon: electrical_services
+                    selectedid: $Param{selected}
+                    signals:
+                      - signal: "route/NAVIGATE"
+                        path: app/${uesio/studio.app->uesio/core.uniquekey}/workspace/${uesio/studio.name}/integrations
+                - uesio/appkit.icontile:
+                    tileVariant: uesio/io.nav
+                    uesio.display:
+                      - type: featureFlag
+                        name: manage_integration_types
+                    uesio.id: integrationtypes
+                    title: Integration Types
+                    icon: code
+                    selectedid: $Param{selected}
+                    signals:
+                      - signal: "route/NAVIGATE"
+                        path: app/${uesio/studio.app->uesio/core.uniquekey}/workspace/${uesio/studio.name}/integrationtypes
+          - uesio/io.navsection:
               title: Security & Access
               content:
                 - uesio/appkit.icontile:
@@ -188,6 +215,33 @@ definition:
                     signals:
                       - signal: "route/NAVIGATE"
                         path: app/${uesio/studio.app->uesio/core.uniquekey}/workspace/${uesio/studio.name}/profiles
+                - uesio/appkit.icontile:
+                    tileVariant: uesio/io.nav
+                    uesio.display:
+                      - type: featureFlag
+                        name: manage_feature_flags
+                    uesio.id: featureflags
+                    title: Feature Flags
+                    icon: new_releases
+                    selectedid: $Param{selected}
+                    signals:
+                      - signal: "route/NAVIGATE"
+                        path: app/${uesio/studio.app->uesio/core.uniquekey}/workspace/${uesio/studio.name}/featureflags
+                - uesio/appkit.icontile:
+                    tileVariant: uesio/io.nav
+                    uesio.display:
+                      - type: featureFlag
+                        name: manage_user_access_tokens
+                    uesio.id: useraccesstokens
+                    title: User Access Tokens
+                    icon: token
+                    selectedid: $Param{selected}
+                    signals:
+                      - signal: "route/NAVIGATE"
+                        path: app/${uesio/studio.app->uesio/core.uniquekey}/workspace/${uesio/studio.name}/useraccesstokens
+          - uesio/io.navsection:
+              title: Authentication & Credentials
+              content:
                 - uesio/appkit.icontile:
                     tileVariant: uesio/io.nav
                     uesio.id: configvalues
@@ -217,16 +271,13 @@ definition:
                         path: app/${uesio/studio.app->uesio/core.uniquekey}/workspace/${uesio/studio.name}/credentials
                 - uesio/appkit.icontile:
                     tileVariant: uesio/io.nav
-                    uesio.display:
-                      - type: featureFlag
-                        name: manage_feature_flags
-                    uesio.id: featureflags
-                    title: Feature Flags
-                    icon: new_releases
+                    uesio.id: signupmethods
+                    title: Signup Methods
+                    icon: person_add
                     selectedid: $Param{selected}
                     signals:
                       - signal: "route/NAVIGATE"
-                        path: app/${uesio/studio.app->uesio/core.uniquekey}/workspace/${uesio/studio.name}/featureflags
+                        path: app/${uesio/studio.app->uesio/core.uniquekey}/workspace/${uesio/studio.name}/signupmethods
                 - uesio/appkit.icontile:
                     tileVariant: uesio/io.nav
                     uesio.display:
@@ -239,27 +290,6 @@ definition:
                     signals:
                       - signal: "route/NAVIGATE"
                         path: app/${uesio/studio.app->uesio/core.uniquekey}/workspace/${uesio/studio.name}/authsources
-                - uesio/appkit.icontile:
-                    tileVariant: uesio/io.nav
-                    uesio.id: signupmethods
-                    title: Signup Methods
-                    icon: person_add
-                    selectedid: $Param{selected}
-                    signals:
-                      - signal: "route/NAVIGATE"
-                        path: app/${uesio/studio.app->uesio/core.uniquekey}/workspace/${uesio/studio.name}/signupmethods
-                - uesio/appkit.icontile:
-                    tileVariant: uesio/io.nav
-                    uesio.display:
-                      - type: featureFlag
-                        name: manage_user_access_tokens
-                    uesio.id: useraccesstokens
-                    title: User Access Tokens
-                    icon: token
-                    selectedid: $Param{selected}
-                    signals:
-                      - signal: "route/NAVIGATE"
-                        path: app/${uesio/studio.app->uesio/core.uniquekey}/workspace/${uesio/studio.name}/useraccesstokens
           - uesio/io.navsection:
               title: Internationalization
               content:


### PR DESCRIPTION
# What does this PR do?

1. Adds the `agent` metadata type.
2. Adds the `manage_agents` feature flag.
3. Adds basic studio UI for managing agents.

<img width="848" alt="Screenshot 2025-03-17 at 10 11 27 AM" src="https://github.com/user-attachments/assets/76811612-a8f4-48c4-bc4a-7c278868c3db" />

NOTE:

This PR does not contain any actual agent functionality, just the ability to create/deploy/retrieve agent metadata items. That's why it's all behind a feature flag.

# Testing

1. Turn on the `manage_agents` feature flag.
2. Basic UI and deploy/retrieve should work for agents.
