### PR TITLE
fix: data manager loads unnecessary fields

### DIFF
--- a/apps/platform/pkg/meta/filesource.go
+++ b/apps/platform/pkg/meta/filesource.go
@@ -9,7 +9,7 @@ import (
 func NewFileSource(key string) (*FileSource, error) {
 	namespace, name, err := ParseKey(key)
 	if err != nil {
-		return nil, errors.New("Bad Key for FileSource")
+		return nil, errors.New("Bad Key for FileSource: " + key)
 	}
 	return NewBaseFileSource(namespace, name), nil
 }

--- a/apps/platform/pkg/meta/permissionset.go
+++ b/apps/platform/pkg/meta/permissionset.go
@@ -11,7 +11,7 @@ import (
 func NewPermissionSet(key string) (*PermissionSet, error) {
 	namespace, name, err := ParseKey(key)
 	if err != nil {
-		return nil, errors.New("Bad Key for PermissionSet")
+		return nil, errors.New("Bad Key for PermissionSet: " + key)
 	}
 	return NewBasePermissionSet(namespace, name), nil
 }

--- a/apps/platform/pkg/meta/profile.go
+++ b/apps/platform/pkg/meta/profile.go
@@ -9,7 +9,7 @@ import (
 func NewProfile(key string) (*Profile, error) {
 	namespace, name, err := ParseKey(key)
 	if err != nil {
-		return nil, errors.New("Bad Key for Profile")
+		return nil, errors.New("Bad Key for Profile: " + key)
 	}
 	return NewBaseProfile(namespace, name), nil
 }


### PR DESCRIPTION
# What does this PR do?

1. Adds better error message logging to some metadata constructors. (This is now consistent across all metadata constructors)
2. Adjusts the `datamanager.tsx` to only load the fields that it's actually going to show. It was filtering out LONGTEXT fields in the table columns, but still loading them in the wire. This particular PR is intended to fix an issue with the following scenario:

1. View collection data for a workspace or site.
2. Select the `userfile` collection
3. Verify that the `uesio/core.data` field is NOT loaded.

This was causing performance issues and unnecessary file data downloads to occur when managing the `userfile` collection. (All of the actual file data was being downloaded)

# Testing

Follow steps above and verify `uesio/core.data` is not loaded into the wire.
