### PR TITLE
Refactor: Improve makeViewId function

### DIFF
--- a/libs/ui/src/bands/view/index.ts
+++ b/libs/ui/src/bands/view/index.ts
@@ -1,4 +1,13 @@
-const makeViewId = (viewdef: string, componentId?: string) =>
-  `${viewdef}(${componentId || ""})`
+import { hash } from "@twind/core"
+import { Context } from "../../context/context"
 
+const makeViewId = (
+  context: Context,
+  viewdef: string,
+  componentId?: string,
+  path?: string,
+) => {
+  const mergedComponentId = componentId && context.mergeString(componentId)
+  return `${viewdef}(${mergedComponentId || (path && hash(path)) || "$root"})`
+}
 export { makeViewId }

--- a/libs/ui/src/components/view.tsx
+++ b/libs/ui/src/components/view.tsx
@@ -10,7 +10,6 @@ import { DefinitionMap, UC } from "../definition/definition"
 import PanelArea from "../utilities/panelarea"
 import { COMPONENT_ID } from "../componentexports"
 import { getFullyQualifiedKey } from "../bands/collection/class"
-import { hash } from "@twind/core"
 
 import { FieldValue } from "../bands/wirerecord/types"
 import {
@@ -68,7 +67,12 @@ const ViewArea: UC<ViewComponentDefinition> = ({
   path,
 }) => (
   <>
-    <View context={context} definition={definition} path={path} />
+    <View
+      context={context}
+      definition={definition}
+      path={path}
+      componentType={ViewComponentId}
+    />
     <PanelArea context={context} />
   </>
 )
@@ -80,8 +84,7 @@ const View: UC<ViewComponentDefinition> = (props) => {
   const { params, slots = {}, view: localViewDefId } = definition
   const viewDefId = getFullyQualifiedKey(localViewDefId, context.getNamespace())
 
-  const uesioId = definition[COMPONENT_ID] || (path && hash(path)) || "$root"
-  const viewId = makeViewId(viewDefId, uesioId)
+  const viewId = makeViewId(context, viewDefId, definition[COMPONENT_ID], path)
 
   const isSubView = !!path
 

--- a/libs/ui/src/utilities/route.tsx
+++ b/libs/ui/src/utilities/route.tsx
@@ -120,7 +120,7 @@ const Route: UtilityComponent = (props) => {
     route,
     viewDef: viewId,
     theme,
-    view: makeViewId(viewId, "$root"),
+    view: makeViewId(props.context, viewId),
   })
 
   setupStyles(routeContext)


### PR DESCRIPTION
# What does this PR do?

The makeViewId function is called in the `route.tsx` component and the `view.tsx` component. This refactor improves the function such that the componentId is always merged with the current context and the default is`$root` if no componentId or path is sent in.
