### PR TITLE
fix: server panics when unable to obtain user and there is no browser session

### DIFF
--- a/apps/platform/pkg/middleware/authenticate.go
+++ b/apps/platform/pkg/middleware/authenticate.go
@@ -55,7 +55,9 @@ func Authenticate(next http.Handler) http.Handler {
 
 		user, err := auth.GetUserFromBrowserSession(browserSession, site)
 		if err != nil {
-			session.Remove(browserSession, w)
+			if browserSession != nil {
+				session.Remove(browserSession, w)
+			}
 			publicSession, err := auth.GetPublicSession(site, nil)
 			if err != nil {
 				http.Error(w, "Failed to create public session: "+err.Error(), http.StatusInternalServerError)


### PR DESCRIPTION
# What does this PR do?

When we're unable to obtain a user during authentication, if the browser session is nil, a panic occurs.

This panic masks the actual error that was encountered when attempting to create the user instance.  For example, if S3 AWS credentials are invalid, [GetUserFromBrowserSession](https://github.com/ues-io/uesio/blob/ebaf5b6bc64bfaacce7d8344a0d9dc7fe77a6ced/apps/platform/pkg/middleware/authenticate.go#L56) will return an error which will then try to remove a potentially `nil` browserSession.

# Testing

Manual testing confirms that panic no longer occurs and underlying error is surfaced.
