### PR TITLE
fix: preview mode loses "in-progress" changes on view

### DIFF
--- a/libs/apps/uesio/builder/bundle/componentpacks/main/src/components/mainwrapper/buildbar/buildbar_tools.tsx
+++ b/libs/apps/uesio/builder/bundle/componentpacks/main/src/components/mainwrapper/buildbar/buildbar_tools.tsx
@@ -59,7 +59,7 @@ const BuildBarTools: definition.UtilityComponent<Props> = (props) => {
     },
   ]
 
-  const baseContext = context.removeViewFrame(1)
+  const baseContext = context.getRouteContext()
 
   const toggleCode = api.signal.getHandler(
     [

--- a/libs/apps/uesio/builder/bundle/componentpacks/main/src/helpers/buildmode.ts
+++ b/libs/apps/uesio/builder/bundle/componentpacks/main/src/helpers/buildmode.ts
@@ -1,4 +1,5 @@
 import { api, context } from "@uesio/ui"
+import { getBuilderExternalState } from "../api/stateapi"
 
 const editPath = "/edit"
 const previewPath = "/preview"
@@ -38,15 +39,18 @@ const swapEditAndPreviewMode = (ctx: context.Context, buildMode: boolean) => {
   document.title = title
 }
 
-const toggleBuildMode = (
+const toggleBuildMode = async (
   ctx: context.Context,
   setBuildMode: (state: boolean) => void,
   buildMode: boolean,
 ) => {
-  api.builder.getBuilderDeps(ctx).then(() => {
-    swapEditAndPreviewMode(ctx, !!buildMode)
-    setBuildMode(!buildMode)
-  })
+  // check if we've already loaded the builder dependencies
+  const isLoaded = !!getBuilderExternalState(ctx, "namespaces")
+  if (!isLoaded) {
+    await api.builder.getBuilderDeps(ctx)
+  }
+  swapEditAndPreviewMode(ctx, !!buildMode)
+  setBuildMode(!buildMode)
 }
 
 export { toggleBuildMode }

--- a/libs/ui/src/hooks/builderapi.ts
+++ b/libs/ui/src/hooks/builderapi.ts
@@ -1,12 +1,10 @@
 import { Context } from "../context/context"
-import * as api from "../api/api"
 
 import { MetadataType } from "../metadata/types"
 import { platform } from "../platform/platform"
 import usePlatformFunc from "./useplatformfunc"
 import { dispatchRouteDeps } from "../bands/route/utils"
 import { loadScripts } from "./usescripts"
-import { makeComponentId } from "./componentapi"
 
 const useMetadataList = (
   context: Context,

--- a/libs/ui/src/hooks/builderapi.ts
+++ b/libs/ui/src/hooks/builderapi.ts
@@ -29,17 +29,6 @@ const useAvailableNamespaces = (
   )
 
 const getBuilderDeps = async (context: Context) => {
-  const workspace = context.getWorkspace()
-  if (!workspace || !workspace.wrapper) return
-
-  const namespaces = api.component.getExternalState(
-    makeComponentId(context, workspace?.wrapper, "namespaces"),
-  )
-
-  const isLoaded = !!namespaces
-
-  if (isLoaded) return
-
   const response = await platform.getBuilderDeps(context)
 
   await loadScripts(response.componentpack, context)


### PR DESCRIPTION
# What does this PR do?

Fixes issue where toggling to "preview" mode in the builder was losing any "in-progress" changes.  This appears to be a regression that was introduced in the work recently completed on the new "builder bar".

Resolves #4816 

# Testing

Manually tested all options in build bar and ensured that in-progress changes are maintained when toggling between "Preview/Build" modes.
