### PR TITLE
Adds an ai builder assistant

### DIFF
--- a/libs/apps/uesio/aikit/bundle/componentpacks/main/src/components/agent_chat/agent_chat.tsx
+++ b/libs/apps/uesio/aikit/bundle/componentpacks/main/src/components/agent_chat/agent_chat.tsx
@@ -1,0 +1,228 @@
+import { nanoid } from "@reduxjs/toolkit"
+import {
+  component,
+  styles,
+  definition,
+  signal,
+  api,
+  context,
+  platform,
+} from "@uesio/ui"
+import { useState } from "react"
+
+type AgentBotResponse = {
+  results: unknown
+}
+
+type ToolResultResponse = {
+  type: "tool_result"
+  tool_use_id: string
+  content: string
+}
+
+type AgentChatDefinition = {
+  buttonLabel?: string
+  wire: string
+  agent: string
+  thread: string
+  beforeChatSignals?: signal.SignalDefinition[] | string
+  afterChatSignals?: signal.SignalDefinition[] | string
+}
+
+const REPLACEMENT_TOOL = "str_replace_editor"
+
+const StyleDefaults = Object.freeze({
+  root: [],
+  actions: [],
+  textarea: [],
+})
+
+const mergeAndRunSignals = async (
+  signals: signal.SignalDefinition[] | string | undefined,
+  context: context.Context,
+) => {
+  const signalsToRun =
+    typeof signals === "string"
+      ? (context.merge(signals) as signal.SignalDefinition[])
+      : signals
+  if (signalsToRun) {
+    return await api.signal.runMany(signalsToRun, context)
+  }
+  return context
+}
+
+const newToolUseMessage = (
+  toolId: string,
+  fileName: string,
+  thread: string,
+) => ({
+  "uesio/aikit.author": "ASSISTANT",
+  "uesio/aikit.type": "tool_use",
+  "uesio/aikit.tool_use_id": toolId,
+  "uesio/aikit.tool_name": REPLACEMENT_TOOL,
+  "uesio/aikit.tool_input": {
+    command: "view",
+    path: fileName,
+  },
+  // TODO: Defaults should be respected here...
+  "uesio/aikit.thread": {
+    "uesio/core.id": thread,
+  },
+})
+
+const newToolResultMessage = (
+  toolId: string,
+  fileContent: string,
+  thread: string,
+) => ({
+  "uesio/aikit.author": "USER",
+  "uesio/aikit.type": "tool_result",
+  "uesio/aikit.tool_use_id": toolId,
+  "uesio/aikit.tool_name": REPLACEMENT_TOOL,
+  "uesio/aikit.content": fileContent,
+  // TODO: Defaults should be respected here...
+  "uesio/aikit.thread": {
+    "uesio/core.id": thread,
+  },
+})
+
+const newUserTextMessage = (text: string, thread: string) => ({
+  "uesio/aikit.author": "USER",
+  "uesio/aikit.type": "text",
+  "uesio/aikit.content": text,
+  // TODO: Defaults should be respected here...
+  "uesio/aikit.thread": {
+    "uesio/core.id": thread,
+  },
+})
+
+const AgentChat: definition.UC<AgentChatDefinition> = (props) => {
+  const { definition, context } = props
+  const {
+    buttonLabel = "Ask Agent",
+    wire,
+    beforeChatSignals,
+    afterChatSignals,
+  } = definition
+  const thread = context.mergeString(definition.thread)
+  const agent = context.mergeString(definition.agent)
+  const Button = component.getUtility("uesio/io.button")
+  const Group = component.getUtility("uesio/io.group")
+  const TextArea = component.getUtility("uesio/io.textareafield")
+
+  const classes = styles.useStyleTokens(StyleDefaults, props)
+
+  const [value, setValue] = useState("")
+
+  const handleButtonClick = async () => {
+    let newContext: context.Context = context.removeViewFrame(1)
+    const inputValue = value
+
+    // Run the before chat signals.
+    // The expectation here is that the signals run will add
+    // component data to the context on the component "uesio/aikit.agent_chat"
+    // with the property "content".
+    newContext = await mergeAndRunSignals(beforeChatSignals, newContext)
+
+    // Check to see if any file data was returned
+    const fileContent = newContext.getComponentDataValue<string>(
+      "uesio/aikit.agent_chat",
+      "content",
+    )
+
+    const toolId = "uesio_tool_" + nanoid()
+
+    // TODO: we could actually get the filename as well here.
+    const fileName = `myview_${Date.now()}.yaml`
+
+    const threadWire = context.getWire(wire)
+    if (!threadWire) return
+
+    if (fileContent) {
+      // If file content was provided in the context, create a fake tool
+      // use and tool result message so that the ai model already has this
+      // file data in context.
+      // TODO: we may want to handle this in a more generic way in the future.
+      threadWire.createRecord(newToolUseMessage(toolId, fileName, thread))
+      threadWire.createRecord(newToolResultMessage(toolId, fileContent, thread))
+      await threadWire.save(context)
+    }
+
+    // Add the temporary chat while we go to the server.
+    // This improves the ux so that the users sees their chat message
+    // immediately while waiting for the ai model to respond.
+    threadWire.createRecord(newUserTextMessage(inputValue, thread))
+
+    setValue("")
+
+    // TODO: Implement better error handling here. Also fix the
+    // weird platform.platform thing.
+    const chatResponse = await platform.platform.callBot(
+      context,
+      "uesio/aikit",
+      "runagent",
+      {
+        thread,
+        agent,
+        input: inputValue,
+        // This helps the ai model know which file we're taking about
+        // when we ask for edits.
+        hiddenInputPrefix: "Editing file: " + fileName + "\n\n",
+      },
+    )
+
+    // This removes the temporary chat message before saving the wire
+    threadWire.cancel()
+    await threadWire.load(context)
+
+    const agentResults = chatResponse.params as AgentBotResponse
+
+    if (!agentResults) return
+
+    // Run the after chat signals.
+    // The expectation here is that the signals run will add
+    // component data to the context on the component "uesio/aikit.agent_chat"
+    // with the property "response".
+    newContext = await mergeAndRunSignals(
+      afterChatSignals,
+      newContext.addComponentFrame("uesio/aikit.agent_chat", agentResults),
+    )
+
+    // Read the tool results context and add the response.
+    const response = newContext.getComponentDataValue<ToolResultResponse[]>(
+      "uesio/aikit.agent_chat",
+      "response",
+    )
+
+    if (!response || !response.length) return
+
+    response.forEach((message) => {
+      threadWire.createRecord(
+        newToolResultMessage(message.tool_use_id, message.content, thread),
+      )
+    })
+
+    await threadWire.save(context)
+  }
+
+  return (
+    <div className={classes.root}>
+      <TextArea
+        value={value}
+        setValue={setValue}
+        context={context}
+        classes={{ input: classes.textarea }}
+      />
+      <Group classes={{ root: classes.actions }} context={context}>
+        <Button
+          label={buttonLabel}
+          variant="uesio/appkit.secondary_small"
+          context={context}
+          onClick={handleButtonClick}
+        />
+      </Group>
+    </div>
+  )
+}
+
+export default AgentChat

