### PR TITLE
[WIP]: chore: improve cascade delete context handling

### DIFF
--- a/apps/platform/pkg/types/workspace/keyinfo.go
+++ b/apps/platform/pkg/types/workspace/keyinfo.go
@@ -32,3 +32,10 @@ func (t KeyInfo) GetAppName() string {
 func (t KeyInfo) GetWorkspaceID() string {
 	return t.workspaceID
 }
+
+func (t KeyInfo) GetUniqueKey() string {
+	if t.GetAppName() != "" && t.GetWorkspaceName() != "" {
+		return t.GetAppName() + ":" + t.GetWorkspaceName()
+	}
+	return ""
+}


### PR DESCRIPTION
# What does this PR do?

1. Limits elevating session permissions during cascade delete operations to only what is needed by using AnonSiteSession instead of SiteAdminSession unless already SiteAdminSession
2. Refactors requesting workspace permissions to fix caching issues, fail fast and avoid unnecessary processing, always ensure that params has workspaceid, appname and workspacename.

NOTE - This is still a WIP, need to resolve ensuring workspaceid/appname/workspace name in one scenario and also determine if there is a reliable way to clear the caches when workspace info changes in order to cache uniquekey to improve overall perf.

# Testing

ci & e2e will cover.
