### PR TITLE
chore: refactor app delete to use built-in cascade instead of custom …

### DIFF
--- a/libs/apps/uesio/studio/bundle/fields/uesio/studio/app/workspaces.yaml
+++ b/libs/apps/uesio/studio/bundle/fields/uesio/studio/app/workspaces.yaml
@@ -4,3 +4,4 @@ label: Workspaces
 referenceGroup:
   collection: workspace
   field: app
+  onDelete: CASCADE


### PR DESCRIPTION
…after bot

# What does this PR do?

Eliminates custom `app` delete after bot code to handle workspace deletes and instead relies on built-in onDelete cascade support.

# Testing

Manually tested and confirmed app & all workspaces were deleted.
