### PR TITLE
feat: support integration site merges

### DIFF
--- a/apps/platform-integration-tests/bundle/integrations/oauth2_authorization_code_1.yaml
+++ b/apps/platform-integration-tests/bundle/integrations/oauth2_authorization_code_1.yaml
@@ -2,4 +2,4 @@ name: oauth2_authorization_code_1
 type: studio_apis_custom
 authentication: OAUTH2_AUTHORIZATION_CODE
 credentials: test_oauth_credentials
-baseUrl: https://studio.uesio-dev.com:3000
+baseUrl: https://studio.$Site{domain}

--- a/apps/platform-integration-tests/bundle/integrations/oauth2_authorization_code_2.yaml
+++ b/apps/platform-integration-tests/bundle/integrations/oauth2_authorization_code_2.yaml
@@ -2,4 +2,4 @@ name: oauth2_authorization_code_2
 type: studio_apis_custom
 authentication: OAUTH2_AUTHORIZATION_CODE
 credentials: test_oauth_credentials
-baseUrl: https://studio.uesio-dev.com:3000
+baseUrl: https://studio.$Site{domain}

--- a/apps/platform-integration-tests/bundle/integrations/secret_access_allowed.yaml
+++ b/apps/platform-integration-tests/bundle/integrations/secret_access_allowed.yaml
@@ -1,4 +1,4 @@
 name: secret_access_allowed
 type: studio_apis_custom
 credentials: secret_access_allowed
-baseUrl: https://studio.uesio-dev.com:3000
+baseUrl: https://studio.$Site{domain}

--- a/apps/platform-integration-tests/bundle/integrations/secret_access_forbidden.yaml
+++ b/apps/platform-integration-tests/bundle/integrations/secret_access_forbidden.yaml
@@ -1,4 +1,4 @@
 name: secret_access_forbidden
 type: studio_apis_custom
 credentials: secret_access_forbidden
-baseUrl: https://studio.uesio-dev.com:3000
+baseUrl: https://studio.$Site{domain}

--- a/apps/platform-integration-tests/bundle/integrations/studio_apis.yaml
+++ b/apps/platform-integration-tests/bundle/integrations/studio_apis.yaml
@@ -1,3 +1,3 @@
 name: studio_apis
 type: studio_apis_custom
-baseUrl: https://studio.uesio-dev.com:3000
+baseUrl: https://studio.$Site{domain}

--- a/apps/platform-integration-tests/bundle/integrations/test_api_key.yaml
+++ b/apps/platform-integration-tests/bundle/integrations/test_api_key.yaml
@@ -2,4 +2,4 @@ name: test_api_key
 type: api_key_tester
 authentication: API_KEY
 credentials: test_api_key_credentials
-baseUrl: https://studio.uesio-dev.com:3000
+baseUrl: https://studio.$Site{domain}

--- a/apps/platform-integration-tests/bundle/integrations/weather_api.yaml
+++ b/apps/platform-integration-tests/bundle/integrations/weather_api.yaml
@@ -1,3 +1,3 @@
 name: weather_api
 type: weather_api
-baseUrl: https://studio.uesio-dev.com:3000
+baseUrl: https://studio.$Site{domain}

--- a/apps/platform/pkg/bot/jsdialect/integrationmetadata.go
+++ b/apps/platform/pkg/bot/jsdialect/integrationmetadata.go
@@ -1,9 +1,14 @@
 package jsdialect
 
-import "github.com/thecloudmasters/uesio/pkg/meta"
+import (
+	botutils "github.com/thecloudmasters/uesio/pkg/bot/utils"
+	"github.com/thecloudmasters/uesio/pkg/types/wire"
+)
 
-type IntegrationMetadata meta.Integration
+type IntegrationMetadata struct {
+	connection *wire.IntegrationConnection
+}
 
