### PR TITLE
chore: include .DS_Store in default generated gitignore

### DIFF
--- a/libs/apps/uesio/core/bundle/bots/generator/init/templates/template.gitignore
+++ b/libs/apps/uesio/core/bundle/bots/generator/init/templates/template.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 .uesio
 node_modules/
 bundle/componentpacks/*/dist/


### PR DESCRIPTION
# What does this PR do?

Adds `.DS_Store` to generated `.gitignore`

# Testing

Manual testing confirms its included :)
