### PR TITLE
fix: ensure agents are deleted when workspace gets deleted

### DIFF
--- a/libs/apps/uesio/studio/bundle/fields/uesio/studio/workspace/agents.yaml
+++ b/libs/apps/uesio/studio/bundle/fields/uesio/studio/workspace/agents.yaml
@@ -1,0 +1,7 @@
+name: agents
+type: REFERENCEGROUP
+label: Agents
+referenceGroup:
+  collection: agent
+  field: workspace
+  onDelete: CASCADE


### PR DESCRIPTION
# What does this PR do?

Ensures that agents & their userfiles are physically deleted from db & filesystem when workspace is deleted.

# Testing

Manually tested and confirmed expected behavior.
