### PR TITLE
Feature: add core agent collection

### DIFF
--- a/apps/platform-integration-tests/hurl_specs/metadata_list_core_collections.hurl
+++ b/apps/platform-integration-tests/hurl_specs/metadata_list_core_collections.hurl
@@ -46,3 +46,38 @@ jsonpath "$.collections['uesio/core.signupmethod'].fields['uesio/core.authsource
 jsonpath "$.collections['uesio/core.signupmethod'].fields['uesio/core.authsource'].namespace" == "uesio/core"
 jsonpath "$.collections['uesio/core.signupmethod'].fields['uesio/core.appicon'].name" == "appicon"
 jsonpath "$.collections['uesio/core.signupmethod'].fields['uesio/core.appicon'].namespace" == "uesio/core"
+
+# Test a wire load with a condition on unique key
+POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/wires/load
+Accept: application/json
+{
+    "wires": [
+        {
+            "collection": "uesio/core.signupmethod",
+            "query": true,
+            "conditions": [
+                {
+                    "field": "uesio/core.uniquekey",
+                    "value": "uesio/studio.platform"
+                }
+            ]
+        }
+    ],
+    "includeMetadata": true
+}
+HTTP 200
+[Asserts]
+jsonpath "$.wires[0].data" count == 1
+jsonpath "$.wires[0].data[0]['uesio/core.name']" == "platform"
+jsonpath "$.wires[0].data[0]['uesio/core.namespace']" == "uesio/studio"
+jsonpath "$.wires[0].data[0]['uesio/core.authsource']" == "uesio/core.platform"
+jsonpath "$.wires[0].data[0]['uesio/core.appicon']" == "design_services"
+jsonpath "$.collections['uesio/core.signupmethod'].name" == "signupmethod"
+jsonpath "$.collections['uesio/core.signupmethod'].fields['uesio/core.name'].name" == "name"
+jsonpath "$.collections['uesio/core.signupmethod'].fields['uesio/core.name'].namespace" == "uesio/core"
+jsonpath "$.collections['uesio/core.signupmethod'].fields['uesio/core.namespace'].name" == "namespace"
+jsonpath "$.collections['uesio/core.signupmethod'].fields['uesio/core.namespace'].namespace" == "uesio/core"
+jsonpath "$.collections['uesio/core.signupmethod'].fields['uesio/core.authsource'].name" == "authsource"
+jsonpath "$.collections['uesio/core.signupmethod'].fields['uesio/core.authsource'].namespace" == "uesio/core"
+jsonpath "$.collections['uesio/core.signupmethod'].fields['uesio/core.appicon'].name" == "appicon"
+jsonpath "$.collections['uesio/core.signupmethod'].fields['uesio/core.appicon'].namespace" == "uesio/core"

--- a/apps/platform-integration-tests/hurl_specs/metadata_list_siteadmin_context.hurl
+++ b/apps/platform-integration-tests/hurl_specs/metadata_list_siteadmin_context.hurl
@@ -29,7 +29,7 @@ HTTP 200
 # TODO: Unclear why this assert exists as its fragile and likely does not help in any way since underlying
 # data can change across the test suite.  Evaluate this tests purpose and adjust the assert to be
 # explicit/more meaningful or remove.
-jsonpath "$[*]" count == 28
+jsonpath "$[*]" count == 29
 # Spot check a uesio/tests collection
 jsonpath "$['uesio/tests.animal'].key" == "uesio/tests.animal"
 jsonpath "$['uesio/tests.animal'].namespace" == "uesio/tests"
@@ -61,7 +61,7 @@ HTTP 200
 # TODO: Unclear why this assert exists as its fragile and likely does not help in any way since underlying
 # data can change across the test suite.  Evaluate this tests purpose and adjust the assert to be
 # explicit/more meaningful or remove.
-jsonpath "$[*]" count == 14
+jsonpath "$[*]" count == 15
 # Spot check a uesio/core collection
 jsonpath "$['uesio/core.user'].key" == "uesio/core.user"
 jsonpath "$['uesio/core.user'].namespace" == "uesio/core"

--- a/apps/platform-integration-tests/hurl_specs/metadata_list_version_context.hurl
+++ b/apps/platform-integration-tests/hurl_specs/metadata_list_version_context.hurl
@@ -29,7 +29,7 @@ HTTP 200
 # TODO: Unclear why this assert exists as its fragile and likely does not help in any way since underlying
 # data can change across the test suite.  Evaluate this tests purpose and adjust the assert to be
 # explicit/more meaningful or remove.
-jsonpath "$[*]" count == 28
+jsonpath "$[*]" count == 29
 # Spot check a uesio/tests collection
 jsonpath "$['uesio/tests.animal'].key" == "uesio/tests.animal"
 jsonpath "$['uesio/tests.animal'].namespace" == "uesio/tests"
