### PR TITLE
feat: add additional sql operators

### DIFF
--- a/apps/platform-e2e/cypress/support/testdata.ts
+++ b/apps/platform-e2e/cypress/support/testdata.ts
@@ -12,7 +12,7 @@ export function getUniqueAppName() {
     { length: 8 },
     getRandomLowercaseAlphabetLetter,
   ).join("")
-  return `e2e${randomLetters}`
+  return `tests_e2e_${randomLetters}`
 }
 
 export function deleteApp(appName: string) {

--- a/apps/platform-integration-tests/hurl_seeds/delete_app.hurl
+++ b/apps/platform-integration-tests/hurl_seeds/delete_app.hurl
@@ -16,7 +16,7 @@ HTTP *
 status toString matches /^(204|404)$/
 
 # Delete the tests app if it already exists, which should cascade delete the workspace and all of its metadata
-DELETE {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/api/v1/collection/uesio/studio/app?uesio/studio.fullname=eq.uesio%2Ftests
+DELETE {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/api/v1/collection/uesio/studio/app?uesio/studio.fullname=sw.uesio%2Ftests
 HTTP *
 [Asserts]
 status toString matches /^(204|404)$/
@@ -28,10 +28,12 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/wires/l
         {
             "name": "workspaces",
             "collection": "uesio/studio.workspace",
+            "query": true,
+            "fields": [{ "id": "uesio/core.uniquekey" }],
             "conditions": [
                 {
                     "field": "uesio/studio.app->uesio/studio.fullname",
-                    "operator": "EQ",
+                    "operator": "STARTS_WITH",
                     "value": "uesio/tests"
                 }
             ]
@@ -50,10 +52,12 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/wires/l
         {
             "name": "sites",
             "collection": "uesio/studio.site",
+            "query": true,
+            "fields": [{ "id": "uesio/core.uniquekey" }],            
             "conditions": [
                 {
                     "field": "uesio/studio.app->uesio/studio.fullname",
-                    "operator": "EQ",
+                    "operator": "STARTS_WITH",
                     "value": "uesio/tests"
                 }
             ]

--- a/apps/platform-integration-tests/hurl_specs/delete_api.hurl
+++ b/apps/platform-integration-tests/hurl_specs/delete_api.hurl
@@ -8,8 +8,11 @@ HTTP 200
 session_id: cookie "sessid"
 user_id: jsonpath "$.user.id"
 
-# Create an app named delete_api to delete it later
+# Create an app named tests_delete_api to delete it later
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/wires/save
+[Options]
+# This should be made unique once https://github.com/Orange-OpenSource/hurl/issues/3720 is implemented
+variable: app_name=tests_int_delete_api
 {
     "wires": [
         {
@@ -23,7 +26,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/wires/s
                     },
                     "uesio/studio.color": "#0e7490",
                     "uesio/studio.icon": "bug_report",
-                    "uesio/studio.name": "delete_api",
+                    "uesio/studio.name": "{{app_name}}",
                     "uesio/studio.description": "Delete API tests"
                 }
             },
@@ -39,6 +42,9 @@ jsonpath "$.wires[0].errors" == null
 
 # Create a workspace to delete it later
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/wires/save
+[Options]
+# This should be made unique once https://github.com/Orange-OpenSource/hurl/issues/3720 is implemented
+variable: workspace_name=delete_api_ws
 {
     "wires": [
         {
@@ -49,7 +55,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/wires/s
                     "uesio/studio.app": {
                         "uesio/core.id": "{{app_id}}"
                     },
-                    "uesio/studio.name": "delete_api_ws"
+                    "uesio/studio.name": "{{workspace_name}}"
                 }
             }
         }
@@ -58,10 +64,10 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/wires/s
 HTTP 200
 [Asserts]
 jsonpath "$.wires[0].errors" == null
-jsonpath "$.wires[0].changes['1']['uesio/core.uniquekey']" == "uesio/delete_api:delete_api_ws"
+jsonpath "$.wires[0].changes['1']['uesio/core.uniquekey']" == "uesio/{{app_name}}:{{workspace_name}}"
 
 # Delete the workspace that we just created and assert that it was deleted properly 204 (No Content)
-DELETE {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/api/v1/collection/uesio/studio/workspace?uesio/studio.name=eq.delete_api_ws
+DELETE {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/api/v1/collection/uesio/studio/workspace?uesio/studio.name=eq.{{workspace_name}}
 HTTP 204
 
 # Verify that the workspace got deleted
@@ -75,7 +81,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/wires/l
                 {
                     "field": "uesio/studio.name",
                     "operator": "EQ",
-                    "value": "uesio/delete_api_ws"
+                    "value": "uesio/{{workspace_name}}"
                 }
             ]
         }
@@ -87,11 +93,11 @@ jsonpath "$.wires[0].errors" not exists
 jsonpath "$.wires[0].data" count == 0
 
 # Delete the workspace again and assert that the http status code is 404 (Not Found)
-DELETE {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/api/v1/collection/uesio/studio/workspace?uesio/studio.name=eq.delete_api_ws
+DELETE {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/api/v1/collection/uesio/studio/workspace?uesio/studio.name=eq.{{workspace_name}}
 HTTP 404
 
 # Delete the app that we created and assert that it was deleted properly 204 (No Content)
-DELETE {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/api/v1/collection/uesio/studio/app?uesio/studio.name=eq.delete_api
+DELETE {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/api/v1/collection/uesio/studio/app?uesio/studio.name=eq.{{app_name}}
 HTTP 204
 
 # Verify that the app got deleted
@@ -105,7 +111,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/wires/l
                 {
                     "field": "uesio/studio.name",
                     "operator": "EQ",
-                    "value": "uesio/delete_api"
+                    "value": "uesio/{{app_name}}"
                 }
             ]
         }
@@ -117,5 +123,5 @@ jsonpath "$.wires[0].errors" not exists
 jsonpath "$.wires[0].data" count == 0
 
 # Delete the app again and assert that the http status code is 404 (Not Found)
-DELETE {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/api/v1/collection/uesio/studio/app?uesio/studio.name=eq.delete_api
+DELETE {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/api/v1/collection/uesio/studio/app?uesio/studio.name=eq.{{app_name}}
 HTTP 404

--- a/apps/platform/pkg/adapt/postgresio/conditions.go
+++ b/apps/platform/pkg/adapt/postgresio/conditions.go
@@ -273,18 +273,6 @@ func processValueCondition(condition wire.LoadRequestCondition, collectionMetada
 		}
 		builder.addQueryPart(fmt.Sprintf("%s ILIKE %s", fieldName, builder.addValue(fmt.Sprintf("%v%%", useValue))))
 
-	case "LIKE":
-		if !isTextType {
-			return fmt.Errorf("operator LIKE is not supported for field type %s", fieldType)
-		}
-		builder.addQueryPart(fmt.Sprintf("%s LIKE %s", fieldName, builder.addValue(fmt.Sprintf("%v", useValue))))
-
-	case "ILIKE":
-		if !isTextType {
-			return fmt.Errorf("operator ILIKE is not supported for field type %s", fieldType)
-		}
-		builder.addQueryPart(fmt.Sprintf("%s ILIKE %s", fieldName, builder.addValue(fmt.Sprintf("%v", useValue))))
-
 	default:
 		if fieldType == "MULTISELECT" {
 			// Same as HAS_ANY

--- a/apps/platform/pkg/adapt/postgresio/conditions.go
+++ b/apps/platform/pkg/adapt/postgresio/conditions.go
@@ -166,7 +166,7 @@ func processValueCondition(condition wire.LoadRequestCondition, collectionMetada
 	if useValue != nil && isCoreUUIDField {
 		useValueString, ok := useValue.(string)
 		if !ok {
-			return fmt.Errorf("Value must be string for field: %s : %s", fieldName, useValue)
+			return fmt.Errorf("value must be string for field: %s : %s", fieldName, useValue)
 		}
 		useValue = useValueString
 	}
@@ -176,12 +176,12 @@ func processValueCondition(condition wire.LoadRequestCondition, collectionMetada
 		uuidStrings := []string{}
 		useValueSlice, ok := useValue.([]any)
 		if !ok {
-			return fmt.Errorf("Value must be slice of strings for field: %s : %s", fieldMetadata.GetFullName(), useValue)
+			return fmt.Errorf("value must be slice of strings for field: %s : %s", fieldMetadata.GetFullName(), useValue)
 		}
 		for _, val := range useValueSlice {
 			useValueString, ok := val.(string)
 			if !ok {
-				return fmt.Errorf("Value must be string for field: %s : %s", fieldName, val)
+				return fmt.Errorf("value must be string for field: %s : %s", fieldName, val)
 			}
 			uuidStrings = append(uuidStrings, useValueString)
 		}
@@ -206,13 +206,13 @@ func processValueCondition(condition wire.LoadRequestCondition, collectionMetada
 
 	case "HAS_ANY":
 		if fieldType != "MULTISELECT" {
-			return errors.New("Operator HAS_ANY only works with fieldType MULTI_SELECT")
+			return errors.New("operator HAS_ANY only works with fieldType MULTI_SELECT")
 		}
 		builder.addQueryPart(fmt.Sprintf("%s ?| %s", fieldName, builder.addValue(useValues)))
 
 	case "HAS_ALL":
 		if fieldType != "MULTISELECT" {
-			return errors.New("Operator HAS_ALL only works with fieldType MULTI_SELECT")
+			return errors.New("operator HAS_ALL only works with fieldType MULTI_SELECT")
 		}
 		builder.addQueryPart(fmt.Sprintf("%s ?& %s", fieldName, builder.addValue(useValues)))
 
@@ -263,15 +263,27 @@ func processValueCondition(condition wire.LoadRequestCondition, collectionMetada
 
 	case "CONTAINS":
 		if !isTextType {
-			return fmt.Errorf("Operator CONTAINS is not supported for field type %s", fieldType)
+			return fmt.Errorf("operator CONTAINS is not supported for field type %s", fieldType)
 		}
 		builder.addQueryPart(fmt.Sprintf("%s ILIKE %s", fieldName, builder.addValue(fmt.Sprintf("%%%v%%", useValue))))
 
 	case "STARTS_WITH":
 		if !isTextType {
-			return fmt.Errorf("Operator STARTS_WITH is not supported for field type %s", fieldType)
+			return fmt.Errorf("operator STARTS_WITH is not supported for field type %s", fieldType)
 		}
 		builder.addQueryPart(fmt.Sprintf("%s ILIKE %s", fieldName, builder.addValue(fmt.Sprintf("%v%%", useValue))))
+
+	case "LIKE":
+		if !isTextType {
+			return fmt.Errorf("operator LIKE is not supported for field type %s", fieldType)
+		}
+		builder.addQueryPart(fmt.Sprintf("%s LIKE %s", fieldName, builder.addValue(fmt.Sprintf("%v", useValue))))
+
+	case "ILIKE":
+		if !isTextType {
+			return fmt.Errorf("operator ILIKE is not supported for field type %s", fieldType)
+		}
+		builder.addQueryPart(fmt.Sprintf("%s ILIKE %s", fieldName, builder.addValue(fmt.Sprintf("%v", useValue))))
 
 	default:
 		if fieldType == "MULTISELECT" {

--- a/apps/platform/pkg/controller/collectiondeleteapi.go
+++ b/apps/platform/pkg/controller/collectiondeleteapi.go
@@ -35,10 +35,6 @@ func getUesioOperatorFromPostgrestOperator(pgOp string) string {
 		return "CONTAINS"
 	case "sw":
 		return "STARTS_WITH"
-	case "like":
-		return "LIKE"
-	case "ilike":
-		return "ILIKE"
 	}
 	return "EQ"
 }

--- a/apps/platform/pkg/controller/collectiondeleteapi.go
+++ b/apps/platform/pkg/controller/collectiondeleteapi.go
@@ -31,6 +31,14 @@ func getUesioOperatorFromPostgrestOperator(pgOp string) string {
 		return "GTE"
 	case "in":
 		return "IN"
+	case "cs":
+		return "CONTAINS"
+	case "sw":
+		return "STARTS_WITH"
+	case "like":
+		return "LIKE"
+	case "ilike":
+		return "ILIKE"
 	}
 	return "EQ"
 }


### PR DESCRIPTION
# What does this PR do?

1. Adds support for the following sql operators:
    1. sw = STARTS_WITH (already supported in conditionsapi, only added to deleterecordapi)
    2. cs = CONTAINS  (already supported in conditionsapi, only added to deleterecordapi)
 2. Modified our e2e & integration tests to always create apps starting with the name "tests"
 3. Modified our test cleanup code to delete all apps starting with "tests" name
 4. Fixed a few issues with asserts on existing tests that were not correctly querying for data and/or retrieving files so they would never return any data (even if it was there) but were asserting on counts = 0.  If there is data, it will be retrieved now so the asserts will work as expected.

> [!IMPORTANT]
> There is some down side to adding support for these operators.  These operators are now exposed to the deleterecordapi meaning you could delete a lot of stuff all at once with a simple http DELETE.  This is helpful, as demonstrated by how it helps us cleanup tests, but does cause some pause.  There are other options for fully cleaning up our tests if we do not want to add these operators due to performance reasons.
 
# Testing

Tested all operators manually and all work as expected.  ci & e2e will cover rest.
