### PR TITLE
fix: ensure generated password meets requirements

### DIFF
--- a/apps/platform/pkg/auth/platform/platform.go
+++ b/apps/platform/pkg/auth/platform/platform.go
@@ -64,9 +64,6 @@ var tests = []PasswordTest{
 const PasswordPolicyAllowedSymbols = `~!@#$%^&*()_+={}|[]\:"<>?,./` + "`-"
 const PasswordPolicySimplifiedSymbols = `!@#$%^&*(){}[]` // should be a subset of PasswordPolicyAllowedSymbols
 
-func PP(password string) error {
-	return passwordPolicyValidation(password)
-}
 func passwordPolicyValidation(password string) error {
 	for _, test := range tests {
 		if t, err := regexp.MatchString(test.test, password); err != nil {

--- a/apps/platform/pkg/auth/platform/platform_test.go
+++ b/apps/platform/pkg/auth/platform/platform_test.go
@@ -1,0 +1,64 @@
+package platform
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_passwordPolicyValidation(t *testing.T) {
+	tests := []struct {
+		name     string
+		password string
+		expected error
+	}{
+		{
+			name:     "Valid Password",
+			password: "ValidPassword123!",
+			expected: nil,
+		},
+		{
+			name:     "Invalid Password - Too Short",
+			password: "Short1!",
+			expected: fmt.Errorf("at least 8 characters"),
+		},
+		{
+			name:     "Invalid Password - No Uppercase",
+			password: "invalidpassword123!",
+			expected: fmt.Errorf("at least 1 upper case"),
+		},
+		{
+			name:     "Invalid Password - No Lowercase",
+			password: "INVALIDPASSWORD123!",
+			expected: fmt.Errorf("at least 1 lower case"),
+		},
+		{
+			name:     "Invalid Password - No special character",
+			password: "ValidPassword123",
+			expected: fmt.Errorf("at least 1 special character"),
+		},
+		{
+			name:     "Invalid Password - Invalid special character (space)",
+			password: "Valid Password123",
+			expected: fmt.Errorf("at least 1 special character"),
+		},
+		{
+			name:     "Invalid Password - No number",
+			password: "ValidPassword!",
+			expected: fmt.Errorf("at least 1 number"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := passwordPolicyValidation(tt.password)
+			if tt.expected != nil {
+				assert.ErrorContains(t, result, tt.expected.Error())
+			} else {
+				assert.Nil(t, result)
+			}
+
+		})
+	}
+}


### PR DESCRIPTION
# What does this PR do?

1. Ensures that generated password during site creation meets requirements of password policy
2. handles generation errors that occur during password generation (validation of the password handling remains the same)
3. Properly enforces the special character requirement in the policy - previously it would accept anything that wasn't a digit/letter/underscore/hyphen as a valid special character (e.g., it would allow a ` ` (space)).

Resolves #4768 

# Testing

Tested manually and added some password unit tests.
