### PR TITLE
chore: remove collection load workaround

### DIFF
--- a/apps/platform/pkg/bot/systemdialect/systembot_load_external.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_load_external.go
@@ -242,11 +242,6 @@ func runUesioExternalLoadBot(op *wire.LoadOp, connection wire.Connection, sessio
 
 	site, err := auth.GetSiteFromHost(parsedBaseUrl.Host)
 	if err != nil {
-		// This is a hack to prevent the page from bombing if we don't have a site for these collections.
-		// We can remove this once we have better error handling for individual wires in a route dependencies load.
-		if op.CollectionName == "uesio/studio.blogentry" || op.CollectionName == "uesio/studio.recentdoc" {
-			return nil
-		}
 		return differentHostLoad(op, session)
 	}
 


### PR DESCRIPTION
# What does this PR do?

Removes the workaround for site collection loads that existed in studio now that #4576 has been implemented.  Note that #4576 does surface an error on the collection wire in the redux store but the error message itself is not surfaced to the page or component yet for display.

# Testing

manual testing to ensure page loads when collections do not exist and that error message is in the redux store.
