### PR TITLE
fix: do not allow `-` (hypen) in metadataname

### DIFF
--- a/apps/platform/pkg/datasource/fieldvalidations/metadataname.go
+++ b/apps/platform/pkg/datasource/fieldvalidations/metadataname.go
@@ -12,7 +12,7 @@ func validateMetadataName(field *wire.FieldMetadata) ValidationFunc {
 	return func(change *wire.ChangeItem) *exceptions.SaveException {
 		val, err := change.FieldChanges.GetField(field.GetFullName())
 		if err == nil && !meta.IsValidMetadataName(fmt.Sprintf("%v", val)) {
-			return exceptions.NewSaveException(change.RecordKey, field.GetFullName(), "Field: "+field.Label+" failed metadata validation, no capital letters or special characters allowed")
+			return exceptions.NewSaveException(change.RecordKey, field.GetFullName(), "Field: "+field.Label+" failed metadata validation, can only contain lowercase characters a-z, the underscore character and the numerals 0-9")
 		}
 		return nil
 	}

--- a/apps/platform/pkg/meta/bot.go
+++ b/apps/platform/pkg/meta/bot.go
@@ -481,7 +481,7 @@ func ValidateParams(params BotParams, paramValues map[string]interface{}, bundle
 		case "METADATANAME":
 			ok := IsValidMetadataName(fmt.Sprintf("%v", paramValue))
 			if !ok {
-				return exceptions.NewInvalidParamException("param failed metadata validation, no capital letters or special characters allowed", param.Name)
+				return exceptions.NewInvalidParamException("param failed metadata validation, can only contain lowercase characters a-z, the underscore character and the numerals 0-9", param.Name)
 			}
 		}
 	}

--- a/apps/platform/pkg/meta/metadata.go
+++ b/apps/platform/pkg/meta/metadata.go
@@ -423,7 +423,8 @@ func Copy(to, from interface{}) error {
 	return reprint.FromTo(from, to)
 }
 
-var validMetaRegex, _ = regexp.Compile("^[a-z0-9_-]+$")
+// Keep in sync with serve.go getNSParam, etc.
+var validMetaRegex, _ = regexp.Compile("^[a-z0-9_]+$")
 
 func IsValidMetadataName(name string) bool {
 	return validMetaRegex.MatchString(name)

--- a/apps/platform/pkg/meta/yamlnodeutils.go
+++ b/apps/platform/pkg/meta/yamlnodeutils.go
@@ -184,7 +184,7 @@ func validateMetadataName(name string, expectedName string) error {
 		return exceptions.NewBadRequestException(fmt.Sprintf("Metadata name does not match filename: %s, %s", name, expectedName))
 	}
 	if !IsValidMetadataName(name) {
-		return exceptions.NewBadRequestException(fmt.Sprintf("Failed metadata validation, no capital letters or special characters allowed: %s", name))
+		return exceptions.NewBadRequestException(fmt.Sprintf("Failed metadata validation, can only contain lowercase characters a-z, the underscore character and the numerals 0-9: %s", name))
 	}
 	return nil
 }

--- a/libs/apps/uesio/studio/bundle/components/section_app_name_desc.yaml
+++ b/libs/apps/uesio/studio/bundle/components/section_app_name_desc.yaml
@@ -18,7 +18,7 @@ definition:
                   uesio.id: new-app-description
             note:
               - uesio/appkit.note:
-                  text: "Note: Your app name can only contain lowercase characters a-z, the underscore character and the numerals 0-9. The app description is optional."                                             
+                  text: "Note: Your app name can only contain lowercase characters a-z, the underscore character and the numerals 0-9. The app description is optional."
 title: App Name and Description
 discoverable: false
 description: App Name and Description

--- a/libs/apps/uesio/studio/bundle/components/section_app_name_desc.yaml
+++ b/libs/apps/uesio/studio/bundle/components/section_app_name_desc.yaml
@@ -18,7 +18,7 @@ definition:
                   uesio.id: new-app-description
             note:
               - uesio/appkit.note:
-                  text: "Note: Your app name must contain only lowercase characters a-z, the underscore character, or the numerals 0-9. The app description is optional."
+                  text: "Note: Your app name can only contain lowercase characters a-z, the underscore character and the numerals 0-9. The app description is optional."                                             
 title: App Name and Description
 discoverable: false
 description: App Name and Description


### PR DESCRIPTION
# What does this PR do?

Retricts metadataname to be lower case letter, digit or underscore (previously would allow a hypen `-`).

Closes #4720 

# Testing

Manual testing confirms.
