### PR TITLE
Refactor: Better Bedrock interfaces for testing

### DIFF
--- a/apps/platform-integration-tests/hurl_specs/bedrock_integration_actions.hurl
+++ b/apps/platform-integration-tests/hurl_specs/bedrock_integration_actions.hurl
@@ -1,5 +1,5 @@
 ###############################################################
-# Tests fetching metadata for and running integration actions
+# Tests invoking bedrock integration actions
 ###############################################################
 
 # Test as a logged-in user so that we don't get redirected to the login page

--- a/apps/platform-integration-tests/hurl_specs/bedrock_integration_actions.hurl
+++ b/apps/platform-integration-tests/hurl_specs/bedrock_integration_actions.hurl
@@ -1,0 +1,31 @@
+###############################################################
+# Tests fetching metadata for and running integration actions
+###############################################################
+
+# Test as a logged-in user so that we don't get redirected to the login page
+POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/uesio/core/mock/login
+{
+    "token": "uesio"
+}
+
+# Invoke the test model -- sanity test
+POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/uesio/tests/dev/integrationactions/run/uesio/aikit/bedrock?action=invokemodel
+{
+    "model": "uesio.test-simple-responder",
+    "messages": [],
+		"system": "",
+		"tools": []
+}
+HTTP 200
+[Asserts]
+```
+Uesio Test Model was invoked with the following options:
+
+{
+  "input": "",
+  "messages": [],
+  "system": "",
+  "model": "uesio.test-simple-responder",
+  "max_tokens_to_sample": 4096
+}
+```

--- a/apps/platform/pkg/controller/integrationaction.go
+++ b/apps/platform/pkg/controller/integrationaction.go
@@ -122,6 +122,9 @@ func RunIntegrationAction(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 		}
+	case string:
+		w.Header().Set("content-type", "text/plain")
+		fmt.Fprint(w, result)
 	default:
 		// Send the response to the client as JSON
 		filejson.RespondJSON(w, r, result)

--- a/apps/platform/pkg/integ/bedrock/invoke.go
+++ b/apps/platform/pkg/integ/bedrock/invoke.go
@@ -3,12 +3,10 @@ package bedrock
 import (
 	"errors"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
 	"github.com/thecloudmasters/uesio/pkg/usage"
 )
 