--- a/libs/apps/uesio/aikit/bundle/components/agent_chat.yaml
+++ b/libs/apps/uesio/aikit/bundle/components/agent_chat.yaml
@@ -1,0 +1,11 @@
+name: agent_chat
+title: Agent Chat
+icon: support_agent
+description: Add a chat to an agent
+category: INTERACTION
+pack: main
+entrypoint: components/agent_chat/agent_chat
+discoverable: false
+properties:
+sections:
+styleRegions:

--- a/libs/apps/uesio/aikit/bundle/permissionsets/agent_user.yaml
+++ b/libs/apps/uesio/aikit/bundle/permissionsets/agent_user.yaml
@@ -1,7 +1,10 @@
 name: agent_user
+bots:
+  uesio/aikit.runagent: true
 files:
   uesio/aikit.anthropic: true
 collections:
+  uesio/core.agent: true
   uesio/aikit.thread: true
   uesio/aikit.thread_item: true
 public: true

--- a/libs/apps/uesio/appkit/bundle/views/agent_thread.yaml
+++ b/libs/apps/uesio/appkit/bundle/views/agent_thread.yaml
@@ -1,0 +1,71 @@
+name: agent_thread
+public: true
+definition:
+  wires:
+    agent:
+      collection: uesio/core.agent
+      conditions:
+        - field: uesio/core.uniquekey
+          value: $Param{agent}
+    threaditems:
+      collection: uesio/aikit.thread_item
+      fields:
+        uesio/aikit.content:
+        uesio/aikit.thread:
+        uesio/aikit.author:
+        uesio/aikit.tool_input:
+        uesio/aikit.tool_use_id:
+        uesio/aikit.tool_name:
+        uesio/aikit.type:
+        uesio/core.createdat:
+        uesio/core.createdby:
+          fields:
+            uesio/core.picture:
+            uesio/core.initials:
+            uesio/core.firstname:
+            uesio/core.lastname:
+            uesio/core.username:
+      conditions:
+        - field: uesio/aikit.thread
+          valueSource: PARAM
+          param: thread_id
+      defaults:
+        - field: uesio/aikit.thread
+          value: $Param{thread_id}
+  components:
+    - uesio/io.scrollpanel:
+        uesio.styleTokens:
+          footer:
+            - pt-2
+        uesio.display:
+          - type: paramIsSet
+            param: thread_id
+        header:
+        content:
+          - uesio/io.deck:
+              wire: threaditems
+              mode: READ
+              id: threaditems
+              uesio.variant: uesio/appkit.tiles
+              components:
+                - uesio/appkit.tile_ai_comment:
+              emptyState:
+                - uesio/io.emptystate:
+                    title: This conversation is empty.
+                    subtitle: ${agent:description}
+                    icon: forum
+                    iconFill: false
+        footer:
+          - uesio/aikit.agent_chat:
+              wire: threaditems
+              agent: $Param{agent}
+              thread: $Param{thread_id}
+              beforeChatSignals: $Param{beforeChatSignals}
+              afterChatSignals: $Param{afterChatSignals}
+  params:
+    agent:
+      type: TEXT
+      required: true
+    thread_id:
+      type: TEXT
+      required: true

