### PR TITLE
chore: enable e2e tests in ci

### DIFF
--- a/apps/platform-e2e/cypress/e2e/builder.cy.ts
+++ b/apps/platform-e2e/cypress/e2e/builder.cy.ts
@@ -111,16 +111,7 @@ components:
         - uesio/io.box: {}
 `
 
-// This Suite was skipped when running in CI in this commit https://github.com/ues-io/uesio/commit/63c83343953b63aec071a4eb13ff8dfbd3996b47
-// It is unclear why it is being skipped, what the failures were, etc. as the tests pass locally.  See https://github.com/ues-io/uesio/issues/4751
-// For now, improving how it is skipped so that it is clearly visible in the logs that it is being skipped.
-// Previously, a test was conditionally executed that logged a message saying a skip was occuring and then return
-// so that no further tests would execute in the suite.  However, this approach emitted a standard log message which
-// required that the logs were CLOSELY inspected to know that the tests were being skipped.  The approach below will
-// ensure any tests in the suite are marked pending and appear in the test summary to increase visibility to skipped tests.
-// TODO: See https://github.com/ues-io/uesio/issues/4751, resolve and enable the test in both local & CI
-const conditionalDescribe = Cypress.env("in_ci") ? describe.skip : describe
-conditionalDescribe("Uesio Route Sanity Tests", () => {
+describe("Uesio Route Sanity Tests", () => {
   const username = Cypress.env("automation_username")
 
   const appName = getUniqueAppName()

--- a/apps/platform-e2e/cypress/e2e/route_sanity.cy.ts
+++ b/apps/platform-e2e/cypress/e2e/route_sanity.cy.ts
@@ -7,16 +7,7 @@ import {
   getWorkspaceBasePath,
 } from "../support/paths"
 
-// This Suite was skipped when running in CI in this commit https://github.com/ues-io/uesio/commit/63c83343953b63aec071a4eb13ff8dfbd3996b47
-// It is unclear why it is being skipped, what the failures were, etc. as the tests pass locally.  See https://github.com/ues-io/uesio/issues/4751
-// For now, improving how it is skipped so that it is clearly visible in the logs that it is being skipped.
-// Previously, a test was conditionally executed that logged a message saying a skip was occuring and then return
-// so that no further tests would execute in the suite.  However, this approach emitted a standard log message which
-// required that the logs were CLOSELY inspected to know that the tests were being skipped.  The approach below will
-// ensure any tests in the suite are marked pending and appear in the test summary to increase visibility to skipped tests.
-// TODO: See https://github.com/ues-io/uesio/issues/4751, resolve and enable the test in both local & CI
-const conditionalDescribe = Cypress.env("in_ci") ? describe.skip : describe
-conditionalDescribe("Uesio Route Sanity Tests", () => {
+describe("Uesio Route Sanity Tests", () => {
   // const username = Cypress.env("automation_username")
 
   const appName = getUniqueAppName()

--- a/apps/platform-e2e/cypress/e2e/smoke.cy.ts
+++ b/apps/platform-e2e/cypress/e2e/smoke.cy.ts
@@ -3,16 +3,7 @@
 import { deleteApp, getUniqueAppName } from "../support/testdata"
 import { getAppNamespace, getWorkspaceBasePath } from "../support/paths"
 
-// This Suite was skipped when running in CI in this commit https://github.com/ues-io/uesio/commit/63c83343953b63aec071a4eb13ff8dfbd3996b47
-// It is unclear why it is being skipped, what the failures were, etc. as the tests pass locally.  See https://github.com/ues-io/uesio/issues/4751
-// For now, improving how it is skipped so that it is clearly visible in the logs that it is being skipped.
-// Previously, a test was conditionally executed that logged a message saying a skip was occuring and then return
-// so that no further tests would execute in the suite.  However, this approach emitted a standard log message which
-// required that the logs were CLOSELY inspected to know that the tests were being skipped.  The approach below will
-// ensure any tests in the suite are marked pending and appear in the test summary to increase visibility to skipped tests.
-// TODO: See https://github.com/ues-io/uesio/issues/4751, resolve and enable the test in both local & CI
-const conditionalDescribe = Cypress.env("in_ci") ? describe.skip : describe
-conditionalDescribe("Uesio Sanity Smoke Tests", () => {
+describe("Uesio Sanity Smoke Tests", () => {
   // const username = Cypress.env("automation_username")
 
   const appName = getUniqueAppName()


### PR DESCRIPTION
# What does this PR do?

Per #4751, enabling the e2e tests that are disabled in CI to see if they work.  All these tests pass locally.

Closes #4751.

# Testing

ci & e2e will cover.
