### PR TITLE
chore: refactor external bundle store url config value

### DIFF
--- a/apps/platform/pkg/bot/systemdialect/systembot_listener_addexternalbundle.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_listener_addexternalbundle.go
@@ -49,7 +49,7 @@ func runAddExternalBundleListenerBot(params map[string]interface{}, connection w
 		return nil, err
 	}
 
-	url, err := url.JoinPath(bundleStoreBaseUrl, "retrieve", appID, version)
+	url, err := url.JoinPath(bundleStoreBaseUrl, "site/bundles/v1/retrieve", appID, version)
 	if err != nil {
 		return nil, err
 	}

--- a/apps/platform/pkg/bot/systemdialect/systembot_listener_addexternalbundle.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_listener_addexternalbundle.go
@@ -2,9 +2,9 @@ package systemdialect
 
 import (
 	"errors"
-	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strconv"
 
 	"github.com/thecloudmasters/uesio/pkg/bundlestore"
@@ -39,7 +39,7 @@ func runAddExternalBundleListenerBot(params map[string]interface{}, connection w
 		return nil, exceptions.NewForbiddenException("you must be a workspace admin to install bundles")
 	}
 
-	bundleStoreDomain, err := configstore.GetValue("uesio/core.bundle_store_domain", session)
+	bundleStoreBaseUrl, err := configstore.GetValue("uesio/studio.external_bundle_store_base_url", session)
 	if err != nil {
 		return nil, err
 	}
@@ -49,7 +49,10 @@ func runAddExternalBundleListenerBot(params map[string]interface{}, connection w
 		return nil, err
 	}
 
-	url := fmt.Sprintf("https://studio.%s/site/bundles/v1/retrieve/%s/%s", bundleStoreDomain, appID, version)
+	url, err := url.JoinPath(bundleStoreBaseUrl, "retrieve", appID, version)
+	if err != nil {
+		return nil, err
+	}
 
 	httpReq, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {

--- a/apps/platform/pkg/configstore/environment/environment.go
+++ b/apps/platform/pkg/configstore/environment/environment.go
@@ -43,7 +43,7 @@ var configValues = map[string]string{
 	"uesio/core.db_port":                          GetEnvWithDefault("UESIO_DB_PORT", "5432"),
 	"uesio/core.db_sslmode":                       GetEnvWithDefault("UESIO_DB_SSLMODE", "disable"),
 	"uesio/core.bundlestore_bucket":               GetEnvWithDefault("UESIO_BUNDLES_BUCKET_NAME", "uesio-bundles"),
-	"uesio/core.bundle_store_domain":              os.Getenv("UESIO_BUNDLE_STORE_DOMAIN"),
+	"uesio/studio.external_bundle_store_base_url": os.Getenv("UESIO_EXTERNAL_BUNDLE_STORE_BASE_URL"),
 	"uesio/core.primary_domain":                   GetEnvWithDefault("UESIO_PRIMARY_DOMAIN", "localhost"),
 }
 

--- a/docs/deployment/aws-ecs/taskdefinition-web-app.json
+++ b/docs/deployment/aws-ecs/taskdefinition-web-app.json
@@ -17,7 +17,7 @@
       "environment": [
         {
           "name": "UESIO_EXTERNAL_BUNDLE_STORE_BASE_URL",
-          "value": "https://studio.ues.io/site/bundles/v1"
+          "value": "https://studio.ues.io"
         },
         {
           "name": "UESIO_PRIMARY_DOMAIN",

--- a/docs/deployment/aws-ecs/taskdefinition-web-app.json
+++ b/docs/deployment/aws-ecs/taskdefinition-web-app.json
@@ -16,8 +16,8 @@
       "essential": true,
       "environment": [
         {
-          "name": "UESIO_BUNDLE_STORE_DOMAIN",
-          "value": "ues.io"
+          "name": "UESIO_EXTERNAL_BUNDLE_STORE_BASE_URL",
+          "value": "https://studio.ues.io/site/bundles/v1"
         },
         {
           "name": "UESIO_PRIMARY_DOMAIN",

--- a/libs/apps/uesio/core/bundle/configvalues/bundle_store_domain.yaml
+++ b/libs/apps/uesio/core/bundle/configvalues/bundle_store_domain.yaml
@@ -1,5 +1,0 @@
-name: bundle_store_domain
-managedBy: app
-store: environment
-defaultValue: ues.io
-public: true

--- a/libs/apps/uesio/studio/bundle/bots/load/loadexternalbundlelisting/bot.ts
+++ b/libs/apps/uesio/studio/bundle/bots/load/loadexternalbundlelisting/bot.ts
@@ -11,7 +11,7 @@ export default function loadexternalbundlelisting(bot: LoadBotApi) {
   const { conditions } = bot.loadRequest
 
   const bundleStoreBaseUrl = bot.getConfigValue("uesio/studio.external_bundle_store_base_url")
-  const url = new URL("list", bundleStoreBaseUrl)
+  const url = new URL("site/bundles/v1/list", bundleStoreBaseUrl)
 
   const response = bot.http.request({
     method: "GET",

--- a/libs/apps/uesio/studio/bundle/bots/load/loadexternalbundlelisting/bot.ts
+++ b/libs/apps/uesio/studio/bundle/bots/load/loadexternalbundlelisting/bot.ts
@@ -10,7 +10,9 @@ type ApiResponse = {
 export default function loadexternalbundlelisting(bot: LoadBotApi) {
   const { conditions } = bot.loadRequest
 
-  const bundleStoreBaseUrl = bot.getConfigValue("uesio/studio.external_bundle_store_base_url")
+  const bundleStoreBaseUrl = bot.getConfigValue(
+    "uesio/studio.external_bundle_store_base_url",
+  )
   const url = new URL("site/bundles/v1/list", bundleStoreBaseUrl)
 
   const response = bot.http.request({

--- a/libs/apps/uesio/studio/bundle/bots/load/loadexternalbundlelisting/bot.ts
+++ b/libs/apps/uesio/studio/bundle/bots/load/loadexternalbundlelisting/bot.ts
@@ -10,12 +10,12 @@ type ApiResponse = {
 export default function loadexternalbundlelisting(bot: LoadBotApi) {
   const { conditions } = bot.loadRequest
 
-  const bundleStoreDomain = bot.getConfigValue("uesio/core.bundle_store_domain")
-  const url = "https://studio." + bundleStoreDomain + "/site/bundles/v1/list"
+  const bundleStoreBaseUrl = bot.getConfigValue("uesio/studio.external_bundle_store_base_url")
+  const url = new URL("list", bundleStoreBaseUrl)
 
   const response = bot.http.request({
     method: "GET",
-    url,
+    url: url.href,
   })
 
   let apiResponse = response.body as unknown as ApiResponse[]

--- a/libs/apps/uesio/studio/bundle/bots/load/loadexternalbundleversion/bot.ts
+++ b/libs/apps/uesio/studio/bundle/bots/load/loadexternalbundleversion/bot.ts
@@ -23,7 +23,7 @@ export default function loadexternalbundleversion(bot: LoadBotApi) {
     return
   }
 
-  const url = new URL(`versions/${bundleVersionValue}/list`, bundleStoreBaseUrl)
+  const url = new URL(`site/bundles/v1/versions/${bundleVersionValue}/list`, bundleStoreBaseUrl)
 
   const response = bot.http.request({
     method: "GET",

--- a/libs/apps/uesio/studio/bundle/bots/load/loadexternalbundleversion/bot.ts
+++ b/libs/apps/uesio/studio/bundle/bots/load/loadexternalbundleversion/bot.ts
@@ -8,7 +8,9 @@ type ApiResponse = {
 export default function loadexternalbundleversion(bot: LoadBotApi) {
   const { conditions } = bot.loadRequest
 
-  const bundleStoreBaseUrl = bot.getConfigValue("uesio/studio.external_bundle_store_base_url")
+  const bundleStoreBaseUrl = bot.getConfigValue(
+    "uesio/studio.external_bundle_store_base_url",
+  )
 
   const externalBundleVersionUniquekey = conditions?.find(
     (condition) => condition.id === "externalBundleVersionUniquekey",
@@ -23,7 +25,10 @@ export default function loadexternalbundleversion(bot: LoadBotApi) {
     return
   }
 
-  const url = new URL(`site/bundles/v1/versions/${bundleVersionValue}/list`, bundleStoreBaseUrl)
+  const url = new URL(
+    `site/bundles/v1/versions/${bundleVersionValue}/list`,
+    bundleStoreBaseUrl,
+  )
 
   const response = bot.http.request({
     method: "GET",

--- a/libs/apps/uesio/studio/bundle/bots/load/loadexternalbundleversion/bot.ts
+++ b/libs/apps/uesio/studio/bundle/bots/load/loadexternalbundleversion/bot.ts
@@ -8,7 +8,7 @@ type ApiResponse = {
 export default function loadexternalbundleversion(bot: LoadBotApi) {
   const { conditions } = bot.loadRequest
 
-  const bundleStoreDomain = bot.getConfigValue("uesio/core.bundle_store_domain")
+  const bundleStoreBaseUrl = bot.getConfigValue("uesio/studio.external_bundle_store_base_url")
 
   const externalBundleVersionUniquekey = conditions?.find(
     (condition) => condition.id === "externalBundleVersionUniquekey",
@@ -23,16 +23,11 @@ export default function loadexternalbundleversion(bot: LoadBotApi) {
     return
   }
 
-  const url =
-    "https://studio." +
-    bundleStoreDomain +
-    "/site/bundles/v1/versions/" +
-    bundleVersionValue +
-    "/list"
+  const url = new URL(`versions/${bundleVersionValue}/list`, bundleStoreBaseUrl)
 
   const response = bot.http.request({
     method: "GET",
-    url,
+    url: url.href,
   })
   const apiResponse = response.body as unknown as ApiResponse[]
   apiResponse.forEach((record) =>

--- a/libs/apps/uesio/studio/bundle/configvalues/external_bundle_store_base_url.yaml
+++ b/libs/apps/uesio/studio/bundle/configvalues/external_bundle_store_base_url.yaml
@@ -1,5 +1,5 @@
 name: external_bundle_store_base_url
 managedBy: app
 store: environment
-defaultValue: https://studio.ues.io/site/bundles/v1
+defaultValue: https://studio.ues.io
 public: true

--- a/libs/apps/uesio/studio/bundle/configvalues/external_bundle_store_base_url.yaml
+++ b/libs/apps/uesio/studio/bundle/configvalues/external_bundle_store_base_url.yaml
@@ -1,0 +1,5 @@
+name: external_bundle_store_base_url
+managedBy: app
+store: environment
+defaultValue: https://studio.ues.io/site/bundles/v1
+public: true


### PR DESCRIPTION
# What does this PR do?


1. Renames `bundle_store_domain` config value to `external_bundle_store_base_url`
2. Moves the config value to `studio` from `core` since it only makes sense and is only used in studio context

The current `bundle_store_domain` config value has a few shortcomings:
1. It required hardcoded `studio` prefix in the code to build the url
2. It required hardcoded `scheme` in the code to build the url
3. It was in `uesio.core` when it is only applicable to `uesio.studio`

Requires infra changes to dev & prod prior to deploy since environment variable is being renamed.

# Testing

ci & e2e will cover.

@humandad - I'm not setup to test this manually locally, can you run through a couple of tests?