-func (im *IntegrationMetadata) GetBaseURL() string {
-	return im.BaseURL
+func (im *IntegrationMetadata) GetBaseURL() (string, error) {
+	return botutils.GetBaseURL(im.connection, im.connection.GetSession())
 }

--- a/apps/platform/pkg/bot/jsdialect/loadbot.go
+++ b/apps/platform/pkg/bot/jsdialect/loadbot.go
@@ -113,7 +113,9 @@ func (lb *LoadBotAPI) GetIntegration() *IntegrationMetadata {
 	if lb.integrationConnection == nil || lb.integrationConnection.GetIntegration() == nil {
 		return nil
 	}
-	return (*IntegrationMetadata)(lb.integrationConnection.GetIntegration())
+	return &IntegrationMetadata{
+		connection: lb.integrationConnection,
+	}
 }
 
 func (lb *LoadBotAPI) GetConfigValue(configValueKey string) (string, error) {

--- a/apps/platform/pkg/bot/jsdialect/runintegrationactionbot.go
+++ b/apps/platform/pkg/bot/jsdialect/runintegrationactionbot.go
@@ -57,7 +57,9 @@ func (b *RunIntegrationActionBotAPI) GetIntegration() *IntegrationMetadata {
 	if b.integrationConnection == nil || b.integrationConnection.GetIntegration() == nil {
 		return nil
 	}
-	return (*IntegrationMetadata)(b.integrationConnection.GetIntegration())
+	return &IntegrationMetadata{
+		connection: b.integrationConnection,
+	}
 }
 
 func (b *RunIntegrationActionBotAPI) GetSession() *SessionAPI {

--- a/apps/platform/pkg/bot/jsdialect/savebot.go
+++ b/apps/platform/pkg/bot/jsdialect/savebot.go
@@ -75,7 +75,9 @@ func (sba *SaveBotAPI) GetIntegration() *IntegrationMetadata {
 	if sba.integrationConnection == nil || sba.integrationConnection.GetIntegration() == nil {
 		return nil
 	}
-	return (*IntegrationMetadata)(sba.integrationConnection.GetIntegration())
+	return &IntegrationMetadata{
+		connection: sba.integrationConnection,
+	}
 }
 func (sb *SaveBotAPI) GetCollectionMetadata(collectionKey string) (*BotCollectionMetadata, error) {
 	metadata, err := sb.saveOp.GetMetadata()

--- a/apps/platform/pkg/bot/systemdialect/systembot_load_external.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_load_external.go
@@ -1,17 +1,15 @@
 package systemdialect
 
 import (
-	"errors"
 	"fmt"
 	"net/url"
 
 	"github.com/thecloudmasters/uesio/pkg/auth"
 	"github.com/thecloudmasters/uesio/pkg/bot/jsdialect"
+	botutils "github.com/thecloudmasters/uesio/pkg/bot/utils"
 	"github.com/thecloudmasters/uesio/pkg/datasource"
-	"github.com/thecloudmasters/uesio/pkg/merge"
 	"github.com/thecloudmasters/uesio/pkg/meta"
 	"github.com/thecloudmasters/uesio/pkg/sess"
-	"github.com/thecloudmasters/uesio/pkg/templating"
 	"github.com/thecloudmasters/uesio/pkg/types/wire"
 )
 
@@ -30,7 +28,7 @@ func differentHostLoad(op *wire.LoadOp, session *sess.Session) error {
 		return err
 	}
 
-	baseUrl, err := getBaseUrl(integrationConnection, session)
+	baseUrl, err := botutils.GetBaseURL(integrationConnection, session)
 	if err != nil {
 		return err
 	}
@@ -208,29 +206,13 @@ func sameHostLoad(op *wire.LoadOp, connection wire.Connection, site *meta.Site, 
 
 }
 
-func getBaseUrl(integrationConnection *wire.IntegrationConnection, session *sess.Session) (string, error) {
-	integration := integrationConnection.GetIntegration()
-	if integration == nil {
-		return "", errors.New("not integration provided by integration connection")
-	}
-	template, err := templating.NewWithFuncs(integration.BaseURL, templating.ForceErrorFunc, merge.ServerMergeFuncs)
-	if err != nil {
-		return "", err
-	}
-
-	return templating.Execute(template, merge.ServerMergeData{
-		Session: session,
-	})
-
-}
-
 func runUesioExternalLoadBot(op *wire.LoadOp, connection wire.Connection, session *sess.Session) error {
 	integrationConnection, err := op.GetIntegrationConnection()
 	if err != nil {
 		return err
 	}
 
-	baseUrl, err := getBaseUrl(integrationConnection, session)
+	baseUrl, err := botutils.GetBaseURL(integrationConnection, session)
 	if err != nil {
 		return err
 	}

--- a/apps/platform/pkg/bot/utils/mergeutils.go
+++ b/apps/platform/pkg/bot/utils/mergeutils.go
@@ -1,0 +1,39 @@
+package botutils
+
+import (
+	"errors"
+
+	"github.com/thecloudmasters/uesio/pkg/merge"
+	"github.com/thecloudmasters/uesio/pkg/sess"
+	"github.com/thecloudmasters/uesio/pkg/templating"
+	"github.com/thecloudmasters/uesio/pkg/types/wire"
+)
+
+// TODO: The prior version of this lived in systembot_load_external.go and only applied to system bots with external.
+// This makes it a utility function that can be used regardless of dialect.  To maintain full backwards compat,
+// accepting IntegrationConnection and separate Session since that is the way that it worked previously but
+// IntegrationConnection has the session on it so possibly could just reduce to a single param.  Unclear
+// if it's possible for the session passed to a "loadbotfunc" could ever be different than the one associated
+// with the IntegrationConnection available vai op.GetIntegration().  Depending on that answer, reduce
+// this to a single param or leave as-is.
+func GetBaseURL(integrationConnection *wire.IntegrationConnection, session *sess.Session) (string, error) {
+	integration := integrationConnection.GetIntegration()
+	if integration == nil {
+		return "", errors.New("not integration provided by integration connection")
+	}
+
+	return processMerge(integration.BaseURL, session)
+}
+
+func processMerge(templateString string, session *sess.Session) (string, error) {
+	template, err := templating.NewWithFuncs(templateString, templating.ForceErrorFunc, merge.ServerMergeFuncs)
+	if err != nil {
+		return "", err
+	}
+
+	x, err := templating.Execute(template, merge.ServerMergeData{
+		Session: session,
+	})
+	return x, err
+
+}


### PR DESCRIPTION
# What does this PR do?

Adds support for `$Site` merges on GetBaseURL to integration bots.  Previously, $Site was only supported in systemdialect bots.

Note - One other non-breaking change is that the previous code was intending to "hide/abstract" the `Integration` type from non-system dialects via IntegrationMetadata using a type declaration.  This was hiding/abstracting `Integration` but not the embedded types in `Integration` (e.g., BuitlIn, BundleBase, etc.).  This PR avoids type embedding for `IntegrationMetadata` ensuring that only what we want to expose is exposed.

# Testing

ci & e2e will cover.
