### PR TITLE
chore: workaround for gh required status checks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,12 +19,9 @@ on:
         type: string
   push:
     branches: [main]
-    paths-ignore: [".vscode/**", "docs/**", "**/README.md", "LICENSE.md", ".github/**.md"]
   merge_group:
   pull_request:
     branches: [main]
-    # Note - Ignore is not commit specific, if any file in the PR is outside of this list, workflow will run, see https://github.com/orgs/community/discussions/25161#discussioncomment-3246673
-    paths-ignore: [".vscode/**", "docs/**", "**/README.md", "LICENSE.md", ".github/**.md"]
 
 # Automatically cancel in-progress actions on the same branch except for main
 concurrency:
@@ -36,9 +33,40 @@ env:
   DOCKER_LOGS_FOLDER: ./docker-logs
 
 jobs:
+  # This job is used to check if any files that have changed require the full workflow to run. It is used instead
+  # of the `paths-ignore` filter in the workflow "on" trigger due to the required status checks configured
+  # for the ci workflow in the repo Rulesets. Github actions leaves required status check in "pending" state
+  # when the entire workflow is skipped. Given this, a PR that requites the checks is not mergeable without bypassing
+  # the required checks which requires the ruleset to have admins configured to allow bypass which is not ideal. Using
+  # the approach below, the check-changes jobs will always run and all other jobs depend on "check-changes" job and
+  # should condition on the result using "if: ${{ needs.check-changes.outputs.run_job == 'true' }}".
+  # IMPORTANT: All other jobs in this workflow should condition on this job per the above information.
+  # See
+  #   - https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks).
+  #   - https://github.com/orgs/community/discussions/13690
+  #   - https://github.com/orgs/community/discussions/44490
+  #   - https://github.com/github/docs/issues/8926
+  #   - https://github.com/actions/runner/issues/2566
+  check-changes:
+    name: Check for file changes
+    runs-on: ubuntu-latest
+    outputs:
+      run_job: ${{ steps.filter.outputs.run_job }}
+    steps:
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          # Note - For PRs, the check is not commit specific, if any file in the PR is outside of this list run_job will be true. Identical behavior to https://github.com/orgs/community/discussions/25161#discussioncomment-3246673.
+          predicate-quantifier: "every"
+          list-files: "json"
+          filters: |
+            run_job: ["!.vscode/**", "!docs/**", "!**/README.md", "!LICENSE.md", "!.github/**.md"]
+
   build:
     name: Build and test
     runs-on: ubuntu-latest
+    if: ${{ needs.check-changes.outputs.run_job == 'true' }}
+    needs: [check-changes]
     outputs:
       image_sha: ${{ steps.setDockerSHAs.outputs.image_sha }}
       image_version: ${{ steps.setDockerSHAs.outputs.image_version }}
@@ -197,6 +225,8 @@ jobs:
   check:
     name: Check format and lint
     runs-on: ubuntu-latest
+    if: ${{ needs.check-changes.outputs.run_job == 'true' }}
+    needs: [check-changes]
     timeout-minutes: 5
     steps:
       - name: Checkout
@@ -256,6 +286,8 @@ jobs:
   typecheck:
     name: Check types
     runs-on: ubuntu-latest
+    if: ${{ needs.check-changes.outputs.run_job == 'true' }}
+    needs: [check-changes]
     timeout-minutes: 5
     steps:
       - name: Checkout
@@ -286,9 +318,9 @@ jobs:
 
   update-dev-branch:
     name: Update Dev environment to latest image
-    if: github.ref_name == 'main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
-    needs: [build, check, typecheck]
+    if: github.ref_name == 'main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && ${{ needs.check-changes.outputs.run_job == 'true' }}
+    needs: [build, check, typecheck, check-changes]
     timeout-minutes: 3
     permissions:
       id-token: write # This is required for requesting a OIDC JWT for AWS

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -319,7 +319,7 @@ jobs:
   update-dev-branch:
     name: Update Dev environment to latest image
     runs-on: ubuntu-latest
-    if: github.ref_name == 'main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && ${{ needs.check-changes.outputs.run_job == 'true' }}
+    if: ${{ github.ref_name == 'main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && needs.check-changes.outputs.run_job == 'true' }}
     needs: [build, check, typecheck, check-changes]
     timeout-minutes: 3
     permissions:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,6 +47,8 @@ jobs:
   #   - https://github.com/orgs/community/discussions/44490
   #   - https://github.com/github/docs/issues/8926
   #   - https://github.com/actions/runner/issues/2566
+  # NOTE: There is a benign bug in dorny/paths-filter@v3 that will result in the following warning in the logs - see https://github.com/dorny/paths-filter/issues/225
+  #   "Unexpected input(s) 'predicate-quantifier', valid inputs are ['token', 'working-directory', 'ref', 'base', 'filters', 'list-files', 'initial-fetch-depth']"
   check-changes:
     name: Check for file changes
     runs-on: ubuntu-latest


### PR DESCRIPTION
# What does this PR do?

The `main` branch is protected by rulesets that require status checks (e.g., build_and_test, format, lint), however the `ci` workflow has `paths-ignore` meaning that the workflow won't run if only certain files have changed.  The issue is that GH required status checks are still required but the workflow will never run. 

This PR works around this limitation in GH using the following approach:

1. Defines a `check_changes` job that checks which files have changed and sets an output variable `run_job` to true if any files outside of the `ignore` list have changed
2. Conditions all other jobs to only run when `run_job == true`

In this situation, the job will be skipped and the result will be "succeeded" thereby satisfying the required status check and allowing the ruleset to not require the ability for admins to "bypass" the rule.  The bypass was required previously because the required status checks would never complete due to the `paths-ignore` and the way GH handles required status checks.

Full Details
```yaml
  # This job is used to check if any files that have changed require the full workflow to run. It is used instead
  # of the `paths-ignore` filter in the workflow "on" trigger due to the required status checks configured
  # for the ci workflow in the repo Rulesets. Github actions leaves required status check in "pending" state
  # when the entire workflow is skipped. Given this, a PR that requites the checks is not mergeable without bypassing
  # the required checks which requires the ruleset to have admins configured to allow bypass which is not ideal. Using
  # the approach below, the check-changes jobs will always run and all other jobs depend on "check-changes" job and
  # should condition on the result using "if: ${{ needs.check-changes.outputs.run_job == 'true' }}".
  # IMPORTANT: All other jobs in this workflow should condition on this job per the above information.
  # See
  #   - https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks).
  #   - https://github.com/orgs/community/discussions/13690
  #   - https://github.com/orgs/community/discussions/44490
  #   - https://github.com/github/docs/issues/8926
  #   - https://github.com/actions/runner/issues/2566
```

# Testing

ci itself will be the test.
