### PR TITLE
refactor: simplify cascade deletes

### DIFF
--- a/apps/platform/pkg/datasource/cascade.go
+++ b/apps/platform/pkg/datasource/cascade.go
@@ -26,7 +26,7 @@ func getCascadeDeletes(
 
 	deleteIds := op.Deletes.GetIDs()
 	userFilesToDelete := &wire.Collection{}
-	loadOp := &wire.LoadOp{
+	userFileIdLoadOp := &wire.LoadOp{
 		CollectionName: meta.USERFILEMETADATA_COLLECTION_NAME,
 		Collection:     userFilesToDelete,
 		WireName:       "deleteUserFiles",
@@ -41,7 +41,7 @@ func getCascadeDeletes(
 		LoadAll: true,
 	}
 
-	err := LoadWithError(loadOp, session, &LoadOptions{
+	err := LoadWithError(userFileIdLoadOp, session, &LoadOptions{
 		Connection: connection,
 	})
 	if err != nil {
@@ -107,7 +107,7 @@ func getCascadeDeletes(
 			}
 		}
 
-		op.AttachMetadataCache(metadata)
+		idLoadOp.AttachMetadataCache(metadata)
 
 		err = connection.Load(idLoadOp, versionSession)
 		if err != nil {


### PR DESCRIPTION
# What does this PR do?

1. Simplifies the cascade delete logic.

Because of a previous implementation where multiple operations were handled by the cascade delete function, this code was more complicated than it needed to be. This PR removes an unnecessary for loop, and returns early for fields not relevant to CASCADE delete.