### PR TITLE
chore: assert on explicit values in tests

### DIFF
--- a/apps/platform-e2e/cypress/e2e/smoke.cy.ts
+++ b/apps/platform-e2e/cypress/e2e/smoke.cy.ts
@@ -10,8 +10,7 @@ describe("Uesio Sanity Smoke Tests", () => {
   const namespace = getAppNamespace(appName)
   const workspaceName = "test"
   const workspaceBasePath = getWorkspaceBasePath(appName, workspaceName)
-  const NUM_COMMON_FIELDS = 8
-
+  
   // This test is too flaky to be run in CI
   // TODO: Investigate why this doesn't work well in CI
   if (Cypress.env("in_ci")) {
@@ -155,7 +154,10 @@ describe("Uesio Sanity Smoke Tests", () => {
       // Initially there should be no fields
       cy.get('table[id$="commonFields"]>tbody')
         .children("tr")
-        .should("have.length", NUM_COMMON_FIELDS)
+        // TODO: Unclear why this assert exists as its fragile and likely does not help in any way since underlying
+        // data can change across the test suite.  Evaluate this tests purpose and adjust the assert to be
+        // explicit/more meaningful, for example assert that the specific fields we expect to be there are there.      
+        .should("have.length", 8)
     })
   })
 

--- a/apps/platform-e2e/cypress/e2e/smoke.cy.ts
+++ b/apps/platform-e2e/cypress/e2e/smoke.cy.ts
@@ -10,7 +10,7 @@ describe("Uesio Sanity Smoke Tests", () => {
   const namespace = getAppNamespace(appName)
   const workspaceName = "test"
   const workspaceBasePath = getWorkspaceBasePath(appName, workspaceName)
-  
+
   // This test is too flaky to be run in CI
   // TODO: Investigate why this doesn't work well in CI
   if (Cypress.env("in_ci")) {
@@ -156,7 +156,7 @@ describe("Uesio Sanity Smoke Tests", () => {
         .children("tr")
         // TODO: Unclear why this assert exists as its fragile and likely does not help in any way since underlying
         // data can change across the test suite.  Evaluate this tests purpose and adjust the assert to be
-        // explicit/more meaningful, for example assert that the specific fields we expect to be there are there.      
+        // explicit/more meaningful, for example assert that the specific fields we expect to be there are there.
         .should("have.length", 8)
     })
   })

--- a/apps/platform-integration-tests/hurl_specs/allmetadata.hurl
+++ b/apps/platform-integration-tests/hurl_specs/allmetadata.hurl
@@ -169,7 +169,11 @@ Accept: application/json
 }
 HTTP 200
 [Asserts]
-jsonpath "$.wires[0].data" count == {{num_common_fields}}
+# this number should be the number of common fields
+# TODO: Unclear why this assert exists as its fragile and likely does not help in any way since underlying
+# data can change across the test suite.  Evaluate this tests purpose and adjust the assert to be
+# explicit/more meaningful. 
+jsonpath "$.wires[0].data" count == 8
 jsonpath "$.wires[0].data[0]['uesio/core.uniquekey']" == "uesio/tests.animal:uesio/core.collection"
 jsonpath "$.wires[0].data[1]['uesio/core.uniquekey']" == "uesio/tests.animal:uesio/core.createdat"
 jsonpath "$.wires[0].data[2]['uesio/core.uniquekey']" == "uesio/tests.animal:uesio/core.createdby"

--- a/apps/platform-integration-tests/hurl_specs/metadata_list_siteadmin_context.hurl
+++ b/apps/platform-integration-tests/hurl_specs/metadata_list_siteadmin_context.hurl
@@ -25,7 +25,11 @@ GET {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/siteadmin/ues
 Accept: application/json
 HTTP 200
 [Asserts]
-jsonpath "$[*]" count == {{num_core_and_tests_collections}}
+# this number should be the sum of the number of collections in core, tests, aikit & appkit
+# TODO: Unclear why this assert exists as its fragile and likely does not help in any way since underlying
+# data can change across the test suite.  Evaluate this tests purpose and adjust the assert to be
+# explicit/more meaningful or remove.
+jsonpath "$[*]" count == 28
 # Spot check a uesio/tests collection
 jsonpath "$['uesio/tests.animal'].key" == "uesio/tests.animal"
 jsonpath "$['uesio/tests.animal'].namespace" == "uesio/tests"
@@ -39,7 +43,11 @@ GET {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/siteadmin/ues
 Accept: application/json
 HTTP 200
 [Asserts]
-jsonpath "$[*]" count == {{num_tests_collections}}
+# this number should be the number of collections in tests
+# TODO: Unclear why this assert exists as its fragile and likely does not help in any way since underlying
+# data can change across the test suite.  Evaluate this tests purpose and adjust the assert to be
+# explicit/more meaningful or remove.
+jsonpath "$[*]" count == 11
 # Spot check a uesio/tests collection
 jsonpath "$['uesio/tests.animal'].key" == "uesio/tests.animal"
 jsonpath "$['uesio/tests.animal'].namespace" == "uesio/tests"
@@ -49,7 +57,11 @@ GET {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/siteadmin/ues
 Accept: application/json
 HTTP 200
 [Asserts]
-jsonpath "$[*]" count == {{num_public_core_collections}}
+# this number should be the number of collections in core
+# TODO: Unclear why this assert exists as its fragile and likely does not help in any way since underlying
+# data can change across the test suite.  Evaluate this tests purpose and adjust the assert to be
+# explicit/more meaningful or remove.
+jsonpath "$[*]" count == 14
 # Spot check a uesio/core collection
 jsonpath "$['uesio/core.user'].key" == "uesio/core.user"
 jsonpath "$['uesio/core.user'].namespace" == "uesio/core"

--- a/apps/platform-integration-tests/hurl_specs/metadata_list_version_context.hurl
+++ b/apps/platform-integration-tests/hurl_specs/metadata_list_version_context.hurl
@@ -25,7 +25,11 @@ GET {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/version/uesio
 Accept: application/json
 HTTP 200
 [Asserts]
-jsonpath "$[*]" count == {{num_core_and_tests_collections}}
+# this number should be the sum of the number of collections in core, tests, aikit & appkit
+# TODO: Unclear why this assert exists as its fragile and likely does not help in any way since underlying
+# data can change across the test suite.  Evaluate this tests purpose and adjust the assert to be
+# explicit/more meaningful or remove.
+jsonpath "$[*]" count == 28
 # Spot check a uesio/tests collection
 jsonpath "$['uesio/tests.animal'].key" == "uesio/tests.animal"
 jsonpath "$['uesio/tests.animal'].namespace" == "uesio/tests"
@@ -39,7 +43,11 @@ GET {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/version/uesio
 Accept: application/json
 HTTP 200
 [Asserts]
-jsonpath "$[*]" count == {{num_tests_collections}}
+# this number should be the number of collections in tests
+# TODO: Unclear why this assert exists as its fragile and likely does not help in any way since underlying
+# data can change across the test suite.  Evaluate this tests purpose and adjust the assert to be
+# explicit/more meaningful or remove.
+jsonpath "$[*]" count == 11
 # Spot check a uesio/tests collection
 jsonpath "$['uesio/tests.animal'].key" == "uesio/tests.animal"
 jsonpath "$['uesio/tests.animal'].namespace" == "uesio/tests"
@@ -49,7 +57,11 @@ GET {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/version/uesio
 Accept: application/json
 HTTP 200
 [Asserts]
-jsonpath "$[*]" count == {{num_public_core_collections}}
+# this number should be the number of collections in core
+# TODO: Unclear why this assert exists as its fragile and likely does not help in any way since underlying
+# data can change across the test suite.  Evaluate this tests purpose and adjust the assert to be
+# explicit/more meaningful or remove.
+jsonpath "$[*]" count == 14
 # Spot check a uesio/core collection
 jsonpath "$['uesio/core.user'].key" == "uesio/core.user"
 jsonpath "$['uesio/core.user'].namespace" == "uesio/core"

--- a/apps/platform-integration-tests/hurl_specs/metadata_list_workspace_context.hurl
+++ b/apps/platform-integration-tests/hurl_specs/metadata_list_workspace_context.hurl
@@ -25,7 +25,11 @@ GET {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/ues
 Accept: application/json
 HTTP 200
 [Asserts]
-jsonpath "$[*]" count == {{num_core_and_tests_collections}}
+# this number should be the sum of the number of collections in core, tests, aikit & appkit
+# TODO: Unclear why this assert exists as its fragile and likely does not help in any way since underlying
+# data can change across the test suite.  Evaluate this tests purpose and adjust the assert to be
+# explicit/more meaningful or remove.
+jsonpath "$[*]" count == 28
 # Spot check a uesio/tests collection
 jsonpath "$['uesio/tests.animal'].key" == "uesio/tests.animal"
 jsonpath "$['uesio/tests.animal'].namespace" == "uesio/tests"
@@ -39,7 +43,11 @@ GET {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/ues
 Accept: application/json
 HTTP 200
 [Asserts]
-jsonpath "$[*]" count == {{num_tests_collections}}
+# this number should be the number of collections in tests
+# TODO: Unclear why this assert exists as its fragile and likely does not help in any way since underlying
+# data can change across the test suite.  Evaluate this tests purpose and adjust the assert to be
+# explicit/more meaningful or remove.
+jsonpath "$[*]" count == 11
 # Spot check a uesio/tests collection
 jsonpath "$['uesio/tests.animal'].key" == "uesio/tests.animal"
 jsonpath "$['uesio/tests.animal'].namespace" == "uesio/tests"
@@ -49,7 +57,11 @@ GET {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/ues
 Accept: application/json
 HTTP 200
 [Asserts]
-jsonpath "$[*]" count == {{num_public_core_collections}}
+# this number should be the number of collections in core
+# TODO: Unclear why this assert exists as its fragile and likely does not help in any way since underlying
+# data can change across the test suite.  Evaluate this tests purpose and adjust the assert to be
+# explicit/more meaningful or remove.
+jsonpath "$[*]" count == 14
 # Spot check a uesio/core collection
 jsonpath "$['uesio/core.user'].key" == "uesio/core.user"
 jsonpath "$['uesio/core.user'].namespace" == "uesio/core"

--- a/apps/platform-integration-tests/hurl_specs/object_and_field_level_security_owner_field.hurl
+++ b/apps/platform-integration-tests/hurl_specs/object_and_field_level_security_owner_field.hurl
@@ -47,8 +47,8 @@ HTTP 200
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/uesio/tests/dev/wires/save
 Accept: application/json
 [Options]
-variable: brand="brand_{{unix_epoch_seconds}}"
-variable: category="category_{{unix_epoch_seconds}}"
+variable: brand="brand_{{newUuid}}"
+variable: category="category_{{newUuid}}"
 {
     "wires": [
         {

--- a/apps/platform-integration-tests/hurl_specs/object_and_field_level_security_public_user.hurl
+++ b/apps/platform-integration-tests/hurl_specs/object_and_field_level_security_public_user.hurl
@@ -131,8 +131,8 @@ body contains "Profile uesio/tests.public does not have delete access to the ues
 # because the public profile DOES have permission to create them
 POST {{site_scheme}}://tests.{{site_primary_domain}}:{{site_port}}/site/wires/save
 [Options]
-variable: genus="Choloepus {{unix_epoch_seconds}}"
-variable: species="Didactylus {{unix_epoch_seconds}}"
+variable: genus="Choloepus {{newUuid}}"
+variable: species="Didactylus {{newUuid}}"
 {
     "wires": [
         {
@@ -284,8 +284,8 @@ body contains "Profile uesio/tests.public does not have delete access to the ues
 # because the public profile DOES NOT have permission to create them
 POST {{site_scheme}}://tests.{{site_primary_domain}}:{{site_port}}/site/wires/save
 [Options]
-variable: brand="brand {{unix_epoch_seconds}}"
-variable: category="category {{unix_epoch_seconds}}"
+variable: brand="brand {{newUuid}}"
+variable: category="category {{newUuid}}"
 {
     "wires": [
         {
@@ -358,8 +358,8 @@ HTTP 200
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/uesio/tests/dev/wires/save
 Accept: application/json
 [Options]
-variable: brand="brand_{{unix_epoch_seconds}}"
-variable: category="category_{{unix_epoch_seconds}}"
+variable: brand="brand_{{newUuid}}"
+variable: category="category_{{newUuid}}"
 {
     "wires": [
         {

--- a/apps/platform-integration-tests/hurl_specs/site_signup.hurl
+++ b/apps/platform-integration-tests/hurl_specs/site_signup.hurl
@@ -1,12 +1,21 @@
 # Verify that if self-signup on a signup method is NOT enabled,
 # an error is returned when you attempt to sign up for a new account.
 POST {{site_scheme}}://tests.{{site_primary_domain}}:{{site_port}}/site/auth/uesio/tests/noselfsignup/signup
+[Options]
+# This was previously using {{unix_epoch_seconds}} to create random value, however hurl does not currently have a way
+# to randomly generate data that satisfies our validation of letter/digit/underscore only.  For these tests, we do not
+# need random data since all of our tests require that the tests-init script be run to create the data before every
+# execution anyway.  The benefit of having user_suffix be random is that it would allow this individual file to execute
+# on its own without having to re-run tests-init every time, however the way all these tests are written, they don't
+# lend themselves to that execution style anyway.  For now, changing to fixed value but could potentially revisit if/when
+# hurl extends its built-in function support for random data (see https://github.com/Orange-OpenSource/hurl/issues/3720)
+variable: user_suffix="12345"
 {
-    "username": "test_signup_user_{{unix_epoch_seconds}}",
+    "username": "test_signup_user_{{user_suffix}}",
     "password": "1479182734abcdEFGHJ%(",
     "firstname": "Test",
     "lastname": "User",
-    "email": "tester_{{unix_epoch_seconds}}@ues.io"
+    "email": "tester_{{user_suffix}}@ues.io"
 }
 HTTP 403
 [Asserts]
@@ -16,11 +25,11 @@ body == "this site does not support self-signup\n"
 
 POST {{site_scheme}}://tests.{{site_primary_domain}}:{{site_port}}/site/auth/uesio/tests/tester/signup
 {
-    "username": "test_signup_user_{{unix_epoch_seconds}}",
+    "username": "test_signup_user_{{user_suffix}}",
     "password": "1479182734abcdEFGHJ%(",
     "firstname": "Test",
     "lastname": "User",
-    "email": "tester_{{unix_epoch_seconds}}@ues.io"
+    "email": "tester_{{user_suffix}}@ues.io"
 }
 HTTP 200
 
@@ -50,7 +59,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/siteadmin/ue
             "conditions": [
                 {
                     "field": "uesio/tests.to_emails",
-                    "value": "[\"tester_{{unix_epoch_seconds}}@ues.io\"]"
+                    "value": "[\"tester_{{user_suffix}}@ues.io\"]"
                 }
             ],
             "params": {
@@ -79,7 +88,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/siteadmin/ue
             "conditions": [
                 {
                     "field": "uesio/core.email",
-                    "value": "tester_{{unix_epoch_seconds}}@ues.io"
+                    "value": "tester_{{user_suffix}}@ues.io"
                 }
             ],
             "params": {
@@ -100,13 +109,13 @@ jsonpath "$.wires[0].data" count == 1
 jsonpath "$.wires[0].data[0]['uesio/tests.verification_code']" exists
 jsonpath "$.wires[0].data[0]['uesio/tests.link']" exists
 jsonpath "$.wires[1].data" count == 1
-jsonpath "$.wires[1].data[0]['uesio/core.username']" == "test_signup_user_{{unix_epoch_seconds}}"
-jsonpath "$.wires[1].data[0]['uesio/core.email']" == "tester_{{unix_epoch_seconds}}@ues.io"
+jsonpath "$.wires[1].data[0]['uesio/core.username']" == "test_signup_user_{{user_suffix}}"
+jsonpath "$.wires[1].data[0]['uesio/core.email']" == "tester_{{user_suffix}}@ues.io"
 jsonpath "$.wires[1].data[0]['uesio/core.firstname']" == "Test"
 jsonpath "$.wires[1].data[0]['uesio/core.lastname']" == "User"
 
 # Confirm the signup using the verification code
-GET {{site_scheme}}://tests.{{site_primary_domain}}:{{site_port}}/site/auth/uesio/tests/tester/signup/confirm?code={{verification_code}}&username=test_signup_user_{{unix_epoch_seconds}}
+GET {{site_scheme}}://tests.{{site_primary_domain}}:{{site_port}}/site/auth/uesio/tests/tester/signup/confirm?code={{verification_code}}&username=test_signup_user_{{user_suffix}}
 HTTP 302
 [Asserts]
 header "Location" == "/"

--- a/apps/platform-integration-tests/hurl_specs/view_definition_validation.hurl
+++ b/apps/platform-integration-tests/hurl_specs/view_definition_validation.hurl
@@ -73,7 +73,14 @@ workspace_id: jsonpath "$.wires[1].data[0]['uesio/core.id']"
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/wires/save
 Accept: application/json
 [Options]
-variable: validyamlview="validyamlview_{{unix_epoch_seconds}}"
+# This was previously using {{unix_epoch_seconds}} to create random value, however hurl does not currently have a way
+# to randomly generate data that satisfies our validation of letter/digit/underscore only.  For these tests, we do not
+# need random data since all of our tests require that the tests-init script be run to create the data before every
+# execution anyway.  The benefit of having view_suffix be random is that it would allow this individual file to execute
+# on its own without having to re-run tests-init every time, however the way all these tests are written, they don't
+# lend themselves to that execution style anyway.  For now, changing to fixed value but could potentially revisit if/when
+# hurl extends its built-in function support for random data (see https://github.com/Orange-OpenSource/hurl/issues/3720)
+variable: view_suffix="123456789"
 {
     "wires": [
         {
@@ -82,7 +89,7 @@ variable: validyamlview="validyamlview_{{unix_epoch_seconds}}"
             "changes": {
                 "temp1": {
                     "uesio/studio.definition": "  wires:\n    users:\n        collection: uesio/core.user\n        fields:\n            uesio/core.id:\n            uesio/core.firstname:\n            uesio/core.lastname: {}\n        conditions:\n            - field: uesio/core.firstname\n              value: Sally\n            - field: uesio/core.lastname\n              valueSource: VALUE\n              operator: NOT_EQ\n              value: Jones\n        batchsize: 100\n  components:\n",
-                    "uesio/studio.name": "{{validyamlview}}"
+                    "uesio/studio.name": "validyamlview_{{view_suffix}}"
                 }
             },
             "params": {
@@ -108,7 +115,7 @@ Accept: application/json
             "changes":{
                 "temp1":{
                     "uesio/studio.definition": "wires:\n  users:\n    collectio: uesio/core.user\n    fields:\n      uesio/core.id:\n      uesio/core.firstname:\n      uesio/core.lastname: {}\n    batchsize: this is not a valid number\ncomponents:\n",
-                    "uesio/studio.name":"invalidyamlview_{{unix_epoch_seconds}}"
+                    "uesio/studio.name":"invalidyamlview_{{view_suffix}}"
                 }
             },
             "params": {
@@ -126,8 +133,6 @@ jsonpath "$.wires[0].errors[0].message" == "Field 'Definition' failed YAML schem
 # Create a view with a valid ViewOnly wire
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/wires/save
 Accept: application/json
-[Options]
-variable: viewonlywiretest="viewonlywiretest_{{unix_epoch_seconds}}"
 {
     "wires": [
         {
@@ -136,7 +141,7 @@ variable: viewonlywiretest="viewonlywiretest_{{unix_epoch_seconds}}"
             "changes":{
                 "temp1":{
                     "uesio/studio.definition": "wires:\n  users:\n    viewOnly: true\n    fields:\n      foo:\n        type: NUMBER\n        label: Foo\n        number:\n          decimals: 2\ncomponents:\n",
-                    "uesio/studio.name":"{{viewonlywiretest}}"
+                    "uesio/studio.name":"viewonlywiretest_{{view_suffix}}"
                 }
             },
             "params": {
@@ -161,7 +166,7 @@ Accept: application/json
             "changes":{
                 "temp1":{
                     "uesio/studio.definition": "wires:\n  users:\n    viewOnly: true\n    fields:\n      foo:\n        type: BAR\n        required: no\n        number:\n          some: thing\ncomponents:\n",
-                    "uesio/studio.name":"invalidviewonlywire_{{unix_epoch_seconds}}"
+                    "uesio/studio.name":"invalidviewonlywire_{{view_suffix}}"
                 }
             },
             "params": {

--- a/scripts/tests/start-integration-tests.sh
+++ b/scripts/tests/start-integration-tests.sh
@@ -2,15 +2,6 @@
 
 set -e
 
-# this enables {{unix_epoch_seconds}} variable to be used within tests to add some uniqueness to seed values
-export HURL_unix_epoch_seconds=$(date +%s)
-export HURL_num_common_fields=8
-export HURL_num_public_core_collections=14
-export HURL_num_tests_collections=11
-export HURL_num_aikit_collections=2
-export HURL_num_appkit_collections=1
-# this number should be the sum of the above two variables
-export HURL_num_core_and_tests_collections=$(($HURL_num_public_core_collections + $HURL_num_tests_collections + $HURL_num_aikit_collections + $HURL_num_appkit_collections))
 export HURL_site_scheme=$UESIO_TEST_SCHEME
 export HURL_site_primary_domain=$UESIO_TEST_DOMAIN
 export HURL_site_port=$UESIO_TEST_PORT


### PR DESCRIPTION
# What does this PR do?

Changes asserts in integration tests (and one e2e test) to be performed on explicit values instead of the value of a global variable.  There are a couple of reasons for this change:

1. When a change is made that affects a test that was using one of these variables, the variable would be updated but not the test so it is unclear what tests are affected by a specific code change.  Eliminating the variables ensures that when code changes that affects a test, the test itself is updated.
2. Reduce complexity when trying to run single test files directly via hurl (e.g., `npx hurl testfile.hurl`.  Previously, this was only possible by passing every variable in via the command line or having a variable file that contained all the necessary variables.  By eliminating the variables, the tests can be easier to execute and require less setup both in our own test scripts and when run ad-hoc.

Note that there are still underlying areas of improvement with the way the tests are structured/written that require tests-init to be run prior to every execution of a individual test file or the entire suite.  

# Testing

ci & e2e will cover.
