### PR TITLE
fix: variant merge bug and add tests

### DIFF
--- a/libs/ui/src/component/component.tsx
+++ b/libs/ui/src/component/component.tsx
@@ -93,7 +93,7 @@ function getDefinitionFromVariant(
 function mergeContextVariants(
   definition: DefinitionMap | undefined,
   componentType: MetadataKey,
-  componentTypeDef: ComponentDef,
+  componentTypeDef: ComponentDef | undefined,
   context: Context,
 ): DefinitionMap | undefined {
   if (!definition) return definition
@@ -107,7 +107,6 @@ function mergeContextVariants(
       [component.STYLE_VARIANT]: variantName,
     }
   }
-  if (!componentTypeDef) return definition
   const variantDefinition = getVariantDefinition(
     componentType,
     componentTypeDef,
@@ -116,7 +115,7 @@ function mergeContextVariants(
   )
   if (!variantDefinition) return definition
   return mergeDefinitionMaps(
-    componentTypeDef.type === Declarative
+    componentTypeDef?.type === Declarative
       ? variantDefinition
       : removeStylesNode(variantDefinition),
     definition,
@@ -327,6 +326,7 @@ const getUtility = <T extends UtilityProps = UtilityPropsPlus>(
 
 export {
   addDefaultPropertyAndSlotValues,
+  mergeContextVariants,
   Component,
   DECLARATIVE_COMPONENT,
   getVariantDefinition,


### PR DESCRIPTION
# What does this PR do?

There are cases where a componentDef isn't correctly loaded into the registry, but the component still needs to be rendered. It makes sense that if a componentDef isn't loaded, then we have no idea what the default variant for a component is. However, if a component explicitly asks for a variant, and that variant is loaded, we should still respect that and merge the variant.

Previously we were bailing early if componentDef didn't exist in the registry.

This PR also adds tests to verify this functionality.
