### PR TITLE
fix: add missing getHostUrl to ListenerBotApi types

### DIFF
--- a/apps/platform-integration-tests/generated/@types/@uesio/index.d.ts
+++ b/apps/platform-integration-tests/generated/@types/@uesio/index.d.ts
@@ -220,6 +220,7 @@ interface ListenerBotApi<T = Record<string, BotParamValue>> {
   getNamespace: () => string
   // Returns the name of the Bot, e.g "add_numbers"
   getName: () => string
+  getHostUrl: () => string
   copyFile: (
     sourceFileKey: string,
     sourcePath: string,

--- a/libs/ui/src/public_types/server/index.d.ts
+++ b/libs/ui/src/public_types/server/index.d.ts
@@ -219,6 +219,7 @@ interface ListenerBotApi<T = Record<string, BotParamValue>> {
   getNamespace: () => string
   // Returns the name of the Bot, e.g "add_numbers"
   getName: () => string
+  getHostUrl: () => string  
   copyFile: (
     sourceFileKey: string,
     sourcePath: string,

--- a/libs/ui/src/public_types/server/index.d.ts
+++ b/libs/ui/src/public_types/server/index.d.ts
@@ -219,7 +219,7 @@ interface ListenerBotApi<T = Record<string, BotParamValue>> {
   getNamespace: () => string
   // Returns the name of the Bot, e.g "add_numbers"
   getName: () => string
-  getHostUrl: () => string  
+  getHostUrl: () => string
   copyFile: (
     sourceFileKey: string,
     sourcePath: string,


### PR DESCRIPTION
# What does this PR do?

Adds missing `getHostUrl` func to ListenerBotApi type

# Testing

types only, ci will cover.
