### PR TITLE
chore: convert buffer directly to string

### DIFF
--- a/apps/platform/pkg/bot/jsdialect/apihelpers.go
+++ b/apps/platform/pkg/bot/jsdialect/apihelpers.go
@@ -154,7 +154,7 @@ func getFileContents(sourceKey, sourcePath string, session *sess.Session, connec
 	if err != nil {
 		return "", err
 	}
-	return string(buf.Bytes()), nil
+	return buf.String(), nil
 }
 
 func getHostUrl(session *sess.Session, connection wire.Connection) (string, error) {

--- a/apps/platform/pkg/bot/jsdialect/generatorbot.go
+++ b/apps/platform/pkg/bot/jsdialect/generatorbot.go
@@ -297,7 +297,7 @@ func (gba *GeneratorBotAPI) GetTemplate(templateFile string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return string(buf.Bytes()), nil
+	return buf.String(), nil
 }
 
 func (gba *GeneratorBotAPI) MergeYamlString(params map[string]interface{}, templateString string) (string, error) {

--- a/apps/platform/pkg/bot/tsdialect/tsdialect.go
+++ b/apps/platform/pkg/bot/tsdialect/tsdialect.go
@@ -27,7 +27,7 @@ func (b *TSDialect) hydrateBot(bot *meta.Bot, session *sess.Session, connection 
 		return err
 	}
 	// Transform from TS to JS
-	result := esbuild.Transform(string(buf.Bytes()), esbuild.TransformOptions{
+	result := esbuild.Transform(buf.String(), esbuild.TransformOptions{
 		Loader: esbuild.LoaderTS,
 	})
 	if len(result.Errors) > 0 {


### PR DESCRIPTION
# What does this PR do?

1. uses `buf.String()` instead of `string(buf.Bytes())`

This is part of a series of changes to get us inline with golangci-lint rules.