### PR TITLE
chore: eliminate hardcoded https when url scheme is required

### DIFF
--- a/apps/platform-integration-tests/generated/@types/@uesio/index.d.ts
+++ b/apps/platform-integration-tests/generated/@types/@uesio/index.d.ts
@@ -107,6 +107,8 @@ interface SiteApi {
   getDomain: () => string
   // Return the subdomain of the site
   getSubDomain: () => string
+  // Return the scheme of the site
+  getScheme: () => string  
 }
 interface WorkspaceApi {
   // Return the name of the workspace

--- a/apps/platform/pkg/auth/samlauth/samlauth.go
+++ b/apps/platform/pkg/auth/samlauth/samlauth.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/thecloudmasters/uesio/pkg/meta"
 	"github.com/thecloudmasters/uesio/pkg/sess"
+	uesiotls "github.com/thecloudmasters/uesio/pkg/tls"
 	"github.com/thecloudmasters/uesio/pkg/types/exceptions"
 	"github.com/thecloudmasters/uesio/pkg/types/wire"
 )
@@ -117,7 +118,7 @@ func (c *Connection) getSPInternal(requestURL string) (*samlsp.Middleware, error
 		return nil, err
 	}
 
-	rootURLString := "https://" + requestURL
+	rootURLString := uesiotls.ServeAppDefaultScheme() + "://" + requestURL
 	contextPrefix := c.session.GetContextURLPrefix()
 	acsURLString := contextPrefix + "/auth/" + c.authSource.Namespace + "/" + c.authSource.Name + "/login"
 

--- a/apps/platform/pkg/bot/jsdialect/sessionapi.go
+++ b/apps/platform/pkg/bot/jsdialect/sessionapi.go
@@ -38,6 +38,10 @@ func (s *SiteAPI) GetSubDomain() string {
 	return s.site.Subdomain
 }
 
+func (s *SiteAPI) GetScheme() string {
+	return s.site.Scheme
+}
+
 type WorkspaceAPI struct {
 	workspace *meta.Workspace
 }

--- a/apps/platform/pkg/controller/oauth/authorize_metadata.go
+++ b/apps/platform/pkg/controller/oauth/authorize_metadata.go
@@ -12,6 +12,7 @@ import (
 	"github.com/thecloudmasters/uesio/pkg/datasource"
 	"github.com/thecloudmasters/uesio/pkg/middleware"
 	oauth "github.com/thecloudmasters/uesio/pkg/oauth2"
+	"github.com/thecloudmasters/uesio/pkg/tls"
 	"github.com/thecloudmasters/uesio/pkg/types/exceptions"
 )
 
@@ -25,7 +26,7 @@ func GetRedirectMetadata(w http.ResponseWriter, r *http.Request) {
 			"invalid integration: %s", err.Error())))
 		return
 	}
-	conf, err := oauth.GetConfig(integrationConnection.GetCredentials(), fmt.Sprintf("https://%s", r.Host))
+	conf, err := oauth.GetConfig(integrationConnection.GetCredentials(), fmt.Sprintf("%s://%s", tls.ServeAppDefaultScheme(), r.Host))
 	if err != nil {
 		ctlutil.HandleError(w, exceptions.NewForbiddenException(fmt.Sprintf(
 			"invalid integration configuration: %s", err.Error())))

--- a/apps/platform/pkg/controller/oauth/callback.go
+++ b/apps/platform/pkg/controller/oauth/callback.go
@@ -15,6 +15,7 @@ import (
 	oauth "github.com/thecloudmasters/uesio/pkg/oauth2"
 	"github.com/thecloudmasters/uesio/pkg/routing"
 	"github.com/thecloudmasters/uesio/pkg/sess"
+	"github.com/thecloudmasters/uesio/pkg/tls"
 	"github.com/thecloudmasters/uesio/pkg/types/exceptions"
 	"github.com/thecloudmasters/uesio/pkg/types/wire"
 )
@@ -68,7 +69,7 @@ func Callback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	host := fmt.Sprintf("https://%s", r.Host)
+	host := fmt.Sprintf("%s://%s", tls.ServeAppDefaultScheme(), r.Host)
 	tok, err := oauth.ExchangeAuthorizationCodeForAccessToken(s.Context(), integrationConnection.GetCredentials(), host, authCode, state)
 	if err != nil {
 		controller.HandleErrorRoute(w, r, s, r.URL.Path, "", err, false)

--- a/apps/platform/pkg/datasource/domain.go
+++ b/apps/platform/pkg/datasource/domain.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/thecloudmasters/uesio/pkg/meta"
 	"github.com/thecloudmasters/uesio/pkg/sess"
+	"github.com/thecloudmasters/uesio/pkg/tls"
 	"github.com/thecloudmasters/uesio/pkg/types/wire"
 )
 
@@ -41,7 +42,7 @@ func QueryDomainFromSite(siteID string, connection wire.Connection) (*meta.SiteD
 
 func GetHostFromDomain(domain *meta.SiteDomain, site *meta.Site) string {
 	if domain.Type == "subdomain" {
-		return fmt.Sprintf("https://%s.%s", domain.Domain, site.Domain)
+		return fmt.Sprintf("%s://%s.%s", tls.ServeAppDefaultScheme(), domain.Domain, site.Domain)
 	}
-	return fmt.Sprintf("https://%s", domain.Domain)
+	return fmt.Sprintf("%s://%s", tls.ServeAppDefaultScheme(), domain.Domain)
 }

--- a/apps/platform/pkg/merge/merge.go
+++ b/apps/platform/pkg/merge/merge.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/thecloudmasters/uesio/pkg/meta"
 	"github.com/thecloudmasters/uesio/pkg/sess"
+	"github.com/thecloudmasters/uesio/pkg/tls"
 )
 
 type ServerMergeData struct {
@@ -66,11 +67,11 @@ var SiteMergeFunc = func(m ServerMergeData, key string) (interface{}, error) {
 	case "subdomain":
 		return siteInfo.Subdomain, nil
 	case "url":
-		url := "https://"
+		var subdomain string
 		if siteInfo.Subdomain != "" {
-			url += siteInfo.Subdomain + "."
+			subdomain = siteInfo.Subdomain + "."
 		}
-		return url + siteInfo.Domain, nil
+		return tls.ServeAppDefaultScheme() + "://" + subdomain + siteInfo.Domain, nil
 	}
 	return nil, nil
 }

--- a/apps/platform/pkg/merge/merge_test.go
+++ b/apps/platform/pkg/merge/merge_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/thecloudmasters/uesio/pkg/meta"
 	"github.com/thecloudmasters/uesio/pkg/sess"
+	"github.com/thecloudmasters/uesio/pkg/tls"
 	"github.com/thecloudmasters/uesio/pkg/types/wire"
 )
 
