### PR TITLE
fix: respect workspace in collection & integration type after save bots

### DIFF
--- a/apps/platform-integration-tests/hurl_specs/collection_fields_lifecycle.hurl
+++ b/apps/platform-integration-tests/hurl_specs/collection_fields_lifecycle.hurl
@@ -72,6 +72,9 @@ workspace_id: jsonpath "$.wires[1].data[0]['uesio/core.id']"
 # Create a collection
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/wires/save
 Accept: application/json
+[Options]
+# This should be made unique once https://github.com/Orange-OpenSource/hurl/issues/3720 is implemented
+variable: collection_name="rare_and_unusual_object"
 {
     "wires": [
         {
@@ -79,7 +82,7 @@ Accept: application/json
             "deletes":{},
             "changes":{
                 "temp1":{
-                    "uesio/studio.name":"rare_and_unusual_object",
+                    "uesio/studio.name":"{{collection_name}}",
                     "uesio/studio.label":"Rare and unusual object",
                     "uesio/studio.plurallabel":"Rare and unusual objects"
                 }
@@ -105,13 +108,13 @@ Accept: application/json
             "deletes":{},
             "changes":{
                 "temp1":{
-                    "uesio/studio.collection":"{{app_fullname}}.rare_and_unusual_object",
+                    "uesio/studio.collection":"{{app_fullname}}.{{collection_name}}",
                     "uesio/studio.name":"object_name",
                     "uesio/studio.label":"Object Name",
                     "uesio/studio.type":"TEXT"
                 },
                 "temp2":{
-                    "uesio/studio.collection":"{{app_fullname}}.rare_and_unusual_object",
+                    "uesio/studio.collection":"{{app_fullname}}.{{collection_name}}",
                     "uesio/studio.name":"estimated_value",
                     "uesio/studio.label":"Estimated Value",
                     "uesio/studio.type":"NUMBER",
@@ -120,7 +123,7 @@ Accept: application/json
                     }
                 },
                 "temp3":{
-                    "uesio/studio.collection":"{{app_fullname}}.rare_and_unusual_object",
+                    "uesio/studio.collection":"{{app_fullname}}.{{collection_name}}",
                     "uesio/studio.name":"reference_field",
                     "uesio/studio.label":"Reference Field",
                     "uesio/studio.type":"REFERENCE",
@@ -178,12 +181,12 @@ Accept: application/json
             "deletes":{},
             "changes":{
                 "temp1":{
-                    "uesio/studio.collection":"{{app_fullname}}.rare_and_unusual_object",
+                    "uesio/studio.collection":"{{app_fullname}}.{{collection_name}}",
                     "uesio/studio.route":"{{app_fullname}}.simple_wire_load",
                     "uesio/studio.type":"list"
                 },
                 "temp2":{
-                    "uesio/studio.collection":"{{app_fullname}}.rare_and_unusual_object",
+                    "uesio/studio.collection":"{{app_fullname}}.{{collection_name}}",
                     "uesio/studio.route":"{{app_fullname}}.dependencies_group",
                     "uesio/studio.type":"detail"
                 }
@@ -209,7 +212,7 @@ Accept: application/json
             "deletes":{},
             "changes":{
                 "temp1":{
-                    "uesio/studio.collection":"{{app_fullname}}.rare_and_unusual_object",
+                    "uesio/studio.collection":"{{app_fullname}}.{{collection_name}}",
                     "uesio/studio.name":"sometoken",
                     "uesio/studio.access":"read"
                 }
@@ -249,7 +252,7 @@ Accept: application/json
             "conditions": [
                 {
                     "field": "uesio/studio.name",
-                    "value": "rare_and_unusual_object"
+                    "value": "{{collection_name}}"
                 }
             ],
             "params": {
@@ -283,7 +286,7 @@ Accept: application/json
             "conditions": [
                 {
                     "field": "uesio/studio.collection",
-                    "value": "{{app_fullname}}.rare_and_unusual_object"
+                    "value": "{{app_fullname}}.{{collection_name}}"
                 }
             ],
             "order": [
@@ -314,7 +317,7 @@ Accept: application/json
             "conditions": [
                 {
                     "field": "uesio/studio.collection",
-                    "value": "{{app_fullname}}.rare_and_unusual_object"
+                    "value": "{{app_fullname}}.{{collection_name}}"
                 }
             ],
             "order": [
@@ -345,7 +348,7 @@ Accept: application/json
             "conditions": [
                 {
                     "field": "uesio/studio.collection",
-                    "value": "{{app_fullname}}.rare_and_unusual_object"
+                    "value": "{{app_fullname}}.{{collection_name}}"
                 }
             ],
             "params": {
@@ -356,30 +359,30 @@ Accept: application/json
 }
 HTTP 200
 [Asserts]
-jsonpath "$.wires[0].data[0]['uesio/studio.name']" == "rare_and_unusual_object"
+jsonpath "$.wires[0].data[0]['uesio/studio.name']" == "{{collection_name}}"
 jsonpath "$.wires[0].data[0]['uesio/studio.label']" == "Rare and unusual object"
 jsonpath "$.wires[0].data[0]['uesio/studio.plurallabel']" == "Rare and unusual objects"
 jsonpath "$.wires[1].data" count == 3
-jsonpath "$.wires[1].data[0]['uesio/studio.collection']" == "{{app_fullname}}.rare_and_unusual_object"
+jsonpath "$.wires[1].data[0]['uesio/studio.collection']" == "{{app_fullname}}.{{collection_name}}"
 jsonpath "$.wires[1].data[0]['uesio/studio.name']" == "estimated_value"
 jsonpath "$.wires[1].data[0]['uesio/studio.label']" == "Estimated Value"
 jsonpath "$.wires[1].data[0]['uesio/studio.type']" == "NUMBER"
 jsonpath "$.wires[1].data[0]['uesio/studio.number']['uesio/studio.decimals']" == 2
-jsonpath "$.wires[1].data[1]['uesio/studio.collection']" == "{{app_fullname}}.rare_and_unusual_object"
+jsonpath "$.wires[1].data[1]['uesio/studio.collection']" == "{{app_fullname}}.{{collection_name}}"
 jsonpath "$.wires[1].data[1]['uesio/studio.name']" == "object_name"
 jsonpath "$.wires[1].data[1]['uesio/studio.label']" == "Object Name"
 jsonpath "$.wires[1].data[1]['uesio/studio.type']" == "TEXT"
-jsonpath "$.wires[1].data[2]['uesio/studio.collection']" == "{{app_fullname}}.rare_and_unusual_object"
+jsonpath "$.wires[1].data[2]['uesio/studio.collection']" == "{{app_fullname}}.{{collection_name}}"
 jsonpath "$.wires[1].data[2]['uesio/studio.name']" == "reference_field"
 jsonpath "$.wires[1].data[2]['uesio/studio.label']" == "Super Cool Reference Field"
 jsonpath "$.wires[1].data[2]['uesio/studio.type']" == "REFERENCE"
 jsonpath "$.wires[1].data[2]['uesio/studio.reference']['uesio/studio.collection']" == "uesio/tests.animal"
 jsonpath "$.wires[2].data" count == 2
-jsonpath "$.wires[2].data[*]['uesio/studio.collection']" contains "{{app_fullname}}.rare_and_unusual_object"
+jsonpath "$.wires[2].data[*]['uesio/studio.collection']" contains "{{app_fullname}}.{{collection_name}}"
 jsonpath "$.wires[2].data[*]['uesio/studio.type']" contains "list"
 jsonpath "$.wires[2].data[*]['uesio/studio.type']" contains "list"
 jsonpath "$.wires[3].data" count == 1
-jsonpath "$.wires[3].data[0]['uesio/studio.collection']" == "{{app_fullname}}.rare_and_unusual_object"
+jsonpath "$.wires[3].data[0]['uesio/studio.collection']" == "{{app_fullname}}.{{collection_name}}"
 jsonpath "$.wires[3].data[0]['uesio/studio.access']" == "read"
 jsonpath "$.wires[3].data[0]['uesio/studio.name']" == "sometoken"
 # TODO This should really be 4 but we are loading too many collections server-side
@@ -413,7 +416,280 @@ jsonpath "$.wires[0].data" count >= 1
 jsonpath "$.wires[0].data[*]['uesio/studio.name']" != ""
 jsonpath "$.wires[0].data[*]['uesio/studio.label']" != ""
 
-# Delete the collection
+# Capture the record count for collections and related metadata items
+# TODO: hurl doesn't support jsonpath length() function so we can't use that on the request that gets all the ids for these same collections
+# so we need to use aggregates to get the totals. Once https://github.com/Orange-OpenSource/hurl/issues/3935 is implemented, this separate
+# request can be removed in favor of using length() function.
+POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/wires/load
+Accept: application/json
+{
+    "wires": [
+        {
+            "collection":"uesio/studio.collection",
+            "name": "collection",
+            "fields": [
+                {
+                    "id": "uesio/core.id",
+                    "function": "COUNT"
+                }
+            ],
+            "groupby": [
+                {
+                    "id": "uesio/studio.workspace"
+                }
+            ],            
+            "query":true,            
+            "aggregate":true,
+            "params": {
+                "workspaceid": "{{workspace_id}}"
+            }
+        },
+        {
+            "collection":"uesio/studio.field",
+            "name": "fields",
+            "fields": [
+                {
+                    "id": "uesio/core.id",
+                    "function": "COUNT"
+                }
+            ],
+            "groupby": [
+                {
+                    "id": "uesio/studio.workspace"
+                }
+            ],            
+            "query":true,            
+            "aggregate":true,
+            "params": {
+                "workspaceid": "{{workspace_id}}"
+            }
+        },
+        {
+            "collection":"uesio/studio.routeassignment",
+            "name": "routeassignment",
+            "fields": [
+                {
+                    "id": "uesio/core.id",
+                    "function": "COUNT"
+                }
+            ],
+            "groupby": [
+                {
+                    "id": "uesio/studio.workspace"
+                }
+            ],            
+            "query":true,            
+            "aggregate":true,
+            "params": {
+                "workspaceid": "{{workspace_id}}"
+            }
+        },
+        {
+            "collection":"uesio/studio.recordchallengetoken",
+            "name": "recordchallengetokens",
+            "fields": [
+                {
+                    "id": "uesio/core.id",
+                    "function": "COUNT"
+                }
+            ],
+            "groupby": [
+                {
+                    "id": "uesio/studio.workspace"
+                }
+            ],            
+            "query":true,            
+            "aggregate":true,
+            "params": {
+                "workspaceid": "{{workspace_id}}"
+            }
+        }
+    ]
+}
+HTTP 200
+[Asserts]
+jsonpath "$.wires" count == 4
+jsonpath "$.wires[0].data" count == 1
+jsonpath "$.wires[1].data" count == 1
+jsonpath "$.wires[2].data" count == 1
+jsonpath "$.wires[3].data" count == 1
+[Captures]
+workspace_collection_count: jsonpath "$.wires[0].data[0]['uesio/core.id_count']"
+workspace_field_count: jsonpath "$.wires[1].data[0]['uesio/core.id_count']"
+workspace_routeassignment_count: jsonpath "$.wires[2].data[0]['uesio/core.id_count']"
+workspace_recordchallengetoken_count: jsonpath "$.wires[3].data[0]['uesio/core.id_count']"
+
+# Create a bundle, so that we can create another workspace
+POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/bots/call/uesio/studio/createbundle
+{
+    "type": "patch",
+    "description": "test delete collection bundle",
+    "app": "uesio/tests",
+    "workspaceName": "dev"
+}
+HTTP 200
+[Captures]
+major: jsonpath "$.params.major"
+minor: jsonpath "$.params.minor"
+patch: jsonpath "$.params.patch"
+[Asserts]
+jsonpath "$.success" == true
+jsonpath "$.error" == ""
+jsonpath "$.params.description" == "test delete collection bundle"
+
+# Create a workspace using that bundle
+POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/wires/save
+[Options]
+# This should be made unique once https://github.com/Orange-OpenSource/hurl/issues/3720 is implemented
+variable: dup_workspace_name=dev_duplicate_delete_test
+{
+    "wires": [
+        {
+            "wire": "newworkspace",
+            "collection": "uesio/studio.workspace",
+            "changes": {
+                "1": {
+                    "uesio/studio.app": {
+                        "uesio/core.id": "{{app_id}}"
+                    },
+                    "uesio/studio.name": "{{dup_workspace_name}}",
+                    "uesio/studio.sourcebundle": {
+                        "uesio/core.uniquekey": "uesio/tests:{{major}}:{{minor}}:{{patch}}"
+                    }
+                }
+            }
+        }
+    ]
+}
+HTTP 200
+[Asserts]
+jsonpath "$.wires[0].errors" == null
+jsonpath "$.wires[0].changes['1']['uesio/core.uniquekey']" == "uesio/tests:dev_duplicate_delete_test"
+[Captures]
+dup_workspace_id: jsonpath "$.wires[0].changes['1']['uesio/core.id']"
+
+# Verify the duplicate workspace was created and has the right number of items
+POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/wires/load
+Accept: application/json
+{
+    "wires": [
+        {
+            "collection":"uesio/studio.collection",
+            "name": "collection",
+            "fields": [
+                {
+                    "id": "uesio/core.id",
+                    "function": "COUNT"
+                }
+            ],
+            "groupby": [
+                {
+                    "id": "uesio/studio.workspace"
+                }
+            ],            
+            "query":true,            
+            "aggregate":true,
+            "params": {
+                "workspaceid": "{{dup_workspace_id}}"
+            }
+        },
+        {
+            "collection":"uesio/studio.field",
+            "name": "fields",
+            "fields": [
+                {
+                    "id": "uesio/core.id",
+                    "function": "COUNT"
+                }
+            ],
+            "groupby": [
+                {
+                    "id": "uesio/studio.workspace"
+                }
+            ],            
+            "query":true,            
+            "aggregate":true,
+            "params": {
+                "workspaceid": "{{dup_workspace_id}}"
+            }
+        },
+        {
+            "collection":"uesio/studio.routeassignment",
+            "name": "routeassignment",
+            "fields": [
+                {
+                    "id": "uesio/core.id",
+                    "function": "COUNT"
+                }
+            ],
+            "groupby": [
+                {
+                    "id": "uesio/studio.workspace"
+                }
+            ],            
+            "query":true,            
+            "aggregate":true,
+            "params": {
+                "workspaceid": "{{dup_workspace_id}}"
+            }
+        },
+        {
+            "collection":"uesio/studio.recordchallengetoken",
+            "name": "recordchallengetokens",
+            "fields": [
+                {
+                    "id": "uesio/core.id",
+                    "function": "COUNT"
+                }
+            ],
+            "groupby": [
+                {
+                    "id": "uesio/studio.workspace"
+                }
+            ],            
+            "query":true,            
+            "aggregate":true,
+            "params": {
+                "workspaceid": "{{dup_workspace_id}}"
+            }
+        },
+        {
+            "collection":"uesio/studio.collection",
+            "name": "collection",
+            "fields": [
+                {
+                    "id": "uesio/core.id"
+                }
+            ],
+            "conditions": [
+                {
+                    "field": "uesio/studio.name",
+                    "value": "{{collection_name}}"
+                }
+            ],
+            "query":true,            
+            "params": {
+                "workspaceid": "{{dup_workspace_id}}"
+            }
+        }    
+    ]
+}
+HTTP 200
+[Asserts]
+jsonpath "$.wires" count == 5
+jsonpath "$.wires[0].data" count == 1
+jsonpath "$.wires[1].data" count == 1
+jsonpath "$.wires[2].data" count == 1
+jsonpath "$.wires[3].data" count == 1
+jsonpath "$.wires[4].data" count == 1
+jsonpath "$.wires[0].data[0]['uesio/core.id_count']" == {{workspace_collection_count}}
+jsonpath "$.wires[1].data[0]['uesio/core.id_count']" == {{workspace_field_count}}
+jsonpath "$.wires[2].data[0]['uesio/core.id_count']" == {{workspace_routeassignment_count}}
+jsonpath "$.wires[3].data[0]['uesio/core.id_count']" == {{workspace_recordchallengetoken_count}}
+[Captures]
+dup_collection_id: jsonpath "$.wires[4].data[0]['uesio/core.id']"
+
+# Delete the collection from duplicate workspace
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/wires/save
 Accept: application/json
 {
@@ -421,12 +697,12 @@ Accept: application/json
         {
             "collection":"uesio/studio.collection",
             "deletes":{
-                "{{collection_id}}": {
-                    "uesio/core.id": "{{collection_id}}"
+                "{{collection_name}}": {
+                    "uesio/core.id": "{{dup_collection_id}}"
                 }
             },
             "params": {
-                "workspaceid": "{{workspace_id}}"
+                "workspaceid": "{{dup_workspace_id}}"
             },
             "changes":{},
             "wire":"mywire"
@@ -452,16 +728,12 @@ Accept: application/json
             ],
             "conditions": [
                 {
-                    "field": "uesio/studio.name",
-                    "value": "rare_and_unusual_object"
-                },
-                {
-                    "field": "uesio/studio.workspace",
-                    "value": "{{workspace_id}}"
+                    "field": "uesio/core.id",
+                    "value": "{{dup_collection_id}}"
                 }
             ],
             "params": {
-                "workspaceid": "{{workspace_id}}"
+                "workspaceid": "{{dup_workspace_id}}"
             }
         },
         {
@@ -475,15 +747,15 @@ Accept: application/json
             "conditions": [
                 {
                     "field": "uesio/studio.collection",
-                    "value": "{{app_fullname}}.rare_and_unusual_object"
+                    "value": "{{app_fullname}}.{{collection_name}}"
                 },
                 {
                     "field": "uesio/studio.workspace",
-                    "value": "{{workspace_id}}"
+                    "value": "{{dup_workspace_id}}"
                 }
             ],
             "params": {
-                "workspaceid": "{{workspace_id}}"
+                "workspaceid": "{{dup_workspace_id}}"
             }
         },
         {
@@ -497,15 +769,15 @@ Accept: application/json
             "conditions": [
                 {
                     "field": "uesio/studio.collection",
-                    "value": "{{app_fullname}}.rare_and_unusual_object"
+                    "value": "{{app_fullname}}.{{collection_name}}"
                 },
                 {
                     "field": "uesio/studio.workspace",
-                    "value": "{{workspace_id}}"
+                    "value": "{{dup_workspace_id}}"
                 }
             ],
             "params": {
-                "workspaceid": "{{workspace_id}}"
+                "workspaceid": "{{dup_workspace_id}}"
             }
         },
         {
@@ -519,22 +791,261 @@ Accept: application/json
             "conditions": [
                 {
                     "field": "uesio/studio.collection",
-                    "value": "{{app_fullname}}.rare_and_unusual_object"
+                    "value": "{{app_fullname}}.{{collection_name}}"
                 },
                 {
                     "field": "uesio/studio.workspace",
-                    "value": "{{workspace_id}}"
+                    "value": "{{dup_workspace_id}}"
                 }
             ],
             "params": {
-                "workspaceid": "{{workspace_id}}"
+                "workspaceid": "{{dup_workspace_id}}"
             }
         }
     ]
 }
 HTTP 200
 [Asserts]
+jsonpath "$.wires" count == 4
 jsonpath "$.wires[0].data[*]" isEmpty
 jsonpath "$.wires[1].data[*]" isEmpty
 jsonpath "$.wires[2].data[*]" isEmpty
 jsonpath "$.wires[3].data[*]" isEmpty
+
+# Delete the duplicate workspace
+POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/wires/save
+Accept: application/json
+{
+    "wires": [
+        {
+            "collection":"uesio/studio.workspace",
+            "deletes":{
+                "{{collection_name}}": {
+                    "uesio/core.id": "{{dup_workspace_id}}"
+                }
+            },
+            "params": {
+                "workspaceid": "{{dup_workspace_id}}"
+            },
+            "changes":{},
+            "wire":"mywire"
+        }
+    ]
+}
+HTTP 200
+[Asserts]
+jsonpath "$.wires[0].errors" == null
+
+# Verify duplicate workspace was deleted
+POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/wires/load
+Accept: application/json
+{
+    "wires": [      
+        {
+            "collection":"uesio/studio.collection",
+            "name": "collection",
+            "fields": [
+                {
+                    "id": "uesio/core.id",
+                    "function": "COUNT"
+                }
+            ],
+            "groupby": [
+                {
+                    "id": "uesio/studio.workspace"
+                }
+            ],            
+            "query":true,            
+            "aggregate":true,
+            "params": {
+                "workspaceid": "{{dup_workspace_id}}"
+            }
+        },
+        {
+            "collection":"uesio/studio.field",
+            "name": "fields",
+            "fields": [
+                {
+                    "id": "uesio/core.id",
+                    "function": "COUNT"
+                }
+            ],
+            "groupby": [
+                {
+                    "id": "uesio/studio.workspace"
+                }
+            ],            
+            "query":true,            
+            "aggregate":true,
+            "params": {
+                "workspaceid": "{{dup_workspace_id}}"
+            }
+        },
+        {
+            "collection":"uesio/studio.routeassignment",
+            "name": "routeassignment",
+            "fields": [
+                {
+                    "id": "uesio/core.id",
+                    "function": "COUNT"
+                }
+            ],
+            "groupby": [
+                {
+                    "id": "uesio/studio.workspace"
+                }
+            ],            
+            "query":true,            
+            "aggregate":true,
+            "params": {
+                "workspaceid": "{{dup_workspace_id}}"
+            }
+        },
+        {
+            "collection":"uesio/studio.recordchallengetoken",
+            "name": "recordchallengetokens",
+            "fields": [
+                {
+                    "id": "uesio/core.id",
+                    "function": "COUNT"
+                }
+            ],
+            "groupby": [
+                {
+                    "id": "uesio/studio.workspace"
+                }
+            ],            
+            "query":true,            
+            "aggregate":true,
+            "params": {
+                "workspaceid": "{{dup_workspace_id}}"
+            }
+        },
+        {
+            "collection":"uesio/studio.workspace",
+            "name": "workspace",
+            "fields": [
+                {
+                    "id": "uesio/core.id"
+                }
+            ],
+            "conditions": [
+                {
+                    "field": "uesio/core.id",
+                    "value": "{{dup_workspace_id}}"
+                }
+            ],
+            "query":true,            
+            "params": {
+                "workspaceid": "{{dup_workspace_id}}"
+            }
+        }   
+    ]
+}
+HTTP 200
+[Asserts]
+jsonpath "$.wires" count == 5
+jsonpath "$.wires[0].data" isEmpty
+jsonpath "$.wires[1].data" isEmpty
+jsonpath "$.wires[2].data" isEmpty
+jsonpath "$.wires[3].data" isEmpty
+jsonpath "$.wires[4].data" isEmpty
+
+# Verify dev workspace did not change
+POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/wires/load
+Accept: application/json
+{
+    "wires": [
+        {
+            "collection":"uesio/studio.collection",
+            "name": "collection",
+            "fields": [
+                {
+                    "id": "uesio/core.id",
+                    "function": "COUNT"
+                }
+            ],
+            "groupby": [
+                {
+                    "id": "uesio/studio.workspace"
+                }
+            ],            
+            "query":true,            
+            "aggregate":true,
+            "params": {
+                "workspaceid": "{{workspace_id}}"
+            }
+        },
+        {
+            "collection":"uesio/studio.field",
+            "name": "fields",
+            "fields": [
+                {
+                    "id": "uesio/core.id",
+                    "function": "COUNT"
+                }
+            ],
+            "groupby": [
+                {
+                    "id": "uesio/studio.workspace"
+                }
+            ],            
+            "query":true,            
+            "aggregate":true,
+            "params": {
+                "workspaceid": "{{workspace_id}}"
+            }
+        },
+        {
+            "collection":"uesio/studio.routeassignment",
+            "name": "routeassignment",
+            "fields": [
+                {
+                    "id": "uesio/core.id",
+                    "function": "COUNT"
+                }
+            ],
+            "groupby": [
+                {
+                    "id": "uesio/studio.workspace"
+                }
+            ],            
+            "query":true,            
+            "aggregate":true,
+            "params": {
+                "workspaceid": "{{workspace_id}}"
+            }
+        },
+        {
+            "collection":"uesio/studio.recordchallengetoken",
+            "name": "recordchallengetokens",
+            "fields": [
+                {
+                    "id": "uesio/core.id",
+                    "function": "COUNT"
+                }
+            ],
+            "groupby": [
+                {
+                    "id": "uesio/studio.workspace"
+                }
+            ],            
+            "query":true,            
+            "aggregate":true,
+            "params": {
+                "workspaceid": "{{workspace_id}}"
+            }
+        }  
+    ]
+}
+HTTP 200
+[Asserts]
+jsonpath "$.wires" count == 4
+jsonpath "$.wires[0].data" count == 1
+jsonpath "$.wires[1].data" count == 1
+jsonpath "$.wires[2].data" count == 1
+jsonpath "$.wires[3].data" count == 1
+jsonpath "$.wires[0].data[0]['uesio/core.id_count']" == {{workspace_collection_count}}
+jsonpath "$.wires[1].data[0]['uesio/core.id_count']" == {{workspace_field_count}}
+jsonpath "$.wires[2].data[0]['uesio/core.id_count']" == {{workspace_routeassignment_count}}
+jsonpath "$.wires[3].data[0]['uesio/core.id_count']" == {{workspace_recordchallengetoken_count}}

--- a/apps/platform-integration-tests/hurl_specs/metadata_list_workspace_context.hurl
+++ b/apps/platform-integration-tests/hurl_specs/metadata_list_workspace_context.hurl
@@ -29,7 +29,7 @@ HTTP 200
 # TODO: Unclear why this assert exists as its fragile and likely does not help in any way since underlying
 # data can change across the test suite.  Evaluate this tests purpose and adjust the assert to be
 # explicit/more meaningful or remove.
-jsonpath "$[*]" count == 29
+jsonpath "$[*]" count == 30
 # Spot check a uesio/tests collection
 jsonpath "$['uesio/tests.animal'].key" == "uesio/tests.animal"
 jsonpath "$['uesio/tests.animal'].namespace" == "uesio/tests"
@@ -47,7 +47,7 @@ HTTP 200
 # TODO: Unclear why this assert exists as its fragile and likely does not help in any way since underlying
 # data can change across the test suite.  Evaluate this tests purpose and adjust the assert to be
 # explicit/more meaningful or remove.
-jsonpath "$[*]" count == 11
+jsonpath "$[*]" count == 12
 # Spot check a uesio/tests collection
 jsonpath "$['uesio/tests.animal'].key" == "uesio/tests.animal"
 jsonpath "$['uesio/tests.animal'].namespace" == "uesio/tests"

--- a/apps/platform/pkg/bot/systemdialect/systembot_after_collection.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_after_collection.go
@@ -35,7 +35,7 @@ func runCollectionAfterSaveBot(request *wire.SaveOp, connection wire.Connection,
 		if err != nil {
 			return err
 		}
-		// collection unique keys will be something like "uesio/tests:dev:rare_and_unusual_object", but the "uesio/studio.collection" 
+		// collection unique keys will be something like "uesio/tests:dev:rare_and_unusual_object", but the "uesio/studio.collection"
 		// field for fields will be something like "uesio/tests.rare_and_unusual_object", so we need to parse this
 		// TODO: It seems like there should be a method that already does this somewhere?
 		collectionName, err := parseUniquekeyToCollectionKey(collectionUniqueKey)
@@ -52,27 +52,27 @@ func runCollectionAfterSaveBot(request *wire.SaveOp, connection wire.Connection,
 	var conditions []wire.LoadRequestCondition
 	for workspaceId, collectionNames := range workspaceCollections {
 		collectionCondition := wire.LoadRequestCondition{
-			Field:    "uesio/studio.collection",
+			Field: "uesio/studio.collection",
 		}
 		if len(collectionNames) > 1 {
 			collectionCondition.Operator = "IN"
 			collectionCondition.Values = collectionNames
-		} else			{
+		} else {
 			collectionCondition.Operator = "EQ"
 			collectionCondition.Value = collectionNames[0]
 		}
 		conditions = append(conditions, wire.LoadRequestCondition{
-						Type: "GROUP",
-						Conjunction: "AND",
-						SubConditions: []wire.LoadRequestCondition{
-							{
-								Field: "uesio/studio.workspace",
-								Value: workspaceId,
-								Operator: "EQ",
-							},
-							collectionCondition,
-						},
-					})
+			Type:        "GROUP",
+			Conjunction: "AND",
+			SubConditions: []wire.LoadRequestCondition{
+				{
+					Field:    "uesio/studio.workspace",
+					Value:    workspaceId,
+					Operator: "EQ",
+				},
+				collectionCondition,
+			},
+		})
 	}
 
 	fc := meta.FieldCollection{}
@@ -110,7 +110,7 @@ func runCollectionAfterSaveBot(request *wire.SaveOp, connection wire.Connection,
 				ID: commonfields.Id,
 			},
 		},
-		Conditions: conditions,		
+		Conditions: conditions,
 		Connection: connection,
 		Params:     request.Params,
 	}, session); err != nil {


### PR DESCRIPTION
# What does this PR do?

Ensures that workspace is respected when collection & integration type metadata is being deleted after a collection/integration type has been removed.
 
Resolves #4801 

# Testing

tested manually and confirmed. 

TBD: Write tests.
