### PR TITLE
fix: typo in removeViewFrame function

### DIFF
--- a/libs/ui/src/context/context.ts
+++ b/libs/ui/src/context/context.ts
@@ -377,7 +377,7 @@ class Context {
     if (index === -1) {
       return this.clone([])
     }
-    return this.clone(this.stack.slice(index + 1)).removeRecordFrame(times - 1)
+    return this.clone(this.stack.slice(index + 1)).removeViewFrame(times - 1)
   }
 
   removeAllPropsFrames = (): Context =>


### PR DESCRIPTION
# What does this PR do?

Fixes a bug where removeViewFrame worked incorrectly for `times > 1`.