### PR TITLE
chore: use jsx automatic transform

### DIFF
--- a/apps/cli/pkg/command/pack.go
+++ b/apps/cli/pkg/command/pack.go
@@ -64,16 +64,25 @@ func Pack(options *PackOptions) error {
 	for packName, entryPoint := range entryPoints {
 
 		buildOptions := &api.BuildOptions{
-			EntryPoints:       []string{entryPoint},
-			Bundle:            true,
-			Format:            api.FormatESModule,
-			Outdir:            "bundle/componentpacks",
-			Outbase:           "bundle/componentpacks",
-			AllowOverwrite:    true,
-			External:          pack.GetGlobalsList(globalsMap),
-			Write:             true,
-			Plugins:           []api.Plugin{pack.GetGlobalsPlugin(globalsMap)},
+			EntryPoints:    []string{entryPoint},
+			Bundle:         true,
+			Format:         api.FormatESModule,
+			Outdir:         "bundle/componentpacks",
+			Outbase:        "bundle/componentpacks",
+			AllowOverwrite: true,
+			External:       pack.GetGlobalsList(globalsMap),
+			Write:          true,
+			Plugins:        []api.Plugin{pack.GetGlobalsPlugin(globalsMap)},
+			// TODO: tsconfigRaw will override use of tsconfig.json.  For backwards compat, leaving this as-is for now
+			// but this should likely change to using tsconfig.json here or explicitly providing a configuration
+			// to esbuild.  This configuration matches what is done in ui/build.mjs so that the ui package
+			// and component packs are built with identical configuration.  Since pack is used by outside developers
+			// to build their packs, there is something to be said for controlling tsconfig options for all component
+			// packs.  As we potentially move to component development in studio, building packs will likely be
+			// done on the server so having all packs built by server makes some sense.  Prior to changing the approach
+			// on tsconfigRaw, a long term plan/solution should be considered.
 			TsconfigRaw:       "{}",
+			JSX:               api.JSXAutomatic,
 			MinifyWhitespace:  minify,
 			MinifyIdentifiers: minify,
 			MinifySyntax:      minify,

--- a/libs/ui/build.mjs
+++ b/libs/ui/build.mjs
@@ -12,7 +12,16 @@ const result = await esbuild.build({
   outfile: "../../dist/ui/uesio.js",
   allowOverwrite: true,
   write: true,
+  // TODO: tsconfigRaw will override use of tsconfig.json.  For backwards compat, leaving this as-is for now
+  // but this should likely change to using tsconfig.lib.json here or explicitly providing a configuration
+  // to esbuild.  This configuration matches what is done in pack.go BuildOptions so that the ui package
+  // and component packs are built with identical configuration.  Since pack is used by outside developers
+  // to build their packs, there is something to be said for controlling tsconfig options for all component
+  // packs.  As we potentially move to component development in studio, building packs will likely be
+  // done on the server so having all packs built by server makes some sense.  Prior to changing the approach
+  // on tsconfigRaw, a long term plan/solution should be considered.
   tsconfigRaw: {},
+  jsx: "automatic",
   minify: !isDev,
   format: "esm",
   logLevel: isDev ? "debug" : "warning", // defaults to "warning" if not set https://esbuild.github.io/api/#log-level


### PR DESCRIPTION
# What does this PR do?

Configures esbuild (used in cli `pack` command and in `ui/build.mjs`) to apply `react-jsx` transform.

With the recent changes to react 19, building esm format, etc. this is the next step in updating all the build configurations.  There is still some work to decide/update on tsconfig settings themselves but this change ensures we are using the recommended/most recent transforms for React code.

# Testing

Manually tested including a custom component pack, ci & e2e will cover rest.
