### PR TITLE
chore: decrease dns lookup timeout

### DIFF
--- a/apps/platform/pkg/controller/server.go
+++ b/apps/platform/pkg/controller/server.go
@@ -33,6 +33,11 @@ func GetGracefulShutdownSeconds() int {
 
 func NewServer(serveAddress string, router http.Handler) *ServerWithShutdown {
 	return &ServerWithShutdown{
+		// TODO: Evaluate timeouts here (e.g., ReadTimeout, WriteTimeout, etc.). The default and what
+		// we currently use is 0 (no timeout) which could lead to a client taking a connection forever
+		// which could result in running out of file descriptors.
+		// See https://blog.cloudflare.com/the-complete-guide-to-golang-net-http-timeouts/ &
+		// https://blog.cloudflare.com/exposing-go-on-the-internet/ & https://simon-frey.com/blog/go-as-in-golang-standard-net-http-config-will-break-your-production/
 		Server: http.Server{
 			Addr:    serveAddress,
 			Handler: router,

--- a/apps/platform/pkg/http/localhostclient.go
+++ b/apps/platform/pkg/http/localhostclient.go
@@ -35,7 +35,7 @@ func createCustomTransport() *http.Transport {
 	return &http.Transport{
 		Proxy: defaultTransport.Proxy, // http.ProxyFromEnvironment
 		DialContext: customDialContext(&net.Dialer{
-			Timeout:   30 * time.Second, // same as DefaultTransport
+			Timeout:   5 * time.Second,  // DefaultTransport is 30 * time.Second
 			KeepAlive: 30 * time.Second, // same as DefaultTransport
 		}), // Custom resolver for localhost
 		ForceAttemptHTTP2:     defaultTransport.ForceAttemptHTTP2,     // true


### PR DESCRIPTION
# What does this PR do?

Decreases dns lookup timeout from the default of 30 seconds to 5 seconds.  This needs to be monitored and can be adjusted but 5 seconds should be more than adequate for most situations.

# Testing

tested manually and confirmed the 5 second limit.