--- a/libs/apps/uesio/appkit/bundle/views/agent_threads.yaml
+++ b/libs/apps/uesio/appkit/bundle/views/agent_threads.yaml
@@ -1,0 +1,120 @@
+name: agent_threads
+public: true
+definition:
+  # Wires connect to data in collections
+  wires:
+    threads:
+      collection: uesio/aikit.thread
+      fields:
+        uesio/aikit.title:
+        uesio/aikit.parent:
+      conditions:
+        - field: uesio/core.owner
+          value: $User{id}
+        - field: uesio/aikit.agent
+          value: $Param{agent}
+      defaults:
+        - field: uesio/aikit.agent
+          value: $Param{agent}
+  # Components determine the layout and composition of your view
+  components:
+    - uesio/io.scrollpanel:
+        header:
+          - uesio/io.group:
+              uesio.variant: uesio/appkit.breadcrumbs
+              components:
+                - uesio/appkit.icontile:
+                    tileVariant: uesio/appkit.breadcrumb
+                    title: Threads
+                    icon: forum
+                    signals:
+                      - signal: view/SET_PARAM
+                        param: thread_id
+                        value: ""
+                - uesio/io.item:
+                    uesio.display:
+                      - type: hasValue
+                        value: $Param{thread_id}
+                    external:
+                      collection: uesio/aikit.thread
+                      record: $Param{thread_id}
+                    components:
+                      - uesio/appkit.icontile:
+                          tileVariant: uesio/appkit.breadcrumb
+                          title: $If{[${uesio/aikit.title}][${uesio/aikit.title}][New Conversation]}
+        content:
+          - uesio/io.scrollpanel:
+              uesio.display:
+                - type: paramIsNotSet
+                  param: thread_id
+              content:
+                - uesio/io.deck:
+                    wire: threads
+                    mode: READ
+                    id: threads
+                    uesio.variant: uesio/appkit.tiles
+                    components:
+                      - uesio/appkit.tile_ai_thread:
+                          signals:
+                            - signal: component/CALL
+                              component: uesio/core.view
+                              componentsignal: SET_PARAMS
+                              targettype: specific
+                              componentid: agent_thread
+                              params:
+                                thread_id: ${uesio/core.id}
+                            - signal: view/SET_PARAM
+                              param: thread_id
+                              value: ${uesio/core.id}
+                    emptyState:
+                      - uesio/io.emptystate:
+                          uesio.display:
+                            - type: wireIsNotLoading
+                              wire: threads
+                          title: No Conversations Found
+                          subtitle: You haven't created any ai conversations yet.
+                          icon: forum
+              footer:
+                - uesio/io.box:
+                    components:
+                      - uesio/io.group:
+                          columnGap: 10px
+                          components:
+                            - uesio/io.button:
+                                text: New Conversation
+                                uesio.variant: uesio/appkit.secondary_small
+                                signals:
+                                  - signal: wire/CREATE_RECORD
+                                    stepId: create
+                                    wire: threads
+                                  - signal: wire/SAVE
+                                    wires:
+                                      - threads
+                                  - signal: component/CALL
+                                    component: uesio/core.view
+                                    componentsignal: SET_PARAMS
+                                    targettype: specific
+                                    componentid: agent_thread
+                                    params:
+                                      thread_id: ${uesio/core.id}
+                                  - signal: view/SET_PARAM
+                                    param: thread_id
+                                    value: ${uesio/core.id}
+          - uesio/core.view:
+              uesio.id: agent_thread_$Param{thread_id}
+              uesio.display:
+                - type: paramIsSet
+                  param: thread_id
+              view: agent_thread
+              params:
+                agent: $Param{agent}
+                thread_id: $Param{thread_id}
+                beforeChatSignals: $Param{beforeChatSignals}
+                afterChatSignals: $Param{afterChatSignals}
+        uesio.variant: uesio/appkit.sidebar
+  params:
+    agent:
+      type: TEXT
+      required: true
+    thread_id:
+      type: TEXT

