### PR TITLE
fix: signal properties is an array in yaml

### DIFF
--- a/libs/apps/uesio/builder/bundle/componentpacks/main/src/api/signalsapi.ts
+++ b/libs/apps/uesio/builder/bundle/componentpacks/main/src/api/signalsapi.ts
@@ -43,7 +43,7 @@ type SignalDescriptor = {
   properties: (
     signal: signal.SignalDefinition,
     context: context.Context,
-  ) => ComponentProperty[]
+  ) => ComponentProperty[] | ComponentProperty[]
   outputs?: SignalOutput[]
   canError?: boolean
   disabled?: boolean

--- a/libs/apps/uesio/builder/bundle/componentpacks/main/src/signals/component.ts
+++ b/libs/apps/uesio/builder/bundle/componentpacks/main/src/signals/component.ts
@@ -1,4 +1,4 @@
-import { context, wire, signal, component } from "@uesio/ui"
+import { context, wire, signal } from "@uesio/ui"
 import { SignalBandDefinition } from "../api/signalsapi"
 
 import {
@@ -155,7 +155,7 @@ const signals: SignalBandDefinition = {
           const signalDescriptor = getComponentDef(signal.component)?.signals?.[
             signal.componentsignal
           ]
-          if (signalDescriptor && signalDescriptor.properties){
+          if (signalDescriptor && signalDescriptor.properties) {
             if (typeof signalDescriptor.properties === "function") {
               return baseProperties.concat(
                 signalDescriptor.properties(signal, context),

--- a/libs/apps/uesio/builder/bundle/componentpacks/main/src/signals/component.ts
+++ b/libs/apps/uesio/builder/bundle/componentpacks/main/src/signals/component.ts
@@ -1,4 +1,4 @@
-import { context, wire, signal } from "@uesio/ui"
+import { context, wire, signal, component } from "@uesio/ui"
 import { SignalBandDefinition } from "../api/signalsapi"
 
 import {
@@ -152,13 +152,17 @@ const signals: SignalBandDefinition = {
 
         // Append signal-specific properties, if there are any
         if (signal.component && signal.componentsignal) {
-          const componentDef = getComponentDef(signal.component)?.signals?.[
+          const signalDescriptor = getComponentDef(signal.component)?.signals?.[
             signal.componentsignal
           ]
-          if (componentDef && componentDef.properties) {
-            return baseProperties.concat(
-              componentDef.properties(signal, context),
-            )
+          if (signalDescriptor && signalDescriptor.properties){
+            if (typeof signalDescriptor.properties === "function") {
+              return baseProperties.concat(
+                signalDescriptor.properties(signal, context),
+              )
+            } else {
+              return baseProperties.concat(signalDescriptor.properties)
+            }
           }
         }
 


### PR DESCRIPTION
# What does this PR do?

Fixes an issue where signal properties were not being evaluated/incorporated properly when coming from yaml.

When choosing "Run a component signal" in the builder and then choosing the signal from the component, the following error would occur:

Steps to reproduce:
1. Create view
2. Add button
3. Choose Signals tab
4. Add new signal
5. Choose `Run Component Signal`
6. Select `Tabs`
7. Select `Select Tab` for `Component Signal`

![image](https://github.com/user-attachments/assets/54005e0c-aad5-4189-8180-99944f6f79f9)

# Testing

Tested manually, signals are read and run when called.  ci & e2e will cover rest.