@@ -61,7 +61,7 @@ HTTP 200
 # TODO: Unclear why this assert exists as its fragile and likely does not help in any way since underlying
 # data can change across the test suite.  Evaluate this tests purpose and adjust the assert to be
 # explicit/more meaningful or remove.
-jsonpath "$[*]" count == 14
+jsonpath "$[*]" count == 15
 # Spot check a uesio/core collection
 jsonpath "$['uesio/core.user'].key" == "uesio/core.user"
 jsonpath "$['uesio/core.user'].namespace" == "uesio/core"

--- a/apps/platform-integration-tests/hurl_specs/metadata_list_workspace_context.hurl
+++ b/apps/platform-integration-tests/hurl_specs/metadata_list_workspace_context.hurl
@@ -29,7 +29,7 @@ HTTP 200
 # TODO: Unclear why this assert exists as its fragile and likely does not help in any way since underlying
 # data can change across the test suite.  Evaluate this tests purpose and adjust the assert to be
 # explicit/more meaningful or remove.
-jsonpath "$[*]" count == 28
+jsonpath "$[*]" count == 29
 # Spot check a uesio/tests collection
 jsonpath "$['uesio/tests.animal'].key" == "uesio/tests.animal"
 jsonpath "$['uesio/tests.animal'].namespace" == "uesio/tests"
@@ -61,7 +61,7 @@ HTTP 200
 # TODO: Unclear why this assert exists as its fragile and likely does not help in any way since underlying
 # data can change across the test suite.  Evaluate this tests purpose and adjust the assert to be
 # explicit/more meaningful or remove.
-jsonpath "$[*]" count == 14
+jsonpath "$[*]" count == 15
 # Spot check a uesio/core collection
 jsonpath "$['uesio/core.user'].key" == "uesio/core.user"
 jsonpath "$['uesio/core.user'].namespace" == "uesio/core"

--- a/apps/platform/pkg/bot/systemdialect/namespaceswap.go
+++ b/apps/platform/pkg/bot/systemdialect/namespaceswap.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"strconv"
 
+	"github.com/thecloudmasters/uesio/pkg/datasource"
 	"github.com/thecloudmasters/uesio/pkg/meta"
 	"github.com/thecloudmasters/uesio/pkg/reflecttool"
 	"github.com/thecloudmasters/uesio/pkg/types/wire"
@@ -92,10 +93,16 @@ func (c *NamespaceSwapCollection) Len() int {
 }
 
 func (c *NamespaceSwapCollection) SwapNS(value string) string {
+	if datasource.IsBuiltinField(value) {
+		return value
+	}
 	return meta.SwapKeyNamespace(value, c.original, c.modified)
 }
 
 func (c *NamespaceSwapCollection) SwapNSBack(value string) string {
+	if datasource.IsBuiltinField(value) {
+		return value
+	}
 	return meta.SwapKeyNamespace(value, c.modified, c.original)
 }
 

--- a/apps/platform/pkg/bot/systemdialect/systembot_load_allmetadata.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_load_allmetadata.go
@@ -53,6 +53,17 @@ func runCoreMetadataLoadBot(op *wire.LoadOp, connection wire.Connection, session
 
 	studioMetadata := &wire.MetadataCache{}
 
+	itemCondition := extractConditionByField(newOp.Conditions, "uesio/core.uniquekey")
+
+	if itemCondition != nil {
+		newOp.Conditions = []wire.LoadRequestCondition{
+			{
+				Field: "uesio/studio.item",
+				Value: itemCondition.Value,
+			},
+		}
+	}
+
 	err := datasource.GetMetadataForLoad(newOp, studioMetadata, nil, sess.GetStudioAnonSession(session.Context()), connection)
 	if err != nil {
 		return err

--- a/apps/platform/pkg/datasource/builtin.go
+++ b/apps/platform/pkg/datasource/builtin.go
@@ -143,3 +143,8 @@ func GetBuiltinField(key string, collectionKey string) (meta.Field, bool) {
 	field.CollectionRef = collectionKey
 	return field, true
 }
+
+func IsBuiltinField(key string) bool {
+	_, ok := BUILTIN_FIELDS_MAP[key]
+	return ok
+}

--- a/libs/apps/uesio/core/bundle/collections/agent.yaml
+++ b/libs/apps/uesio/core/bundle/collections/agent.yaml
@@ -1,0 +1,5 @@
+name: agent
+type: DYNAMIC
+label: Agent
+pluralLabel: Agents
+public: true


### PR DESCRIPTION
# What does this PR do?

1. adds the `uesio/core.agent` collection. (This is different from the `uesio/studio.agent` collection.) It allows any site to access the agent metadata accessible to them.
2. Fixes a bug with the NamespaceSwap collection where builtin fields were getting swapped when they shouldn't be.
3. Handles queries on core metadata collections with a condition on `uesio/core.uniquekey`.