-func (c *connection) invokeModel(requestOptions map[string]interface{}) (interface{}, error) {
+func (c *Connection) invokeModel(requestOptions map[string]interface{}) (interface{}, error) {
 
 	options, err := hydrateOptions(requestOptions)
 	if err != nil {
@@ -20,24 +18,7 @@ func (c *connection) invokeModel(requestOptions map[string]interface{}) (interfa
 		return nil, errors.New("Model Not Supported: " + options.Model)
 	}
 
-	body, err := handler.GetBody(options)
-	if err != nil {
-		return nil, err
-	}
-
-	input := &bedrockruntime.InvokeModelInput{
-		ModelId:     aws.String(options.Model),
-		Body:        body,
-		ContentType: aws.String("application/json"),
-		Accept:      aws.String("application/json"),
-	}
-
-	output, err := c.client.InvokeModel(c.session.Context(), input, handler.GetClientOptions(input))
-	if err != nil {
-		return nil, handleBedrockError(err)
-	}
-
-	result, inputTokens, outputTokens, err := handler.GetInvokeResult(output.Body)
+	result, inputTokens, outputTokens, err := handler.Invoke(c, options)
 	if err != nil {
 		return nil, handleBedrockError(err)
 	}

--- a/apps/platform/pkg/integ/bedrock/stream.go
+++ b/apps/platform/pkg/integ/bedrock/stream.go
@@ -1,18 +1,7 @@
 package bedrock
 
 import (
-	"context"
 	"errors"
-	"os"
-	"os/signal"
-	"syscall"
-
-	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
-	brtypes "github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
-	"github.com/thecloudmasters/uesio/pkg/integ"
-	"github.com/thecloudmasters/uesio/pkg/types/exceptions"
-	"github.com/thecloudmasters/uesio/pkg/usage"
 )
 
 type MessagesModelStreamOutput struct {
@@ -37,7 +26,7 @@ type MessagesModelStreamOutput struct {
 	Usage *MessagesModelUsage `json:"usage"`
 }
 
-func (c *connection) streamModel(requestOptions map[string]interface{}) (interface{}, error) {
+func (c *Connection) streamModel(requestOptions map[string]interface{}) (interface{}, error) {
 
 	options, err := hydrateOptions(requestOptions)
 	if err != nil {
@@ -49,70 +38,5 @@ func (c *connection) streamModel(requestOptions map[string]interface{}) (interfa
 		return nil, errors.New("Model Not Supported: " + options.Model)
 	}
 
-	body, err := handler.GetBody(options)
-	if err != nil {
-		return nil, err
-	}
-
-	input := &bedrockruntime.InvokeModelWithResponseStreamInput{
-		ModelId:     aws.String(options.Model),
-		Body:        body,
-		ContentType: aws.String("application/json"),
-		Accept:      aws.String("*/*"),
-	}
-
-	output, err := c.client.InvokeModelWithResponseStream(c.session.Context(), input)
-	if err != nil {
-		return nil, handleBedrockError(err)
-	}
-	reader := output.GetStream().Reader
-	eventsChannel := reader.Events()
-	outputStream := integ.NewStream()
-
-	sigTerm := make(chan os.Signal, 1)
-	signal.Notify(sigTerm, syscall.SIGINT, syscall.SIGTERM)
-
-	go (func(ctx context.Context) {
-		defer close(outputStream.Chunk())
-		defer close(outputStream.Err())
-		defer close(outputStream.Done())
-		defer reader.Close()
-	outer:
-		for {
-			select {
-			case e := <-eventsChannel:
-				switch event := e.(type) {
-				case *brtypes.ResponseStreamMemberChunk:
-					result, inputTokens, outputTokens, isDone, err := handler.HandleStreamChunk(event.Value.Bytes)
-					if err != nil {
-						outputStream.Err() <- err
-						break outer
-					}
-					if result != nil {
-						outputStream.Chunk() <- result
-					}
-					if inputTokens > 0 {
-						usage.RegisterEvent("INPUT_TOKENS", "INTEGRATION", c.integration.GetKey(), inputTokens, c.session)
-					}
-					if outputTokens > 0 {
-						usage.RegisterEvent("OUTPUT_TOKENS", "INTEGRATION", c.integration.GetKey(), outputTokens, c.session)
-					}
-					if isDone {
-						outputStream.Done() <- 0
-						break outer
-					}
-				}
-			case <-ctx.Done():
-				outputStream.Err() <- errors.New("request cancelled")
-				break outer
-			}
-			if reader != nil && reader.Err() != nil {
-				outputStream.Err() <- exceptions.NewBadRequestException(reader.Err().Error())
-				break outer
-			}
-		}
-	})(c.session.Context())
-
-	return outputStream, nil
-
+	return handler.Stream(c, options)
 }

--- a/apps/platform/pkg/integ/bedrock/uesiotest.go
+++ b/apps/platform/pkg/integ/bedrock/uesiotest.go
@@ -1,0 +1,27 @@
+package bedrock
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/thecloudmasters/uesio/pkg/integ"
+)
+
+type UesioTestModelHandler struct {
+}
+
+var uesioTestModelHandler = &UesioTestModelHandler{}
+
+func (utmh *UesioTestModelHandler) Invoke(connection *Connection, options *InvokeModelOptions) (result any, inputTokens, outputTokens int64, err error) {
+	body, err := json.MarshalIndent(options, "", "  ")
+	if err != nil {
+		return "", 0, 0, err
+	}
+	content := fmt.Sprintf("Uesio Test Model was invoked with the following options:\n\n%s\n", string(body))
+	return content, 0, 0, nil
+}
+
+func (utmh *UesioTestModelHandler) Stream(connection *Connection, options *InvokeModelOptions) (stream *integ.Stream, err error) {
+	return nil, errors.New("streaming is not supported for the uesio test handler")
+}


### PR DESCRIPTION
# What does this PR do?

1. Simplifies the interface for bedrock model handlers. The now just implement an "Invoke" and "Stream" method.
2. Adds a simple `uesio.test-simple-response` model and handler for testing. (The plan is to create another test model called `uesio.test-anthropic-response` that will respond in the anthropic format in a follow-up PR)
3. Removes some of our default input handling, since bedrock handles that input automatically anyways.

# Testing

1. Test creating a new sitekit app with AI content and image generation.
2. Test creating a new appkit app with AI content.
4. Test adding fields to a collection on the collection detail page.
5. Test the CRM app AI tab to verify it still works.
