### PR TITLE
Feature: Add Get Content Builder API

### DIFF
--- a/libs/apps/uesio/builder/bundle/componentpacks/main/src/api/defapi.ts
+++ b/libs/apps/uesio/builder/bundle/componentpacks/main/src/api/defapi.ts
@@ -365,6 +365,9 @@ const getMetadataId = (path: FullPath) =>
 const useContent = (context: ctx.Context, path: FullPath) =>
   useBuilderExternalState<string>(context, getMetadataId(path))
 
+const getContent = (context: ctx.Context, path: FullPath) =>
+  getBuilderExternalState<string>(context, getMetadataId(path))
+
 const setContent = (context: ctx.Context, path: FullPath, value: string) => {
   setMetadataValue(context, path, parse(value), value)
 }
@@ -483,6 +486,7 @@ export {
   changeKey,
   useContent,
   setContent,
+  getContent,
   useDefinition,
   useHasChanges,
   save,


### PR DESCRIPTION
# What does this PR do?

Small PR to add a `getContent` function to the builder API. This allows us to get the up-to-date contents of a metadata item in the builder. (We will use this for the implementation of the AI view-editor tool.
