### PR TITLE
fix: add message id to claude messages

### DIFF
--- a/apps/platform/pkg/integ/bedrock/claude.go
+++ b/apps/platform/pkg/integ/bedrock/claude.go
@@ -16,6 +16,7 @@ type MessagesContent struct {
 	Type  string         `json:"type" bot:"type,omitempty"`
 	Text  string         `json:"text,omitempty" bot:"text,omitempty"`
 	Name  string         `json:"name,omitempty" bot:"name,omitempty"`
+	ID    string         `json:"id,omitempty" bot:"id,omitempty"`
 	Input map[string]any `json:"input,omitempty" bot:"input,omitempty"`
 }
 


### PR DESCRIPTION
# What does this PR do?

Tool use messages in claude return an id property. It should be in our struct.