### PR TITLE
add chat panel feature flag

### DIFF
--- a/apps/platform-integration-tests/hurl_specs/builder_dependencies.hurl
+++ b/apps/platform-integration-tests/hurl_specs/builder_dependencies.hurl
@@ -19,14 +19,9 @@ user_id: jsonpath "$.user.id"
 GET {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/uesio/tests/dev/metadata/builder/uesio/tests/display_conditions
 HTTP 200
 [Asserts]
-# Verify that the feature flags are loaded in the view builder
-# Type Checkbox
-jsonpath "$.featureflag[9].name" == "manage_user_access_tokens"
-jsonpath "$.featureflag[9].type" == "CHECKBOX"
-jsonpath "$.featureflag[9].user" == {{user_id}}
-
-# Type Number
-jsonpath "$.featureflag[10].name" == "max_domains_per_user"
-jsonpath "$.featureflag[10].type" == "NUMBER"
-jsonpath "$.featureflag[10].value" >= 0
-jsonpath "$.featureflag[10].user" == {{user_id}}
+# Verify that the feature flags and labels are not loaded
+# Verify that the correct view definition is returned in the payload
+jsonpath "$.featureflag" isEmpty
+jsonpath "$.label" isEmpty
+jsonpath "$.viewdef[0].namespace" == "uesio/tests"
+jsonpath "$.viewdef[0].name" == "display_conditions"

--- a/apps/platform/pkg/routing/deps.go
+++ b/apps/platform/pkg/routing/deps.go
@@ -501,8 +501,6 @@ func GetBuilderDependencies(viewNamespace, viewName string, deps *preload.Preloa
 		deps.ComponentVariant.AddItem(variants[i])
 	}
 
-	// Load in studio specific feature flags.
-
 	deps.Component.AddItem(preload.NewComponentMergeData(GetBuildModeKey(builderComponentID), true))
 	deps.Component.AddItem(preload.NewComponentMergeData(GetIndexPanelKey(builderComponentID), true))
 

--- a/apps/platform/pkg/routing/deps.go
+++ b/apps/platform/pkg/routing/deps.go
@@ -416,12 +416,21 @@ func GetWorkspaceModeDeps(deps *preload.PreloadMetadata, session *sess.Session, 
 		return err
 	}
 
-	err = bundle.Load(theme, nil, session.RemoveWorkspaceContext(), nil)
+	baseStudioSession := session.RemoveWorkspaceContext()
+
+	err = bundle.Load(theme, nil, baseStudioSession, nil)
 	if err != nil {
 		return err
 	}
 
 	deps.Theme.AddItem(theme)
+
+	// Add in any builder-specfic feature flags.
+	chatPanelFlag, err := featureflagstore.GetFeatureFlag("uesio/studio.chat_panel", baseStudioSession, baseStudioSession.GetContextUser().ID)
+	if err != nil {
+		return err
+	}
+	deps.FeatureFlag.AddItem(chatPanelFlag)
 
 	// Get the metadata list
 	appNames := session.GetContextNamespaces()
@@ -481,11 +490,6 @@ func GetBuilderDependencies(viewNamespace, viewName string, deps *preload.Preloa
 		return errors.New("Failed to load components: " + err.Error())
 	}
 
-	labels, err := translate.GetTranslatedLabels(session)
-	if err != nil {
-		return errors.New("Failed to get translated labels: " + err.Error())
-	}
-
 	for _, component := range components {
 		if err = getDepsForComponent(component, deps, map[string]*yaml.Node{}, session); err != nil {
 			return err
@@ -497,27 +501,7 @@ func GetBuilderDependencies(viewNamespace, viewName string, deps *preload.Preloa
 		deps.ComponentVariant.AddItem(variants[i])
 	}
 
-	for key, value := range labels {
-		label, err := meta.NewLabel(key)
-		if err != nil {
-			return err
-		}
-		label.Value = value
-		deps.Label.AddItem(label)
-	}
-
-	// need an admin session for retrieving feature flags
-	// in order to prevent users from having to have read on the uesio/core.featureflagassignment table
-	adminSession := sess.GetAnonSessionFrom(session)
-
-	featureFlags, err := featureflagstore.GetFeatureFlags(adminSession, session.GetContextUser().ID)
-	if err != nil {
-		return errors.New("Failed to get feature flags: " + err.Error())
-	}
-
-	for _, flag := range *featureFlags {
-		deps.FeatureFlag.AddItem(flag)
-	}
+	// Load in studio specific feature flags.
 
 	deps.Component.AddItem(preload.NewComponentMergeData(GetBuildModeKey(builderComponentID), true))
 	deps.Component.AddItem(preload.NewComponentMergeData(GetIndexPanelKey(builderComponentID), true))

--- a/libs/apps/uesio/builder/bundle/componentpacks/main/src/components/mainwrapper/buildbar/buildbar_tools.tsx
+++ b/libs/apps/uesio/builder/bundle/componentpacks/main/src/components/mainwrapper/buildbar/buildbar_tools.tsx
@@ -44,6 +44,9 @@ const BuildBarTools: definition.UtilityComponent<Props> = (props) => {
 
   const classes = styles.useUtilityStyleTokens(StyleDefaults, props)
 
+  const hasChatFeature =
+    context.getFeatureFlag("uesio/studio.chat_panel")?.value === true
+
   const viewOptions: ViewOption[] = [
     {
       id: "code",
@@ -53,11 +56,14 @@ const BuildBarTools: definition.UtilityComponent<Props> = (props) => {
       id: "index",
       label: "Index Panel",
     },
-    {
+  ]
+
+  if (hasChatFeature) {
+    viewOptions.push({
       id: "chat",
       label: "Chat Panel",
-    },
-  ]
+    })
+  }
 
   const baseContext = context.getRouteContext()
 

--- a/libs/apps/uesio/builder/bundle/componentpacks/main/src/components/mainwrapper/mainwrapper.tsx
+++ b/libs/apps/uesio/builder/bundle/componentpacks/main/src/components/mainwrapper/mainwrapper.tsx
@@ -117,6 +117,9 @@ const MainWrapper: definition.UC<component.ViewComponentDefinition> = (
   const [showIndex] = useBuilderState<boolean>(context, "indexpanel")
   const [showChat] = useBuilderState<boolean>(context, "chatpanel")
 
+  const hasChatFeature =
+    context.getFeatureFlag("uesio/studio.chat_panel")?.value === true
+
   if (!buildMode) {
     return (
       <>
@@ -164,7 +167,7 @@ const MainWrapper: definition.UC<component.ViewComponentDefinition> = (
             </AdjustableHeightArea>
           )}
         </Grid>
-        {showChat && (
+        {showChat && hasChatFeature && (
           <Grid context={context} className={classes.rightpanel}>
             <ChatPanel context={builderContext.deleteWorkspace()} />
           </Grid>

--- a/libs/apps/uesio/studio/bundle/featureflags/chat_panel.yaml
+++ b/libs/apps/uesio/studio/bundle/featureflags/chat_panel.yaml
@@ -1,0 +1,4 @@
+name: chat_panel
+label: Chat Panel
+type: CHECKBOX
+defaultValue: false

--- a/libs/ui/src/bands/featureflag/index.ts
+++ b/libs/ui/src/bands/featureflag/index.ts
@@ -9,9 +9,6 @@ const adapter = createEntityAdapter({
 
 const selectors = adapter.getSelectors((state: RootState) => state.featureflag)
 
-const selectByName = (state: RootState, name: string) =>
-  selectors.selectAll(state).find((el) => el.name && el.name === name)
-
 const metadataSlice = createSlice({
   name: "featureflag",
   initialState: adapter.getInitialState(),
@@ -21,7 +18,7 @@ const metadataSlice = createSlice({
   },
 })
 
-export { selectByName, selectors, adapter }
+export { selectors, adapter }
 
 export const { set, setMany } = metadataSlice.actions
 export default metadataSlice.reducer

--- a/libs/ui/src/bands/selectlist/index.ts
+++ b/libs/ui/src/bands/selectlist/index.ts
@@ -14,9 +14,6 @@ const adapter = createEntityAdapter({
 
 const selectors = adapter.getSelectors((state: RootState) => state.selectlist)
 
-const selectByName = (state: RootState, name: string) =>
-  selectors.selectAll(state).find((el) => el.name && el.name === name)
-
 const selectById = (state: RootState, id: string) =>
   selectors.selectAll(state).find((el) => id === getKey(el))
 
@@ -62,14 +59,7 @@ const useSelectList = (key: string) =>
 
 const useSelectListKeys = () => useSelector(selectors.selectIds) as string[]
 
-export {
-  useSelectList,
-  useSelectListKeys,
-  selectById,
-  selectByName,
-  selectors,
-  adapter,
-}
+export { useSelectList, useSelectListKeys, selectById, selectors, adapter }
 
 export const { set, setMany } = metadataSlice.actions
 export default metadataSlice.reducer

--- a/libs/ui/src/component/display.ts
+++ b/libs/ui/src/component/display.ts
@@ -4,6 +4,7 @@ import { wire as wireApi } from "../api/api"
 import { Wire, WireRecord } from "../wireexports"
 import { DISPLAY_CONDITIONS } from "../componentexports"
 import { metadata } from ".."
+import { getFullyQualifiedKey } from "../bands/collection/class"
 
 type RequireOnlyOne<T, Keys extends keyof T = keyof T> = Pick<
   T,
@@ -377,8 +378,13 @@ function should(condition: DisplayCondition, context: Context): boolean {
 
   if (type === "fieldMode") return condition.mode === context.getFieldMode()
 
-  if (type === "featureFlag")
-    return !!context.getFeatureFlag(condition.name)?.value
+  if (type === "featureFlag") {
+    const qualifiedKey = getFullyQualifiedKey(
+      condition.name,
+      context.getNamespace(),
+    )
+    return !!context.getFeatureFlag(qualifiedKey)?.value
+  }
 
   if (type === "recordIsNew") return !!context.getRecord(wireName)?.isNew()
 

--- a/libs/ui/src/context/context.ts
+++ b/libs/ui/src/context/context.ts
@@ -11,7 +11,7 @@ import { selectors as componentVariantSelectors } from "../bands/componentvarian
 import { selectors as selectListSelectors } from "../bands/selectlist"
 import { selectors as routeAssignmentSelectors } from "../bands/routeassignment"
 import { selectors as themeSelectors } from "../bands/theme"
-import { selectByName as selectFeatureFlagByName } from "../bands/featureflag"
+import { selectors as featureFlagSelectors } from "../bands/featureflag"
 import { selectors as configValueSelectors } from "../bands/configvalue"
 import { selectWire } from "../bands/wire"
 import Wire from "../bands/wire/class"
@@ -534,7 +534,7 @@ class Context {
     fileSelectors.selectById(getCurrentState(), fileKey)?.updatedAt
 
   getFeatureFlag = (name: string) =>
-    selectFeatureFlagByName(getCurrentState(), name)
+    featureFlagSelectors.selectById(getCurrentState(), name)
 
   getConfigValue = (name: string) =>
     configValueSelectors.selectById(getCurrentState(), name)

--- a/libs/ui/src/definition/featureflag.ts
+++ b/libs/ui/src/definition/featureflag.ts
@@ -1,6 +1,6 @@
 import { BundleableBase } from "../metadata/types"
 
 export type FeatureFlagState = {
-  value: string
+  value: string | boolean | number
   type: "CHECKBOX" | "NUMBER"
 } & BundleableBase


### PR DESCRIPTION
# What does this PR do?

1. Removes unnecessary loading of all feature flags and language labels in the builder dependencies. (This isn't necessary, because this is done anyways for *every* page load whether or not you're in the builder. Doing this in the builder, was essentially loading these things twice.

2. Adds the `uesio/studio.chat_panel` feature flag.

3. Makes sure that the `uesio/studio.chat_panel` feature flag value is available in build mode.

4. Removes all `selectByName` selectors. (for feature flag and select list). This is a naive approach to getting values. You can't just ask for a value by name without the fully qualified key. How would you differentiate values from different namespaces?

5. To request a feature flag value, you now need to provide the fully qualified key. If you don't, it will use the view in context's namespace as the namespace of the key you're requesting.