### PR TITLE
chore: move create app buttons to bottom of page

### DIFF
--- a/libs/apps/uesio/appkit/bundle/components/form_new.yaml
+++ b/libs/apps/uesio/appkit/bundle/components/form_new.yaml
@@ -48,6 +48,9 @@ definition:
                         hotkey: "meta+s"
                         uesio.variant: uesio/appkit.primary
                     - uesio/io.button:
+                        uesio.display:
+                          - type: hasNoValue
+                            value: $Prop{hideResetButton}
                         signals:
                           - signal: wire/RESET
                             wire: $Prop{wire}
@@ -57,7 +60,16 @@ definition:
 title: New Record Form
 discoverable: true
 description: A component for a record create form.
+properties:
+  - name: hideNewButton
+    label: Hide New Button
+    type: CHECKBOX
+  - name: hideResetButton
+    label: Hide Reset Button
+    type: CHECKBOX
 sections:
   - type: HOME
     properties:
+      - hideNewButton
+      - hideResetButton
   - type: DISPLAY

--- a/libs/apps/uesio/studio/bundle/views/app_new.yaml
+++ b/libs/apps/uesio/studio/bundle/views/app_new.yaml
@@ -71,19 +71,24 @@ definition:
                     avataricon: web
                     subtitle: ${uesio/studio.user->uniquekey}/${uesio/studio.name}
                     hideNewButton: true
-                    extra_actions:
-                      - uesio/io.button:
-                          text: Create $Collection{label}
-                          hotkey: "meta+s"
-                          uesio.variant: uesio/appkit.primary
-                          uesio.id: save-new-app
-                          pendingText: "Creating App ..."
-                          signals:
-                            - signal: wire/SAVE
-                              wires:
-                                - app
-                            - signal: "route/NAVIGATE"
-                              path: app/${uesio/core.uniquekey}
+                    # TODO: Temporary solution for ensuring that user views all options on create app
+                    # page until the UX can be improved via a wizard component that requires development.
+                    # Hiding the New and Reset button and adding buttons to the bottom of the page.
+                    # see https://github.com/ues-io/uesio/issues/4695
+                    hideResetButton: true
+                    # extra_actions:
+                    #   - uesio/io.button:
+                    #       text: Create $Collection{label}
+                    #       hotkey: "meta+s"
+                    #       uesio.variant: uesio/appkit.primary
+                    #       uesio.id: save-new-app
+                    #       pendingText: "Creating App ..."
+                    #       signals:
+                    #         - signal: wire/SAVE
+                    #           wires:
+                    #             - app
+                    #         - signal: "route/NAVIGATE"
+                    #           path: app/${uesio/core.uniquekey}
                     content:
                       - uesio/studio.section_app_name_desc:
                       - uesio/studio.section_app_owner:
@@ -156,3 +161,30 @@ definition:
                                         - uesio/studio.generatorstarter:
                                             appWire: app
                                             starterTemplate: ${uesio/studio.starter_template}
+
+                      - uesio/io.box:
+                          uesio.variant: uesio/appkit.section
+                          uesio.styleTokens:
+                            root:
+                              - flex
+                              - justify-end
+                              - gap-2
+                          components:
+                            - uesio/io.button:
+                                text: Create $Collection{label}
+                                hotkey: "meta+s"
+                                uesio.variant: uesio/appkit.primary
+                                uesio.id: save-new-app
+                                pendingText: "Creating App ..."
+                                signals:
+                                  - signal: wire/SAVE
+                                    wires:
+                                      - app
+                                  - signal: "route/NAVIGATE"
+                                    path: app/${uesio/core.uniquekey}
+                            - uesio/io.button:
+                                signals:
+                                  - signal: wire/RESET
+                                    wire: app
+                                text: Start Over
+                                uesio.variant: uesio/appkit.secondary


### PR DESCRIPTION
# What does this PR do?

Moves the "Create App/Start Over" buttons to the bottom of the "Create App" page.

This is a temporary solution as mentioned in #4695 to ensure that the user reviews all options in "Create App" prior to creating the app.  The overall UX of this page still needs to be improved via a "wizard" type component (or some other UX solution).

This is only meant to be temporary since it deviates from other pages that have buttons at the top.

Closes #4695 

# Testing

Manual testing confirms expected behavior.