@@ -162,7 +163,7 @@ func Test_serverMergeFuncs(t *testing.T) {
 				Session: studioSession,
 			},
 			"url",
-			"https://www.acme.com",
+			tls.ServeAppDefaultScheme() + "://www.acme.com",
 			nil,
 		},
 		{
@@ -172,7 +173,7 @@ func Test_serverMergeFuncs(t *testing.T) {
 				Session: studioSessionWithoutSubdomain,
 			},
 			"url",
-			"https://acme.com",
+			tls.ServeAppDefaultScheme() + "://acme.com",
 			nil,
 		},
 		{

--- a/apps/platform/pkg/oauth2/authorizationcode_test.go
+++ b/apps/platform/pkg/oauth2/authorizationcode_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/thecloudmasters/uesio/pkg/cache"
 	"github.com/thecloudmasters/uesio/pkg/sess"
+	"github.com/thecloudmasters/uesio/pkg/tls"
 	"github.com/thecloudmasters/uesio/pkg/types/wire"
 )
 
@@ -32,7 +33,7 @@ type TokenEndpointResponse struct {
 
 func TestAuthorizationCodeFlow(t *testing.T) {
 
-	host := "https://studio.ues.io"
+	host := tls.ServeAppDefaultScheme() + "://studio.ues.io"
 	sampleAuthCode := "authcode1234"
 
 	var serveResponseBody string
@@ -69,7 +70,7 @@ func TestAuthorizationCodeFlow(t *testing.T) {
 		"authUrl":      server.URL + "/oauth2/authorize",
 	}
 
-	redirectUri := "https://studio.ues.io/site/oauth2/callback"
+	redirectUri := tls.ServeAppDefaultScheme() + "://studio.ues.io/site/oauth2/callback"
 
 	conf := &oauth2.Config{
 		ClientID:     "testclientid",

--- a/libs/apps/uesio/sitekit/bundle/bots/generator/view_footer/templates/footer.yaml
+++ b/libs/apps/uesio/sitekit/bundle/bots/generator/view_footer/templates/footer.yaml
@@ -10,10 +10,8 @@ components:
                   filepath: ${logoFilePath}
                   height: 44
                   signals:
-                    - signal: route/REDIRECT
-                      namespace: uesio/core
-                      path: https://ues.io
-                      newtab: true
+                    - signal: "route/NAVIGATE"
+                      path: "home"
               - uesio/io.grid:
                   uesio.variant: uesio/sitekit.footer_linkwrapper
                   items: ${categoriesYaml}

--- a/libs/apps/uesio/studio/bundle/bots/listener/select_plan/bot.ts
+++ b/libs/apps/uesio/studio/bundle/bots/listener/select_plan/bot.ts
@@ -29,7 +29,8 @@ export default function select_plan(bot: ListenerBotApi) {
   const user = bot.getUser()
   const domain = bot.getSession().getSite().getDomain()
   const subdomain = bot.getSession().getSite().getSubDomain()
-  const host = `https://${subdomain}.${domain}`
+  const scheme = bot.getSession().getSite().getScheme()
+  const host = `${scheme}://${subdomain}.${domain}`
   const STRIPE_INTEGRATION = "uesio/stripe.stripe"
   const searchResult = bot.runIntegrationAction(
     STRIPE_INTEGRATION,

--- a/libs/ui/src/public_types/server/index.d.ts
+++ b/libs/ui/src/public_types/server/index.d.ts
@@ -106,6 +106,8 @@ interface SiteApi {
   getDomain: () => string
   // Return the subdomain of the site
   getSubDomain: () => string
+  // Return the scheme of the site
+  getScheme: () => string
 }
 interface WorkspaceApi {
   // Return the name of the workspace


### PR DESCRIPTION
# What does this PR do?

Eliminates all hardcoded url scheme (e.g., `https`) references in the code and derives the scheme based on server settings.

# Testing

ci & e2e will cover.
