### PR TITLE
chore: update to hurl 6.1.1

### DIFF
--- a/apps/platform-integration-tests/hurl_fields/user.hurl
+++ b/apps/platform-integration-tests/hurl_fields/user.hurl
@@ -175,16 +175,6 @@ jsonpath "$.wires[0].data[*]['uesio/tests.name']" contains "ID-001"
 
 # Operator: NOT_EQ | valueSource: VALUE | ID011-UUID
 # entry 7
-#
-# NOTE: I had to add the IS_NOT_BLANK condition here because of a weird
-# bug in hurl 4.0.0. The jsonpath is not working correctly if the result
-# has some null values in it.
-# "$.wires[0].data[*]['uesio/tests.user']['uesio/core.id']" strangely returns
-# no data if I select some records without a user.
-# Hopefully this will get fixed in hurl and we'll be able to remove the condition
-# TODO: Update 2025.03.17 - This is still an issue in hurl 6.1.0
-# See https://github.com/Orange-OpenSource/hurl/issues/3869
-
 POST https://{{host}}:{{port}}/workspace/uesio/tests/dev/wires/load
 {
    "wires":[
@@ -197,10 +187,6 @@ POST https://{{host}}:{{port}}/workspace/uesio/tests/dev/wires/load
                "operator":"NOT_EQ",
                "valueSource":"VALUE",
                "value": "{{ID011-UUID}}"
-            },
-            {
-               "field":"uesio/tests.user",
-               "operator":"IS_NOT_BLANK"
             }
          ],
          "query":true
@@ -216,16 +202,6 @@ jsonpath "$.wires[0].data[*]['uesio/tests.user']['uesio/core.id']" not contains 
 
 # Operator: NOT_EQ | valueSource: VALUE | ID011-UUID
 # entry 8
-#
-# NOTE: I had to add the IS_NOT_BLANK condition here because of a weird
-# bug in hurl 4.0.0. The jsonpath is not working correctly if the result
-# has some null values in it.
-# "$.wires[0].data[*]['uesio/tests.user']['uesio/core.id']" strangely returns
-# no data if I select some records without a user.
-# Hopefully this will get fixed in hurl and we'll be able to remove the condition
-# TODO: Update 2025.03.17 - This is still an issue in hurl 6.1.0
-# See https://github.com/Orange-OpenSource/hurl/issues/3869
-
 POST https://{{host}}:{{port}}/workspace/uesio/tests/dev/wires/load
 {
    "wires":[
@@ -239,10 +215,6 @@ POST https://{{host}}:{{port}}/workspace/uesio/tests/dev/wires/load
                "operator":"NOT_EQ",
                "valueSource":"PARAM",
                "param": "ID-011"
-            },
-            {
-               "field":"uesio/tests.user",
-               "operator":"IS_NOT_BLANK"
             }
          ],
          "query":true
@@ -531,7 +503,7 @@ Accept: application/json
 HTTP 200
 [Asserts]
 jsonpath "$.wires[0].data[*]['uesio/tests.user']" contains null
-jsonpath "$.wires[0].data[*]['uesio/tests.user']['uesio/core.id']" not exists
+jsonpath "$.wires[0].data[*]['uesio/tests.user']['uesio/core.id']" isEmpty
 
 # Operator: IS_NOT_BLANK
 # entry 16

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@nx/js": "20.6.2",
         "@nx/react": "20.6.2",
         "@nx/workspace": "20.6.2",
-        "@orangeopensource/hurl": "^6.1.0",
+        "@orangeopensource/hurl": "^6.1.1",
         "@react-hook/resize-observer": "^2.0.2",
         "@reduxjs/toolkit": "^2.6.1",
         "@swc-node/register": "^1.10.10",
@@ -4848,9 +4848,9 @@
       }
     },
     "node_modules/@orangeopensource/hurl": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@orangeopensource/hurl/-/hurl-6.1.0.tgz",
-      "integrity": "sha512-l8cmUWmGZbZ8ztmtFE8jZ6PvmDxgHxIgwzrDArWOxow9ZV5MRJRNHiFQ37CAj02nmrOFHlF7HeD+hjdKMdTHvg==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@orangeopensource/hurl/-/hurl-6.1.1.tgz",
+      "integrity": "sha512-T1wSFAX+/4SfuUprZSlFex8mcmlHbpqf/k5O/E20Nuns9iCA5pOAerY7+OauAos9jDmtFJMf364ZpMfo8xV3JQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@nx/js": "20.6.2",
     "@nx/react": "20.6.2",
     "@nx/workspace": "20.6.2",
-    "@orangeopensource/hurl": "^6.1.0",
+    "@orangeopensource/hurl": "^6.1.1",
     "@react-hook/resize-observer": "^2.0.2",
     "@reduxjs/toolkit": "^2.6.1",
     "@swc-node/register": "^1.10.10",


### PR DESCRIPTION
# What does this PR do?

Updates to hurl 6.1.1 and eliminates the workaround for https://github.com/Orange-OpenSource/hurl/issues/3869

# Testing

ci & e2e will cover.
