### PR TITLE
chore: mark go format & lint tasks cacheable

### DIFF
--- a/apps/cli/project.json
+++ b/apps/cli/project.json
@@ -37,7 +37,8 @@
         "command": "gofmt -l -w -s -e .",
         "cwd": "{projectRoot}"
       },
-      "inputs": ["golang", "default", "^production", "sharedGlobals"]
+      "inputs": ["golang", "default", "^production", "sharedGlobals"],
+      "cache": true
     },
     "gofmt:check": {
       "executor": "nx:run-commands",
@@ -45,7 +46,8 @@
         "command": "output=\"$(gofmt -d -e .)\" && echo \"$output\" && test -z \"$output\"",
         "cwd": "{projectRoot}"
       },
-      "inputs": ["golang", "default", "^production", "sharedGlobals"]
+      "inputs": ["golang", "default", "^production", "sharedGlobals"],
+      "cache": true
     },
     "lint": {
       "dependsOn": ["vet"]
@@ -56,7 +58,8 @@
         "command": "go mod tidy",
         "cwd": "{projectRoot}"
       },
-      "inputs": ["golang", "default", "^production", "sharedGlobals"]
+      "inputs": ["golang", "default", "^production", "sharedGlobals"],
+      "cache": true
     },
     "tidy:check": {
       "executor": "nx:run-commands",
@@ -64,7 +67,8 @@
         "command": "go mod tidy -diff",
         "cwd": "{projectRoot}"
       },
-      "inputs": ["golang", "default", "^production", "sharedGlobals"]
+      "inputs": ["golang", "default", "^production", "sharedGlobals"],
+      "cache": true
     },
     "vet": {
       "executor": "nx:run-commands",
@@ -72,7 +76,8 @@
         "command": "go vet ./...",
         "cwd": "{projectRoot}"
       },
-      "inputs": ["golang", "default", "^production", "sharedGlobals"]
+      "inputs": ["golang", "default", "^production", "sharedGlobals"],
+      "cache": true
     }
   },
   "tags": [],

--- a/apps/platform/project.json
+++ b/apps/platform/project.json
@@ -29,7 +29,8 @@
         "command": "gofmt -l -w -s -e .",
         "cwd": "{projectRoot}"
       },
-      "inputs": ["golang", "default", "^production", "sharedGlobals"]
+      "inputs": ["golang", "default", "^production", "sharedGlobals"],
+      "cache": true
     },
     "gofmt:check": {
       "executor": "nx:run-commands",
@@ -37,7 +38,8 @@
         "command": "output=\"$(gofmt -d -e .)\" && echo \"$output\" && test -z \"$output\"",
         "cwd": "{projectRoot}"
       },
-      "inputs": ["golang", "default", "^production", "sharedGlobals"]
+      "inputs": ["golang", "default", "^production", "sharedGlobals"],
+      "cache": true
     },
     "lint": {
       "dependsOn": ["vet"]
@@ -105,7 +107,8 @@
         "command": "go mod tidy",
         "cwd": "{projectRoot}"
       },
-      "inputs": ["golang", "default", "^production", "sharedGlobals"]
+      "inputs": ["golang", "default", "^production", "sharedGlobals"],
+      "cache": true
     },
     "tidy:check": {
       "executor": "nx:run-commands",
@@ -113,7 +116,8 @@
         "command": "go mod tidy -diff",
         "cwd": "{projectRoot}"
       },
-      "inputs": ["golang", "default", "^production", "sharedGlobals"]
+      "inputs": ["golang", "default", "^production", "sharedGlobals"],
+      "cache": true
     },
     "vet": {
       "executor": "nx:run-commands",
@@ -121,7 +125,8 @@
         "command": "go vet ./...",
         "cwd": "{projectRoot}"
       },
-      "inputs": ["golang", "default", "^production", "sharedGlobals"]
+      "inputs": ["golang", "default", "^production", "sharedGlobals"],
+      "cache": true
     },
     "watch-deps": {
       "executor": "nx:run-commands",


### PR DESCRIPTION
# What does this PR do?

go project format/vet/tidy tasks should be cacheable.

# Testing

Tested manually.
