### PR TITLE
Refactor: Remove recordid option from create record

### DIFF
--- a/libs/apps/uesio/studio/bundle/componentpacks/main/src/components/multipermissionpicker/multipermissionpicker.tsx
+++ b/libs/apps/uesio/studio/bundle/componentpacks/main/src/components/multipermissionpicker/multipermissionpicker.tsx
@@ -103,7 +103,10 @@ const MultiPermissionPicker: definition.UC<MultiPermissionPickerDefinition> = (
     field: string,
     value: boolean,
     recordId: string,
+    record: wire.WireRecord,
   ) => {
+    const idValue = record.getIdFieldValue()
+    if (!idValue) return
     let recordPerms
     if (field === DefaultFieldName) {
       recordPerms = value
@@ -114,8 +117,8 @@ const MultiPermissionPicker: definition.UC<MultiPermissionPickerDefinition> = (
     }
     updateDataValue({
       ...getDataValue(),
-      [recordId]: recordPerms,
-    } as wire.PlainWireRecord)
+      [idValue]: recordPerms,
+    })
   }
 
   // Iterate over the wires in the order specified by the sourceWires prop
@@ -142,13 +145,7 @@ const MultiPermissionPicker: definition.UC<MultiPermissionPickerDefinition> = (
       itemNames.sort()
       return itemNames
     })
-    .reduce(
-      (acc, itemName) => ({
-        ...acc,
-        [itemName]: getPermRecord(itemName),
-      }),
-      {},
-    )
+    .map(getPermRecord)
 
   const firstCollectionLabel = sourceWiresList[0]?.getCollection().getLabel()
   const tableFields = [

--- a/libs/ui/src/bands/wire/class.ts
+++ b/libs/ui/src/bands/wire/class.ts
@@ -122,13 +122,9 @@ class Wire {
     )
   }
 
-  createRecord = (
-    record: PlainWireRecord,
-    prepend?: boolean,
-    recordId?: string,
-  ) => {
+  createRecord = (record: PlainWireRecord, prepend?: boolean) => {
     // TODO: This code should be converted to using createRecordOp
-    if (!recordId) recordId = nanoid()
+    const recordId = nanoid()
     dispatch(
       createRecord({
         entity: this.getFullId(),


### PR DESCRIPTION
# What does this PR do?

1. Removes the ability to optionally send in a "recordid" during a `wire.createRecord` call. This option was only used in one place, and it encourages a hack. (storing actual record information in the "recordid")

NOTE: This is part of a larger effort to clean up and standardize the `wire.createRecord` function.

2. Adjusts and simplifies the `DynamicTable` component to receive an array of initialValues, instead of a map of values with their ids. (This component is currently only used in one place, so this adjustment could be made)

3. Changes the `multipermissionpicker` component to no longer rely on setting non-standard record ids in a wire.

TESTING:

All of the permissionset editing views in the studio should work the same as before.
