### PR TITLE
chore: skip test improvements

### DIFF
--- a/apps/platform-e2e/cypress/e2e/builder.cy.ts
+++ b/apps/platform-e2e/cypress/e2e/builder.cy.ts
@@ -111,17 +111,13 @@ components:
         - uesio/io.box: {}
 `
 
-describe("Uesio Builder Tests", () => {
+// This Suite was skipped when running in CI in this commit https://github.com/ues-io/uesio/commit/63c83343953b63aec071a4eb13ff8dfbd3996b47
+// It is unclear why it is being skipped, what the failures were, etc. as the tests pass locally.  See https://github.com/ues-io/uesio/issues/4751
+// As of commit https://github.com/ues-io/uesio/commit/0fdb2476f6fbb8e58b3dac7804ff319baf5bc894, this test is no longer passing locally.
+// See https://github.com/ues-io/uesio/issues/4752.
+// TODO: See https://github.com/ues-io/uesio/issues/4752, resolve and enable the test in both local & CI
+describe.skip("Uesio Builder Tests", () => {
   const username = Cypress.env("automation_username")
-
-  // This test is too flaky to be run in CI
-  // TODO: Investigate why this doesn't work well in CI
-  if (Cypress.env("in_ci")) {
-    it("test disabled in CI environments due to flakiness", () => {
-      cy.log("skipping test in mock login mode")
-    })
-    return
-  }
 
   const appName = getUniqueAppName()
   const workspaceName = "test"

--- a/apps/platform-e2e/cypress/e2e/route_sanity.cy.ts
+++ b/apps/platform-e2e/cypress/e2e/route_sanity.cy.ts
@@ -7,17 +7,17 @@ import {
   getWorkspaceBasePath,
 } from "../support/paths"
 
-describe("Uesio Route Sanity Tests", () => {
+// This Suite was skipped when running in CI in this commit https://github.com/ues-io/uesio/commit/63c83343953b63aec071a4eb13ff8dfbd3996b47
+// It is unclear why it is being skipped, what the failures were, etc. as the tests pass locally.  See https://github.com/ues-io/uesio/issues/4751
+// For now, improving how it is skipped so that it is clearly visible in the logs that it is being skipped.
+// Previously, a test was conditionally executed that logged a message saying a skip was occuring and then return
+// so that no further tests would execute in the suite.  However, this approach emitted a standard log message which
+// required that the logs were CLOSELY inspected to know that the tests were being skipped.  The approach below will
+// ensure any tests in the suite are marked pending and appear in the test summary to increase visibility to skipped tests.
+// TODO: See https://github.com/ues-io/uesio/issues/4751, resolve and enable the test in both local & CI
+const conditionalDescribe = Cypress.env("in_ci") ? describe.skip : describe
+conditionalDescribe("Uesio Route Sanity Tests", () => {
   // const username = Cypress.env("automation_username")
-
-  // This test is too flaky to be run in CI
-  // TODO: Investigate why this doesn't work well in CI
-  if (Cypress.env("in_ci")) {
-    it("test disabled in CI environments due to flakiness", () => {
-      cy.log("skipping test in mock login mode")
-    })
-    return
-  }
 
   const appName = getUniqueAppName()
   const appNamespace = getAppNamespace(appName)

--- a/apps/platform-e2e/cypress/e2e/smoke.cy.ts
+++ b/apps/platform-e2e/cypress/e2e/smoke.cy.ts
@@ -3,22 +3,22 @@
 import { deleteApp, getUniqueAppName } from "../support/testdata"
 import { getAppNamespace, getWorkspaceBasePath } from "../support/paths"
 
-describe("Uesio Sanity Smoke Tests", () => {
+// This Suite was skipped when running in CI in this commit https://github.com/ues-io/uesio/commit/63c83343953b63aec071a4eb13ff8dfbd3996b47
+// It is unclear why it is being skipped, what the failures were, etc. as the tests pass locally.  See https://github.com/ues-io/uesio/issues/4751
+// For now, improving how it is skipped so that it is clearly visible in the logs that it is being skipped.
+// Previously, a test was conditionally executed that logged a message saying a skip was occuring and then return
+// so that no further tests would execute in the suite.  However, this approach emitted a standard log message which
+// required that the logs were CLOSELY inspected to know that the tests were being skipped.  The approach below will
+// ensure any tests in the suite are marked pending and appear in the test summary to increase visibility to skipped tests.
+// TODO: See https://github.com/ues-io/uesio/issues/4751, resolve and enable the test in both local & CI
+const conditionalDescribe = Cypress.env("in_ci") ? describe.skip : describe
+conditionalDescribe("Uesio Sanity Smoke Tests", () => {
   // const username = Cypress.env("automation_username")
 
   const appName = getUniqueAppName()
   const namespace = getAppNamespace(appName)
   const workspaceName = "test"
   const workspaceBasePath = getWorkspaceBasePath(appName, workspaceName)
-
-  // This test is too flaky to be run in CI
-  // TODO: Investigate why this doesn't work well in CI
-  if (Cypress.env("in_ci")) {
-    it("test disabled in CI environments due to flakiness", () => {
-      cy.log("skipping test in mock login mode")
-    })
-    return
-  }
 
   before(() => {
     cy.loginWithAppAndWorkspace(appName, workspaceName)


### PR DESCRIPTION
# What does this PR do?

1. Marks `builder.cy.ts` e2e tests are skipped - See #4752
2. Improves handling of skipping tests - Previously, a test was conditionally executed when in CI that would log a message and then return from the entire test suite.  The challenge with this is that it shows a successful test but not the skipped test in the test summary so unless you were closely reviewing the detailed log output, you would not know that a test was skipped.  This PR changes that behavior to use the built-in methods that Mocha provides to skip tests.  This approach will mark tests as "pending" and they will have a blue color and appear in the test summary as pending.  This increases visibility to tests that are skipped.

Note - #4751 & #4752 should be investigated, resolved and these tests enabled in all environments.

Summary Before
![image](https://github.com/user-attachments/assets/100f868f-9f29-46a9-be7e-f1bf1cc37dfc)

Summary After
![image](https://github.com/user-attachments/assets/a945092f-682e-4f34-8bbd-c88db8bd6f8d)

# Testing

ci & e2e will cover.