--- a/libs/apps/uesio/builder/bundle/componentpacks/main/src/components/mainwrapper/chatpanel.tsx
+++ b/libs/apps/uesio/builder/bundle/componentpacks/main/src/components/mainwrapper/chatpanel.tsx
@@ -43,11 +43,28 @@ const ChatPanel: definition.UtilityComponent = (props) => {
       className={classes.root}
     >
       <component.Component
-        componentType="uesio/io.emptystate"
+        componentType="uesio/core.view"
         definition={{
-          title: "Not Implemented yet.",
-          subtitle: "The AI Chat feature is coming soon.",
-          icon: "construction",
+          view: "uesio/appkit.agent_threads",
+          "uesio.id": "builderAgent",
+          params: {
+            agent: "uesio/studio.viewbuilder",
+            thread_id: "",
+            beforeChatSignals: [
+              {
+                signal: "component/CALL",
+                component: "uesio/builder.mainwrapper",
+                componentsignal: "GET_SELECTED_CONTENT",
+              },
+            ],
+            afterChatSignals: [
+              {
+                signal: "component/CALL",
+                component: "uesio/builder.mainwrapper",
+                componentsignal: "HANDLE_EDITS",
+              },
+            ],
+          },
         }}
         path={""}
         context={context}

--- a/libs/apps/uesio/builder/bundle/componentpacks/main/src/components/mainwrapper/editortool.tsx
+++ b/libs/apps/uesio/builder/bundle/componentpacks/main/src/components/mainwrapper/editortool.tsx
@@ -1,0 +1,159 @@
+import { signal, context } from "@uesio/ui"
+import { getContent, setContent } from "../../api/defapi"
+import { getSelectedViewPath } from "../../api/stateapi"
+
+type TextResponse = {
+  type: "text"
+  text: string
+}
+
+type ToolUseResponse = {
+  type: "tool_use"
+  id: string
+  name: string
+  input: EditorCommand
+}
+
+type ToolResultResponse = {
+  type: "tool_result"
+  tool_use_id: string
+  content: string
+}
+
+type ReplaceCommand = {
+  command: "str_replace"
+  path: string
+  old_str: string
+  new_str: string
+}
+
+type InsertCommand = {
+  command: "insert"
+  path: string
+  insert_line: number
+  new_str: string
+}
+
+type EditorCommand = ReplaceCommand | InsertCommand
+
+type AnthropicResponse = TextResponse | ToolUseResponse | ToolResultResponse
+
+const handleReplaceCommand = (
+  context: context.Context,
+  message: ToolUseResponse,
+  command: ReplaceCommand,
+): ToolResultResponse => {
+  const selectedPath = getSelectedViewPath(
+    context.removeViewFrame(1).removeViewFrame(1),
+  )
+  const content = getContent(context, selectedPath)
+
+  if (!content) {
+    return {
+      type: "tool_result",
+      tool_use_id: message.id,
+      content: "Failed: Nothing to edit.",
+    }
+  }
+
+  // Find first occurrence
+  const firstIndex = content.indexOf(command.old_str)
+  if (firstIndex === -1) {
+    return {
+      type: "tool_result",
+      tool_use_id: message.id,
+      content: "Failed: Uh oh. Looks like that string wasn't found.",
+    }
+  }
+
+  // Find last occurrence
+  const lastIndex = content.lastIndexOf(command.old_str)
+
+  // If first and last indices differ, there must be multiple occurrences
+  if (firstIndex !== lastIndex) {
+    return {
+      type: "tool_result",
+      tool_use_id: message.id,
+      content:
+        "Failed: Uh oh. Looks like there are multiple instances of that string.",
+    }
+  }
+
+  const newContent = content.replace(command.old_str, command.new_str)
+  setContent(context, selectedPath, newContent)
+  return {
+    type: "tool_result",
+    tool_use_id: message.id,
+    content:
+      "Success! The file has been updated. Please ignore any old versions of this file and only use updated versions.",
+  }
+}
+
+const handleReplaceEditor = (
+  context: context.Context,
+  message: ToolUseResponse,
+): ToolResultResponse => {
+  const command = message.input
+  if (command.command === "str_replace") {
+    return handleReplaceCommand(context, message, command)
+  }
+
+  return {
+    type: "tool_result",
+    tool_use_id: message.id,
+    content: "Failed: Command not supported: " + command.command,
+  }
+}
+
+const handleMessage = (
+  context: context.Context,
+  message: ToolUseResponse,
+): ToolResultResponse => {
+  if (message.name === "str_replace_editor") {
+    return handleReplaceEditor(context, message)
+  }
+
+  return {
+    type: "tool_result",
+    tool_use_id: message.id,
+    content: "Failed: Tool not supported: " + message.name,
+  }
+}
+
+const getSelectedContentDispatcher: signal.ComponentSignalDispatcher<
+  unknown
+> = (state, payload, context) => {
+  const selectedPath = getSelectedViewPath(context.removeViewFrame(1))
+  const content = getContent(context, selectedPath)
+  return context.addComponentFrame("uesio/aikit.agent_chat", {
+    content,
+  })
+}
+
+const handleEditsDispatcher: signal.ComponentSignalDispatcher<unknown> = (
+  state,
+  payload,
+  context,
+) => {
+  const results = context.getComponentData("uesio/aikit.agent_chat")
+
+  const messages = results.data.results as AnthropicResponse[]
+
+  if (!messages) return
+
+  const selectedPath = getSelectedViewPath(
+    context.removeViewFrame(1).removeViewFrame(1),
+  )
+  const content = getContent(context, selectedPath)
+  if (!content) return
+  const response = messages
+    .filter((message) => message.type === "tool_use")
+    .map((message) => {
+      return handleMessage(context, message)
+    })
+  return context.addComponentFrame("uesio/aikit.agent_chat", {
+    response,
+  })
+}
+
+export { getSelectedContentDispatcher, handleEditsDispatcher }

--- a/libs/apps/uesio/builder/bundle/componentpacks/main/src/components/mainwrapper/mainwrapper.tsx
+++ b/libs/apps/uesio/builder/bundle/componentpacks/main/src/components/mainwrapper/mainwrapper.tsx
@@ -15,6 +15,10 @@ import { toggleBuildMode } from "../../helpers/buildmode"
 import BuildBar from "./buildbar/buildbar"
 import { ReactNode } from "react"
 import AdjustableHeightArea from "../../utilities/adjustableheightarea/adjustableheightarea"
+import {
+  getSelectedContentDispatcher,
+  handleEditsDispatcher,
+} from "./editortool"
 
 const StyleDefaults = Object.freeze({
   root: ["h-full", "grid-cols-[1fr]", "auto-cols-auto", "grid-rows-[100%]"],
@@ -175,6 +179,12 @@ MainWrapper.signals = {
   SET_DIMENSIONS: {
     dispatcher: (state, payload) => [payload.width, payload.height],
     target: "dimensions",
+  },
+  GET_SELECTED_CONTENT: {
+    dispatcher: getSelectedContentDispatcher,
+  },
+  HANDLE_EDITS: {
+    dispatcher: handleEditsDispatcher,
   },
 }
 

--- a/libs/apps/uesio/studio/bundle/agents/viewbuilder/agent.yaml
+++ b/libs/apps/uesio/studio/bundle/agents/viewbuilder/agent.yaml
@@ -1,0 +1,7 @@
+name: viewbuilder
+label: View Builder
+description: An AI assistant to help with building views.
+tools:
+  - name: str_replace_editor
+    type: text_editor_20241022
+public: true

--- a/libs/apps/uesio/studio/bundle/agents/viewbuilder/prompt.txt
+++ b/libs/apps/uesio/studio/bundle/agents/viewbuilder/prompt.txt
@@ -1,0 +1,40 @@
+You are a ues.io view builder assistant.
+You are an expert in yaml and tailwind v3.
+You can edit yaml documents in the ues.io format.
+
+ues.io is a declarative application development platform that takes yaml
+documents called "Views" and creates web applications out them using its runtime.
+
+A ues.io view contains two main sections, a "wires" section and a "components" section.
+
+Many elements in ues.io are referenced by a three-part key that fully identifies them.
+The format is <username>/<appname>.<itemname> for example, myorg/myapp.myitem would
+be a key for a metadata item.
+
+Wires specify the connections to data that are available in the view.
+
+Components specify the tree of components that make up the view.
+
+Here is an example ues.io view format.
+
+wires:
+  wire1:
+    collection: myorg/myapp.mycollection
+components:
+  - uesio/io.box:
+      uesio.variant: uesio/io.default
+      uesio.styleTokens:
+        root:
+          - bg-green-500
+      components:
+        - uesio/io.text:
+            text: Hello World
+
+This view displays a box with a green background and the text inside it "Hello World".
+
+There are some properties on components that exist for every component. These are called standard ues.io properties.
+The uesio.variant property specifies the particular variant of that component. Variants typically contain styles for the regions of that component that will be merged at runtime according to the definition of the variant. This property is not required.
+The uesio.styleTokens property is for adding additional styles to regions of the component. Each property of the uesio.styleTokens node specifies a region of the component. The most common (and typically default) region of a component is called "root". Inside each region is a sequence of tailwind tokens specifying inline styles for that region. This property is not required.
+
+You will be asked to help with a specific view that is different from the example, but in the
+same general format.

--- a/libs/apps/uesio/studio/bundle/permissionsets/standard.yaml
+++ b/libs/apps/uesio/studio/bundle/permissionsets/standard.yaml
@@ -19,6 +19,8 @@ bots:
   uesio/studio.select_plan: true
 views:
   uesio/appkit.user_detail_content: true
+  uesio/appkit.agent_thread: true
+  uesio/appkit.agent_threads: true
   uesio/studio.agent: true
   uesio/studio.agents: true
   uesio/studio.app: true

--- a/libs/ui/src/definition/signal.ts
+++ b/libs/ui/src/definition/signal.ts
@@ -44,4 +44,9 @@ type SignalDefinition = {
   }
 }
 
-export type { SignalDefinition, SignalDescriptor, ComponentSignalDescriptor }
+export type {
+  SignalDefinition,
+  SignalDescriptor,
+  ComponentSignalDescriptor,
+  ComponentSignalDispatcher,
+}

--- a/libs/ui/src/signalexports.ts
+++ b/libs/ui/src/signalexports.ts
@@ -1,6 +1,7 @@
 import {
   SignalDefinition,
   ComponentSignalDescriptor,
+  ComponentSignalDispatcher,
   SignalDescriptor,
 } from "./definition/signal"
 
@@ -12,4 +13,9 @@ import {
 
 export { getSignals, getSignal, getComponentSignalDefinition }
 
-export type { ComponentSignalDescriptor, SignalDefinition, SignalDescriptor }
+export type {
+  ComponentSignalDescriptor,
+  ComponentSignalDispatcher,
+  SignalDefinition,
+  SignalDescriptor,
+}


### PR DESCRIPTION
# What does this PR do?

Adds an AI assistant chat panel to the builder.

NOTE: This is just a prototype. The assistant does not know about most of your app metadata. It can only take clues from what's already on the page, and the simple example in the system prompt.

This could be MASSIVELY improved by a better system prompt and bringing collection and component metadata into context.

The best use cases at the moment are
1. Adding/adjusting styles on existing components.
2. Changing existing properties or text.

At the moment, you will probably get the best results with an existing view, where the uesio view format can be inferred from that. I have not tested this with a brand new view, and will probably not work as well until we improve the system prompt and add in the available components and variants.
