### PR TITLE
Refactor: Add ViewDef Id parse function for clarity

### DIFF
--- a/libs/ui/src/bands/route/utils.ts
+++ b/libs/ui/src/bands/route/utils.ts
@@ -22,11 +22,12 @@ import { transformServerWire } from "../wire/transform"
 import { getKey } from "../../metadata/metadata"
 import { ComponentPackState } from "../../definition/componentpack"
 
+const extractViewDefFromViewId = (viewId: string) => viewId.split("(")[0]
 const attachDefToWires = (wires?: ServerWire[], viewdefs?: ViewMetadata[]) => {
   if (!wires || !viewdefs) return [] as PlainWire[]
   return wires.map((wire) => {
-    const viewId = wire.view.split("(")[0]
-    const wireDef = viewdefs.find((viewdef) => getKey(viewdef) === viewId)
+    const viewDefId = extractViewDefFromViewId(wire.view)
+    const wireDef = viewdefs.find((viewdef) => getKey(viewdef) === viewDefId)
       ?.definition.wires?.[wire.name]
     if (!wireDef)
       throw new Error(


### PR DESCRIPTION
# What does this PR do?

This is just a simple PR that names a function and pulls it out of the main area where it's used for clarity. In a followup PR I add some more functionality here. I also rename viewId to viewDefId to be more correct and explicit.

Eventually we'll need to do more checks in this function to verify that it was given a valid viewID.
