### PR TITLE
feat: add component pack metadata item to workspace ui

### DIFF
--- a/libs/apps/uesio/studio/bundle/permissionsets/standard.yaml
+++ b/libs/apps/uesio/studio/bundle/permissionsets/standard.yaml
@@ -37,6 +37,8 @@ views:
   uesio/studio.collections: true
   uesio/studio.component: true
   uesio/studio.components: true
+  uesio/studio.componentpack: true
+  uesio/studio.componentpacks: true
   uesio/studio.configvalue: true
   uesio/studio.configvalues: true
   uesio/studio.credential: true
@@ -154,6 +156,8 @@ routes:
   uesio/studio.collections: true
   uesio/studio.component: true
   uesio/studio.components: true
+  uesio/studio.componentpack: true
+  uesio/studio.componentpacks: true
   uesio/studio.configvalue: true
   uesio/studio.configvalues: true
   uesio/studio.credential: true

--- a/libs/apps/uesio/studio/bundle/routes/componentpack.yaml
+++ b/libs/apps/uesio/studio/bundle/routes/componentpack.yaml
@@ -1,0 +1,5 @@
+name: componentpack
+path: app/{app:\w*\/\w*}/workspace/{workspacename}/componentpacks/{namespace:\w*\/\w*}/{componentpackname}
+view: componentpack
+theme: default
+title: "Component Pack: $Param{componentpackname}"

--- a/libs/apps/uesio/studio/bundle/routes/componentpacks.yaml
+++ b/libs/apps/uesio/studio/bundle/routes/componentpacks.yaml
@@ -1,0 +1,5 @@
+name: componentpacks
+path: app/{app:\w*\/\w*}/workspace/{workspacename}/componentpacks
+view: componentpacks
+theme: default
+title: Component Packs

--- a/libs/apps/uesio/studio/bundle/views/componentpack.yaml
+++ b/libs/apps/uesio/studio/bundle/views/componentpack.yaml
@@ -1,0 +1,62 @@
+name: componentpack
+definition:
+  # Wires are how we pull in data
+  wires:
+    workspaces:
+      collection: uesio/studio.workspace
+      fields:
+        uesio/core.id:
+        uesio/studio.name:
+        uesio/studio.app:
+          fields:
+            uesio/studio.color:
+            uesio/studio.icon:
+      conditions:
+        - field: uesio/core.uniquekey
+          value: $Param{app}:$Param{workspacename}
+    componentpacks:
+      collection: uesio/studio.componentpack
+      conditions:
+        - field: uesio/studio.allmetadata
+          value: true
+        - field: uesio/studio.item
+          value: $Param{namespace}.$Param{componentpackname}
+  # Components are how we describe the layout of our view
+  components:
+    - uesio/io.viewlayout:
+        uesio.variant: uesio/studio.main
+        left:
+          - uesio/core.view:
+              uesio.context:
+                wire: workspaces
+              view: workspacenav
+              params:
+                selected: componentpacks
+                itemType: componentpacks
+                itemIcon: package_2
+                itemName: $Param{componentpackname}
+                itemNameSpace: $Param{namespace}
+                itemNameSpaceIcon: ${componentpacks:uesio/studio.appicon}
+                itemNameSpaceColor: ${componentpacks:uesio/studio.appcolor}
+        content:
+          - uesio/appkit.layout_detail_split:
+              main:
+                - uesio/appkit.form_detail:
+                    wire: componentpacks
+                    avataricon: ${uesio/studio.appicon}
+                    avatariconcolor: ${uesio/studio.appcolor}
+                    deleteconfirm: true
+                    deletesignals:
+                      - signal: wire/MARK_FOR_DELETE
+                      - signal: wire/SAVE
+                      - signal: route/NAVIGATE
+                        path: app/$Param{app}/workspace/$Param{workspacename}/componentpacks
+                    content:
+                      - uesio/io.box:
+                          uesio.variant: uesio/appkit.primarysection
+                          components:
+                            - uesio/io.grid:
+                                uesio.variant: uesio/appkit.two_columns
+                                items:
+                                  - uesio/io.field:
+                                      fieldId: uesio/studio.name

