### PR TITLE
chore: docker containers should honor environment variables

### DIFF
--- a/apps/platform/Dockerfile
+++ b/apps/platform/Dockerfile
@@ -19,6 +19,7 @@ COPY ./dist/ui ./dist/ui
 COPY ./dist/vendor ./dist/vendor
 
 ARG BUILD_VERSION
+# TODO: BUILD_VERSION variable should change to have UESIO prefix
 ENV BUILD_VERSION=${BUILD_VERSION}
 LABEL build_version=${BUILD_VERSION}
 

--- a/apps/platform/pkg/cache/redis.go
+++ b/apps/platform/pkg/cache/redis.go
@@ -116,6 +116,7 @@ func init() {
 		return
 	}
 
+	// TODO: REDIS variables should change to have UESIO prefix
 	redisHost := os.Getenv("REDIS_HOST")
 	redisPort := os.Getenv("REDIS_PORT")
 	redisUser := os.Getenv("REDIS_USER")

--- a/apps/platform/pkg/cmd/serve.go
+++ b/apps/platform/pkg/cmd/serve.go
@@ -86,6 +86,7 @@ func serve(cmd *cobra.Command, args []string) error {
 	}
 
 	// If we have BUILD_VERSION, append that to the prefixes to enable us to have versioned assets
+	// TODO: BUILD_VERSION variable should change to have UESIO prefix
 	version := os.Getenv("BUILD_VERSION")
 	cacheSiteBundles := os.Getenv("UESIO_CACHE_SITE_BUNDLES")
 	cacheStaticAssets := false
@@ -422,12 +423,14 @@ func serve(cmd *cobra.Command, args []string) error {
 	// Special handling for local routes
 	lr.HandleFunc("/{route:.*}", controller.ServeLocalRoute)
 
+	// TODO: PORT variable should change to have UESIO prefix
 	port := os.Getenv("PORT")
 	if port == "" {
 		port = "3000"
 	}
 	// Host can be blank by default, but in local development it should be set to "localhost"
 	// to prevent the annoying "Allow incoming connections" firewall warning on Mac OS
+	//TODO: HOST variable should change to have UESIO prefix
 	host := os.Getenv("HOST")
 	serveAddr := host + ":" + port
 

--- a/docker-compose-local.yaml
+++ b/docker-compose-local.yaml
@@ -7,9 +7,12 @@ services:
         # Intentionally leaving BUILD_VERSION blank so that current time is used to ensure static assets are always refetched
         - BUILD_VERSION=
     ports:
-      - "3000:3000"
+      # TODO: PORT variable should change to have UESIO prefix
+      - "${PORT:-3000}:${PORT:-3000}"
     environment:
+      # TODO: REDIS_HOST variable should change to have UESIO prefix
       REDIS_HOST: host.docker.internal
+      # TODO: REDIS_PORT variable should change to have UESIO prefix
       REDIS_PORT: 6379
       UESIO_BUNDLES_BUCKET_NAME: uesiobundlestore-dev
       UESIO_CACHE_SITE_BUNDLES: "true"
@@ -24,11 +27,17 @@ services:
       UESIO_PLATFORM_FILESOURCE_TYPE: uesio.local
       UESIO_SESSION_STORE: redis
       UESIO_USERFILES_BUCKET_NAME: uesiofiles-dev
-      UESIO_MOCK_AUTH: "true"
-      UESIO_USE_HTTPS: "true"
-      UESIO_DEBUG_SQL: "true"
-      PORT: 3000
-      UESIO_DEV: "true"
-      UESIO_PRIMARY_DOMAIN: "uesio-dev.com"
+      UESIO_MOCK_AUTH: "${UESIO_MOCK_AUTH:-true}"
+      UESIO_USE_HTTPS: "${UESIO_USE_HTTPS:-true}"
+      UESIO_ALLOW_INSECURE_COOKIES: "${UESIO_ALLOW_INSECURE_COOKIES:-false}"
+      UESIO_DEBUG_SQL: "${UESIO_DEBUG_SQL:-true}"
+      # TODO: PORT variable should change to have UESIO prefix
+      PORT: "${PORT:-3000}"
+      # TODO: HOST variable should change to have UESIO prefix
+      HOST: "${HOST-}"
+      UESIO_DEV: ${UESIO_DEV:-true}
+      UESIO_PRIMARY_DOMAIN: "${UESIO_PRIMARY_DOMAIN:-uesio-dev.com}"
+      # TODO: LOG_LEVEL variable should change to have UESIO prefix
+      LOG_LEVEL: "${LOG_LEVEL--4}"
     volumes:
       - ./apps/platform/ssl:/ssl

--- a/docker-compose-tests.yaml
+++ b/docker-compose-tests.yaml
@@ -16,16 +16,19 @@ services:
       retries: 4
       start_period: 10s
   app:
-    image: "$APP_IMAGE"
+    image: "${APP_IMAGE:?error}"
     depends_on:
       db:
         condition: service_healthy
       redis:
         condition: service_started
     ports:
-      - "3000:3000"
+      # TODO: PORT variable should change to have UESIO prefix
+      - "${PORT:-3000}:${PORT:-3000}"
     environment:
+      # TODO: REDIS_HOST variable should change to have UESIO prefix
       REDIS_HOST: redis
+      # TODO: REDIS_PORT variable should change to have UESIO prefix
       REDIS_PORT: 6379
       UESIO_BUNDLES_BUCKET_NAME: uesiobundlestore-dev
       UESIO_CACHE_SITE_BUNDLES: "true"
@@ -40,12 +43,18 @@ services:
       UESIO_PLATFORM_FILESOURCE_TYPE: uesio.local
       UESIO_SESSION_STORE: redis
       UESIO_USERFILES_BUCKET_NAME: uesiofiles-dev
-      UESIO_MOCK_AUTH: "true"
-      UESIO_USE_HTTPS: "true"
-      UESIO_DEBUG_SQL: "true"
-      PORT: 3000
-      UESIO_DEV: "true"
-      UESIO_PRIMARY_DOMAIN: "uesio-dev.com"
+      UESIO_MOCK_AUTH: "${UESIO_MOCK_AUTH:-true}"
+      UESIO_USE_HTTPS: "${UESIO_USE_HTTPS:-true}"
+      UESIO_ALLOW_INSECURE_COOKIES: "${UESIO_ALLOW_INSECURE_COOKIES:-false}"
+      UESIO_DEBUG_SQL: "${UESIO_DEBUG_SQL:-true}"
+      # TODO: PORT variable should change to have UESIO prefix
+      PORT: "${PORT:-3000}"
+      # TODO: HOST variable should change to have UESIO prefix
+      HOST: "${HOST-}"
+      UESIO_DEV: ${UESIO_DEV:-true}
+      UESIO_PRIMARY_DOMAIN: "${UESIO_PRIMARY_DOMAIN:-uesio-dev.com}"
+      # TODO: LOG_LEVEL variable should change to have UESIO prefix
+      LOG_LEVEL: "${LOG_LEVEL--4}"
     volumes:
       - ./apps/platform/ssl:/ssl
     command: sh -c "./uesio migrate && ./uesio seed && ./uesio serve"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,11 @@
     "watch-platform-deps": "nx run platform:watch-deps",
     "watch-dev": "nx run platform:serve:watch"
   },
