### PR TITLE
chore: remove go.work.sum from git

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,6 +63,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: go.work
+          # Maintaining go.work.sum even though not in repo in case its added back - don't want to overlookg re-adding it
           cache-dependency-path: |
             apps/*/go.sum
             go.work.sum
@@ -112,6 +113,7 @@ jobs:
         with:
           path: |
             go-build-cache
+          # Maintaining go.work.sum even though not in repo in case its added back - don't want to overlookg re-adding it
           key: ${{ runner.os }}-docker-cache-${{ hashFiles('apps/**/go.sum', 'go.work.sum') }}
 
       - name: Inject cache into docker
@@ -198,6 +200,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: go.work
+          # Maintaining go.work.sum even though not in repo in case its added back - don't want to overlookg re-adding it
           cache-dependency-path: |
             apps/*/go.sum
             go.work.sum

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -115,6 +115,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: go.work
+          # Maintaining go.work.sum even though not in repo in case its added back - don't want to overlookg re-adding it
           cache-dependency-path: |
             apps/*/go.sum
             go.work.sum

--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,10 @@ queries/results
 .nx/cache
 .nx/workspace-data
 
+# Go
+# See comment in ./go.work regarding why go.work.sum is ignored
+go.work.sum
+
 # CI workflows cache go which creates a go-build-cache directory that contains packages that contain package.json files
 # so whenever nx is run, it "thinks" they are "projects" in the nx workspace and then fails to parse them (e.g., they
 # do not have a "name" property).  The below could be included in a .nxignore file since the problem is nx specific,

--- a/go.work
+++ b/go.work
@@ -1,7 +1,13 @@
 // There are differing opinions on whether or not go.work/go.work.sum should be checked in to version control.
 // This repo is a monorepo containing containing multiple-go modules that are NOT intended to be consumed
 // externally.  The general guidance on this, although unofficial, is that is is OK to commit these files
-// to version control.  See https://github.com/golang/go/issues/53502
+// to version control and many large projects do.  That said, we are not committing go.work.sum because its unclear 
+// how it is maintained by go as it seems to change from time to time even though dependencies aren't changing.  
+// Given the frequency that this file changes during development, it becomes cumbersome to maintain. Depending on 
+// how things go (no pun intended) and/or if go provides better guidance/documentation around these two files this 
+// can be revisited.  If issues arise, go.work can also be removed since again, these two files are only intended for 
+// development and not used when building the modules.
+// See https://github.com/golang/go/issues/51941 & https://github.com/golang/go/issues/53502
 
 go 1.24.1
 

--- a/go.work.sum
+++ b/go.work.sum
@@ -1,9 +1,0 @@
-cloud.google.com/go v0.112.2 h1:ZaGT6LiG7dBzi6zNOvVZwacaXlmf3lRqnC4DQzqyRQw=
-cloud.google.com/go/compute v1.25.1 h1:ZRpHJedLtTpKgr3RV1Fx23NuaAEN1Zfx9hw1u4aJdjU=
-github.com/chzyer/logex v1.2.1/go.mod h1:JLbx6lG2kDbNRFnfkgvh4eRJRPX1QCoOIWomwysCBrQ=
-github.com/chzyer/readline v1.5.1/go.mod h1:Eh+b79XXUwfKfcPLepksvw2tcLE/Ct21YObkaSkeBlk=
-github.com/chzyer/test v1.0.0/go.mod h1:2JlltgoNkt4TW/z9V/IzDdFaMTM2JPIi26O1pF38GC8=
-github.com/googleapis/gax-go v2.0.0+incompatible h1:j0GKcs05QVmm7yesiZq2+9cxHkNK9YM6zKx4D2qucQU=
-github.com/ianlancetaylor/demangle v0.0.0-20240312041847-bd984b5ce465/go.mod h1:gx7rwoVhcfuVKG5uya9Hs3Sxj7EIvldVofAWIUtGouw=
-golang.org/x/sys v0.0.0-20220310020820-b874c991c1a5/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-google.golang.org/genproto v0.0.0-20240213162025-012b6fc9bca9 h1:9+tzLLstTlPTRyJTh+ah5wIMsBW5c4tQwGTN3thOW9Y=


### PR DESCRIPTION
# What does this PR do?

Eliminate go.work.sum from git.  Reasons are:

1. go.work & go.work.sum are very poorly documented by go
2. go.work.sum seems to change frequently even when deps haven't changed - may be machine specific
3. both files are intended for development purposes only and not used in builds

For now, leaving go.work since uesio is monorepo with no publicly consumed libraries so having go.work does provide some benefits without each developer having to maintain it individually.  

If/When go.work & go.work.sum documentation is improved and there is clear information about these files and how to properly use them in various scenarios, this can be revisited.

See https://github.com/golang/go/issues/51941 & https://github.com/golang/go/issues/53502

# Testing

ci & e2e will cover.