--- a/libs/apps/uesio/studio/bundle/views/componentpacks.yaml
+++ b/libs/apps/uesio/studio/bundle/views/componentpacks.yaml
@@ -1,0 +1,95 @@
+name: componentpacks
+definition:
+  # Wires are how we pull in data
+  wires:
+    workspaces:
+      collection: uesio/studio.workspace
+      fields:
+        uesio/core.id:
+        uesio/studio.name:
+        uesio/studio.app:
+          fields:
+            uesio/studio.color:
+            uesio/studio.icon:
+      conditions:
+        - field: uesio/core.uniquekey
+          value: $Param{app}:$Param{workspacename}
+    componentpacks:
+      collection: uesio/studio.componentpack
+      conditions:
+        - field: uesio/studio.allmetadata
+          value: true
+        - field: uesio/studio.namespace
+          operator: EQ
+          inactive: false
+          id: localMetadataOnly
+          valueSource: PARAM
+          param: app
+  # Components are how we describe the layout of our view
+  components:
+    - uesio/io.viewlayout:
+        uesio.variant: uesio/studio.main
+        left:
+          - uesio/core.view:
+              uesio.context:
+                wire: workspaces
+              view: workspacenav
+              params:
+                selected: componentpacks
+                itemType: componentpacks
+                itemIcon: package_2
+        content:
+          - uesio/appkit.layout_detail_split:
+              main:
+                - uesio/io.titlebar:
+                    uesio.variant: uesio/appkit.main
+                    title: Component Packs
+                    subtitle: Source code for your components.
+                    avatar:
+                      - uesio/io.text:
+                          uesio.variant: uesio/io.icon
+                          text: package_2
+                    actions:
+                      - uesio/io.group:
+                          components:
+                            - uesio/studio.generatorbutton:
+                                uesio.context:
+                                  workspace:
+                                    name: $Param{workspacename}
+                                    app: $Param{app}
+                                buttonVariant: uesio/appkit.secondary
+                                hotkey: "n"
+                                icon: add
+                                label: New Component Pack
+                                generator: uesio/core.componentpack
+                - uesio/io.box:
+                    uesio.variant: uesio/appkit.primarysection
+                    components:
+                      - uesio/studio.listheader:
+                          wire: componentpacks
+                          searchFields:
+                            - uesio/studio.name
+                      - uesio/io.table:
+                          uesio.id: componentpacksTable
+                          wire: componentpacks
+                          uesio.variant: uesio/appkit.main
+                          columns:
+                            - label: Component Pack
+                              components:
+                                - uesio/studio.item_metadata:
+                              width: 220px
+                            - field: uesio/core.updatedby
+                              user:
+                                subtitle: $Time{uesio/core.updatedat}
+                              width: 200px
+                            - field: uesio/core.createdby
+                              user:
+                                subtitle: $Time{uesio/core.createdat}
+                              width: 200px
+                          rowactions:
+                            - text: Details
+                              type: DEFAULT
+                              signals:
+                                - signal: route/NAVIGATE
+                                  path: app/$Param{app}/workspace/$Param{workspacename}/componentpacks/${uesio/studio.namespace}/${uesio/studio.name}
+                          pagesize: 10

--- a/libs/apps/uesio/studio/bundle/views/workspacenav.yaml
+++ b/libs/apps/uesio/studio/bundle/views/workspacenav.yaml
@@ -124,6 +124,18 @@ definition:
                         path: app/${uesio/studio.app->uesio/core.uniquekey}/workspace/${uesio/studio.name}/components
                 - uesio/appkit.icontile:
                     tileVariant: uesio/io.nav
+                    uesio.display:
+                      - type: featureFlag
+                        name: manage_components
+                    uesio.id: componentpacks
+                    title: Component Packs
+                    icon: package_2
+                    selectedid: $Param{selected}
+                    signals:
+                      - signal: "route/NAVIGATE"
+                        path: app/${uesio/studio.app->uesio/core.uniquekey}/workspace/${uesio/studio.name}/componentpacks
+                - uesio/appkit.icontile:
+                    tileVariant: uesio/io.nav
                     uesio.id: themes
                     title: Themes
                     icon: palette


### PR DESCRIPTION
# What does this PR do?

This is just a start, but this PR adds a UI for administering component packs behind the `manage_components` feature flag. Right now, you can only add and delete component packs.

However, in a follow-up PR we could add the ability to browse files in a component pack and even make edits.

<img width="1404" alt="Screenshot 2025-04-22 at 12 01 31 PM" src="https://github.com/user-attachments/assets/665798b3-1a7d-45e0-81ab-60ed6d64a2c8" />