-  "nx": {},
+  "nx": {
+    "includedScripts": [
+      "tests-docker"
+    ]
+  },
   "files": [],
   "devDependencies": {
     "@dagrejs/dagre": "^1.1.4",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "tests-init": "nx run platform-integration-tests:setup-data",
     "tests-integration": "nx run-many -t test-integration",
     "tests-all": "nx run-many -t test && nx run-many -t test-integration test-e2e --parallel=1",
-    "tests-docker": "bash scripts/run-docker-tests.sh",
+    "tests-docker": "nx exec -- bash ./scripts/run-docker-tests.sh",
     "tests-cypress-open": "nx run platform-e2e:open-cypress",
     "tests-cypress-run": "nx run platform-e2e:e2e",
     "format": "nx format:write",
@@ -47,6 +47,7 @@
     "watch-platform-deps": "nx run platform:watch-deps",
     "watch-dev": "nx run platform:serve:watch"
   },
+  "nx": {},
   "files": [],
   "devDependencies": {
     "@dagrejs/dagre": "^1.1.4",


### PR DESCRIPTION
# What does this PR do?

Ensures that docker containers honor environment variables.

This is the next step towards standardizing build/run/test/etc. to start from a "common" environment.  This is achieved via ensuring that `nx` runs all scripts/tasks as it will [automatically load]() environment files if present.

This PR ensures that any core `UESIO_*` environment variables (e.g., UESIO_USE_HTTPS, PORT, UESIO_PRIMARY_DOMAIN, etc.) are used when building the container (e.g., `npm run in-docker`, `npm run tests-docker`, etc.).

Notes:
1. there are still hardcoded `https` references in the code that require adjustment prior to everything working the way its intended using env variables as the starting point.  To ensure backwards compat until these are addressed, all env vars have defaults in docker compose files if the env var is empty/not set.
2. The [package.json](https://github.com/ues-io/uesio/compare/chore/refactor-docker-images?expand=1#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R50) now contains an `"nx": {}` entry.  This is required to be able to use `nx` to run [root/workspace](https://nx.dev/recipes/running-tasks/root-level-scripts) level tasks.  This is accomplished with [nx exec](https://github.com/ues-io/uesio/compare/chore/refactor-docker-images?expand=1#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R25).  Note that only `tests-docker` is included in root level tasks available.  The reason for this is that by default, nx will include all npm scripts in root level tasks, however since the npm scripts use nx (e.g., "test" task calls `nx run-many --target=test --all`) this creates an infinite loop when nx attempts to serialize its graph.  If npm script names were different than the target names, this would likely not be an issue.  However, rather than refactor all the npm script names, simply restricting which takes are available on root to only the ones we want to expose avoids the issue.  This is ultimately what we want anyway since we don't really want to be able to call `nx run uesio:build`, only `nx run uesio:tests-docker` (where `uesio` is the name of our root project via its name in package.json).

# Testing

ci & e2e will cover.
