### PR TITLE
fix: initial preview then toggle to build mode breaks builder

### DIFF
--- a/libs/apps/uesio/builder/bundle/componentpacks/main/src/api/stateapi.ts
+++ b/libs/apps/uesio/builder/bundle/componentpacks/main/src/api/stateapi.ts
@@ -128,6 +128,12 @@ const getBuildMode = (context: ctx.Context) =>
 const useBuildMode = (context: ctx.Context) =>
   useBuilderState<boolean>(context, "buildmode") || false
 
+const getBuildDepsLoaded = (context: ctx.Context) =>
+  getBuilderState<boolean>(context, "builddepsloaded") || false
+
+const useBuildDepsLoaded = (context: ctx.Context, initialState: boolean) =>
+  useBuilderState<boolean>(context, "builddepsloaded", initialState) || false
+
 const useSelectedPath = (context: ctx.Context) =>
   parseFullPath(useBuilderExternalState<string>(context, "selected"))
 
@@ -507,6 +513,8 @@ const getSlotComponents = (
 export {
   getBuildMode,
   useBuildMode,
+  getBuildDepsLoaded,
+  useBuildDepsLoaded,
   useDropPath,
   setDropPath,
   useDragPath,

--- a/libs/apps/uesio/builder/bundle/componentpacks/main/src/components/mainwrapper/buildbar/buildbar_main_buttons.tsx
+++ b/libs/apps/uesio/builder/bundle/componentpacks/main/src/components/mainwrapper/buildbar/buildbar_main_buttons.tsx
@@ -1,6 +1,6 @@
 import { definition, component, hooks, styles } from "@uesio/ui"
 import { cancel, save, useHasChanges } from "../../../api/defapi"
-import { useBuildMode } from "../../../api/stateapi"
+import { useBuildDepsLoaded, useBuildMode } from "../../../api/stateapi"
 import { toggleBuildMode } from "../../../helpers/buildmode"
 
 // Yes, navigator.platform is deprecated, but according to MDN in 2023
@@ -23,6 +23,10 @@ const BuildBarMainButtons: definition.UtilityComponent = (props) => {
 
   const hasChanges = useHasChanges(context)
   const [buildMode, setBuildMode] = useBuildMode(context)
+  const [buildDepsLoaded, setBuildDepsLoaded] = useBuildDepsLoaded(
+    context,
+    !!buildMode,
+  )
 
   hooks.useHotKeyCallback("meta+s", () => {
     save(context)
@@ -39,7 +43,13 @@ const BuildBarMainButtons: definition.UtilityComponent = (props) => {
         label={buildMode ? "Preview" : "Build"}
         variant="uesio/builder.secondarytoolbar"
         onClick={() => {
-          toggleBuildMode(context, setBuildMode, !!buildMode)
+          toggleBuildMode(
+            context,
+            setBuildMode,
+            setBuildDepsLoaded,
+            !!buildMode,
+            !!buildDepsLoaded,
+          )
         }}
       />
       <Button

--- a/libs/apps/uesio/builder/bundle/componentpacks/main/src/components/mainwrapper/mainwrapper.tsx
+++ b/libs/apps/uesio/builder/bundle/componentpacks/main/src/components/mainwrapper/mainwrapper.tsx
@@ -4,6 +4,7 @@ import {
   useBuildMode,
   useBuilderState,
   getBuilderComponentId,
+  useBuildDepsLoaded,
 } from "../../api/stateapi"
 import PropertiesPanel from "./propertiespanel/propertiespanel"
 import ViewInfoPanel from "./viewinfopanel/viewinfopanel"
@@ -59,6 +60,10 @@ const MainWrapper: definition.UC<component.ViewComponentDefinition> = (
   const Grid = component.getUtility("uesio/io.grid")
 
   const [buildMode, setBuildMode] = useBuildMode(context)
+  const [buildDepsLoaded, setBuildDepsLoaded] = useBuildDepsLoaded(
+    context,
+    !!buildMode,
+  )
 
   // Add a view frame to our builder context so that our component ids work right
   const builderContext = context
@@ -79,7 +84,13 @@ const MainWrapper: definition.UC<component.ViewComponentDefinition> = (
   hooks.useHotKeyCallback(
     "meta+u",
     () => {
-      toggleBuildMode(builderContext, setBuildMode, !!buildMode)
+      toggleBuildMode(
+        builderContext,
+        setBuildMode,
+        setBuildDepsLoaded,
+        !!buildMode,
+        !!buildDepsLoaded,
+      )
     },
     true,
     [buildMode, setBuildMode],

--- a/libs/apps/uesio/builder/bundle/componentpacks/main/src/helpers/buildmode.ts
+++ b/libs/apps/uesio/builder/bundle/componentpacks/main/src/helpers/buildmode.ts
@@ -42,14 +42,13 @@ const swapEditAndPreviewMode = (ctx: context.Context, buildMode: boolean) => {
 const toggleBuildMode = async (
   ctx: context.Context,
   setBuildMode: (state: boolean) => void,
+  setBuildDepsLoaded: (state: boolean) => void,
   buildMode: boolean,
+  buildDepsLoaded: boolean,
 ) => {
-  // check if we've already loaded the builder dependencies
-  // TODO: This should likely come from state rather than a component that we
-  // know won't be loaded in "preview" mode
-  const isLoaded = !!getBuilderExternalState(ctx, "indexpanel")
-  if (!isLoaded) {
+  if (!buildMode && !buildDepsLoaded) {
     await api.builder.getBuilderDeps(ctx)
+    setBuildDepsLoaded(true)
   }
   swapEditAndPreviewMode(ctx, !!buildMode)
   setBuildMode(!buildMode)

--- a/libs/apps/uesio/builder/bundle/componentpacks/main/src/helpers/buildmode.ts
+++ b/libs/apps/uesio/builder/bundle/componentpacks/main/src/helpers/buildmode.ts
@@ -1,5 +1,4 @@
 import { api, context } from "@uesio/ui"
-import { getBuilderExternalState } from "../api/stateapi"
 
 const editPath = "/edit"
 const previewPath = "/preview"

--- a/libs/apps/uesio/builder/bundle/componentpacks/main/src/helpers/buildmode.ts
+++ b/libs/apps/uesio/builder/bundle/componentpacks/main/src/helpers/buildmode.ts
@@ -45,7 +45,9 @@ const toggleBuildMode = async (
   buildMode: boolean,
 ) => {
   // check if we've already loaded the builder dependencies
-  const isLoaded = !!getBuilderExternalState(ctx, "namespaces")
+  // TODO: This should likely come from state rather than a component that we
+  // know won't be loaded in "preview" mode
+  const isLoaded = !!getBuilderExternalState(ctx, "indexpanel")
   if (!isLoaded) {
     await api.builder.getBuilderDeps(ctx)
   }


### PR DESCRIPTION
# What does this PR do?

Fixes the issue where starting in preview mode and then toggling to build mode would result in portions of the builder not displaying properly (e.g., index, properties panel).

The changes made in https://github.com/ues-io/uesio/pull/4817 actually fixed multiple issues.  In the previous code, the detection of the namespaces component was always returning `false` so we were attempting to load deps every time we went to `build` mode.  ~~We should likely move the way we determine whether or not we need to load deps in to state vs. checking for a component that we know doesn't exist in "preview" mode but this PR will solve the issue for now.~~ UPDATE: Migrated to using state for builder dep detection.

# Testing

Tested manually and all works.
