### PR TITLE
refactor: make userfilemetadata implement file.metadata

### DIFF
--- a/apps/platform/pkg/bot/jsdialect/apihelpers.go
+++ b/apps/platform/pkg/bot/jsdialect/apihelpers.go
@@ -139,7 +139,7 @@ func botCopyUserFile(sourceFileID, destCollectionID, destRecordID, destFieldID s
 	_, err = filesource.Upload([]*filesource.FileUploadOp{
 		{
 			Data:         buf,
-			Path:         userFileMetadata.Path,
+			Path:         userFileMetadata.Path(),
 			CollectionID: destCollectionID,
 			RecordID:     destRecordID,
 			FieldID:      destFieldID,

--- a/apps/platform/pkg/bulk/exportfiles.go
+++ b/apps/platform/pkg/bulk/exportfiles.go
@@ -70,7 +70,7 @@ func exportFiles(create bundlestore.FileCreator, spec *meta.JobSpec, session *se
 	}
 
 	for _, userFile := range *userFiles {
-		file, err := create(fmt.Sprintf("files/%s/%s", userFile.ID, userFile.Path))
+		file, err := create(fmt.Sprintf("files/%s/%s", userFile.ID, userFile.Path()))
 		if err != nil {
 			return err
 		}

--- a/apps/platform/pkg/bundlestore/filebundlestore/filebundlestore.go
+++ b/apps/platform/pkg/bundlestore/filebundlestore/filebundlestore.go
@@ -101,8 +101,10 @@ func (b *FileBundleStoreConnection) GetItem(item meta.BundleableItem, options *b
 		},
 	}
 
-	item.SetModified(*fileMetadata.LastModified())
-	item.SetCreated(*fileMetadata.LastModified())
+	lastModified := fileMetadata.LastModified()
+
+	item.SetModified(lastModified)
+	item.SetCreated(lastModified)
 
 	item.SetModifiedBy(fakeNamespaceUser)
 	item.SetCreatedBy(fakeNamespaceUser)

--- a/apps/platform/pkg/bundlestore/workspacebundlestore/workspacebundlestore.go
+++ b/apps/platform/pkg/bundlestore/workspacebundlestore/workspacebundlestore.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"strings"
-	"time"
 
 	"github.com/thecloudmasters/uesio/pkg/bundlestore"
 	"github.com/thecloudmasters/uesio/pkg/constant/commonfields"
@@ -18,27 +17,6 @@ import (
 	"github.com/thecloudmasters/uesio/pkg/types/file"
 	"github.com/thecloudmasters/uesio/pkg/types/wire"
 )
-
-type wsFileMeta struct {
-	userFileMeta *meta.UserFileMetadata
-}
-
-func newWorkspaceFileMeta(info *meta.UserFileMetadata) file.Metadata {
-	return &wsFileMeta{info}
-}
-
-func (fm *wsFileMeta) ContentLength() int64 {
-	return fm.userFileMeta.ContentLength
-}
-
-func (fm *wsFileMeta) Path() string {
-	return fm.userFileMeta.Path
-}
-
-func (fm *wsFileMeta) LastModified() *time.Time {
-	t := time.Unix(fm.userFileMeta.UpdatedAt, 0)
-	return &t
-}
 
 func getParamsFromWorkspace(workspace *meta.Workspace) map[string]interface{} {
 	return map[string]interface{}{
@@ -323,7 +301,7 @@ func (b *WorkspaceBundleStoreConnection) GetItemAttachment(w io.Writer, item met
 	if err != nil {
 		return nil, err
 	}
-	return newWorkspaceFileMeta(userFileMetadata), nil
+	return userFileMetadata, nil
 }
 
 func (b *WorkspaceBundleStoreConnection) GetAttachmentData(item meta.AttachableItem) (*meta.UserFileMetadataCollection, error) {
@@ -357,7 +335,7 @@ func (b *WorkspaceBundleStoreConnection) GetAttachmentPaths(item meta.Attachable
 	}
 	paths := make([]file.Metadata, userFiles.Len())
 	for i, ufm := range *userFiles {
-		paths[i] = newWorkspaceFileMeta(ufm)
+		paths[i] = ufm
 	}
 	return paths, nil
 }
@@ -369,7 +347,7 @@ func (b *WorkspaceBundleStoreConnection) GetItemAttachments(creator bundlestore.
 	}
 
 	for _, ufm := range *userFiles {
-		f, err := creator(ufm.Path)
+		f, err := creator(ufm.Path())
 		if err != nil {
 			return err
 		}

--- a/apps/platform/pkg/controller/file/componentpack.go
+++ b/apps/platform/pkg/controller/file/componentpack.go
@@ -42,7 +42,7 @@ func ServeComponentPackFile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	lastModified := *fileMeta.LastModified()
+	lastModified := fileMeta.LastModified()
 
 	// Get the greater of the two modification times
 	if lastModified.Unix() < componentPack.UpdatedAt {

--- a/apps/platform/pkg/controller/file/font.go
+++ b/apps/platform/pkg/controller/file/font.go
@@ -41,7 +41,7 @@ func ServeFontFile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	lastModified := *fileMeta.LastModified()
+	lastModified := fileMeta.LastModified()
 
 	// Get the greater of the two modification times
 	if lastModified.Unix() < font.UpdatedAt {

--- a/apps/platform/pkg/controller/file/serve_file.go
+++ b/apps/platform/pkg/controller/file/serve_file.go
@@ -73,7 +73,7 @@ func ServeFileContent(file *meta.File, version string, path string, w http.Respo
 	}
 	respondFile(w, r, &FileRequest{
 		Path:         path,
-		LastModified: *fileMetadata.LastModified(),
+		LastModified: fileMetadata.LastModified(),
 		Namespace:    file.Namespace,
 		Version:      version,
 	}, bytes.NewReader(buf.Bytes()))

--- a/apps/platform/pkg/controller/file/userfile.go
+++ b/apps/platform/pkg/controller/file/userfile.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"io"
 	"net/http"
-	"time"
 
 	"github.com/gorilla/mux"
 
@@ -101,8 +100,8 @@ func DownloadUserFile(w http.ResponseWriter, r *http.Request) {
 		ctlutil.HandleError(w, err)
 	} else {
 		respondFile(w, r, &FileRequest{
-			Path:         userFile.Path,
-			LastModified: time.Unix(userFile.UpdatedAt, 0),
+			Path:         userFile.Path(),
+			LastModified: userFile.LastModified(),
 			Namespace:    "",
 			Version:      version,
 		}, bytes.NewReader(buf.Bytes()))
@@ -129,8 +128,8 @@ func DownloadAttachment(w http.ResponseWriter, r *http.Request) {
 		ctlutil.HandleError(w, err)
 	} else {
 		respondFile(w, r, &FileRequest{
-			Path:         userFile.Path,
-			LastModified: time.Unix(userFile.UpdatedAt, 0),
+			Path:         userFile.Path(),
+			LastModified: userFile.LastModified(),
 			Namespace:    "",
 			Version:      version,
 		}, bytes.NewReader(buf.Bytes()))

--- a/apps/platform/pkg/fileadapt/s3/download.go
+++ b/apps/platform/pkg/fileadapt/s3/download.go
@@ -47,8 +47,8 @@ func (fm *s3FileMeta) ContentLength() int64 {
 	return 0
 }
 
-func (fm *s3FileMeta) LastModified() *time.Time {
-	return fm.s3Output.LastModified
+func (fm *s3FileMeta) LastModified() time.Time {
+	return *fm.s3Output.LastModified
 }
 
 func (c *Connection) Download(w io.Writer, path string) (file.Metadata, error) {

--- a/apps/platform/pkg/fileadapt/s3/list.go
+++ b/apps/platform/pkg/fileadapt/s3/list.go
@@ -31,8 +31,8 @@ func (fm *s3PaginatorFileMeta) ContentLength() int64 {
 	return 0
 }
 
-func (fm *s3PaginatorFileMeta) LastModified() *time.Time {
-	return fm.s3Output.LastModified
+func (fm *s3PaginatorFileMeta) LastModified() time.Time {
+	return *fm.s3Output.LastModified
 }
 
 func (c *Connection) List(path string) ([]file.Metadata, error) {

--- a/apps/platform/pkg/filesource/download.go
+++ b/apps/platform/pkg/filesource/download.go
@@ -107,7 +107,7 @@ func DownloadItem(w io.Writer, userFile *meta.UserFileMetadata, session *sess.Se
 	}
 
 	usage.RegisterEvent("DOWNLOAD", "FILESOURCE", userFile.FileSourceID, 0, session)
-	usage.RegisterEvent("DOWNLOAD_BYTES", "FILESOURCE", userFile.FileSourceID, userFile.ContentLength, session)
+	usage.RegisterEvent("DOWNLOAD_BYTES", "FILESOURCE", userFile.FileSourceID, userFile.ContentLength(), session)
 
 	return userFile, nil
 }

--- a/apps/platform/pkg/filesource/upload.go
+++ b/apps/platform/pkg/filesource/upload.go
@@ -131,7 +131,7 @@ func Upload(ops []*FileUploadOp, connection wire.Connection, session *sess.Sessi
 			CollectionID: op.CollectionID,
 			MimeType:     mime.TypeByExtension(path.Ext(op.Path)),
 			FieldID:      op.FieldID,
-			Path:         op.Path,
+			FilePath:     op.Path,
 			Type:         GetFileType(op.FieldID),
 			RecordID:     op.RecordID,
 			FileSourceID: PLATFORM_FILE_SOURCE,
@@ -152,7 +152,7 @@ func Upload(ops []*FileUploadOp, connection wire.Connection, session *sess.Sessi
 			return nil, err
 		}
 
-		ufm.ContentLength = written
+		ufm.FileContentLength = written
 
 		usage.RegisterEvent("UPLOAD", "FILESOURCE", ufm.FileSourceID, 0, session)
 		usage.RegisterEvent("UPLOAD_BYTES", "FILESOURCE", ufm.FileSourceID, written, session)

--- a/apps/platform/pkg/meta/userfilemetadata.go
+++ b/apps/platform/pkg/meta/userfilemetadata.go
@@ -3,18 +3,19 @@ package meta
 import (
 	"fmt"
 	"strings"
+	"time"
 )
 
 type UserFileMetadata struct {
-	BuiltIn       `yaml:",inline"`
-	CollectionID  string `json:"uesio/core.collectionid"`
-	MimeType      string `json:"uesio/core.mimetype"`
-	FieldID       string `json:"uesio/core.fieldid"`
-	FileSourceID  string `json:"uesio/core.filesourceid"`
-	Path          string `json:"uesio/core.path"`
-	RecordID      string `json:"uesio/core.recordid"`
-	Type          string `json:"uesio/core.type"`
-	ContentLength int64  `json:"uesio/core.contentlength"`
+	BuiltIn           `yaml:",inline"`
+	CollectionID      string `json:"uesio/core.collectionid"`
+	MimeType          string `json:"uesio/core.mimetype"`
+	FieldID           string `json:"uesio/core.fieldid"`
+	FileSourceID      string `json:"uesio/core.filesourceid"`
+	FilePath          string `json:"uesio/core.path"`
+	RecordID          string `json:"uesio/core.recordid"`
+	Type              string `json:"uesio/core.type"`
+	FileContentLength int64  `json:"uesio/core.contentlength"`
 }
 
 func (ufm *UserFileMetadata) GetCollection() CollectionableGroup {
@@ -50,12 +51,25 @@ func (ufm *UserFileMetadata) GetRelativePath() string {
 	collectionPath := strings.ReplaceAll(ufm.CollectionID, ".", "/")
 	fieldPath := strings.ReplaceAll(ufm.FieldID, ".", "/")
 	if ufm.FieldID != "" {
-		return fmt.Sprintf("%s/%s/field/%s/%s", collectionPath, ufm.RecordID, fieldPath, ufm.Path)
+		return fmt.Sprintf("%s/%s/field/%s/%s", collectionPath, ufm.RecordID, fieldPath, ufm.FilePath)
 	}
-	return fmt.Sprintf("%s/%s/attachment/%s", collectionPath, ufm.RecordID, ufm.Path)
+	return fmt.Sprintf("%s/%s/attachment/%s", collectionPath, ufm.RecordID, ufm.FilePath)
 }
 
 func (ufm *UserFileMetadata) UnmarshalJSON(data []byte) error {
 	type alias UserFileMetadata
 	return refScanner((*alias)(ufm), data)
+}
+
+// Methods to implement the file.Metadata interface
+func (ufm *UserFileMetadata) ContentLength() int64 {
+	return ufm.FileContentLength
+}
+
+func (ufm *UserFileMetadata) Path() string {
+	return ufm.FilePath
+}
+
+func (ufm *UserFileMetadata) LastModified() time.Time {
+	return time.Unix(ufm.UpdatedAt, 0)
 }

--- a/apps/platform/pkg/types/file/filemetadata.go
+++ b/apps/platform/pkg/types/file/filemetadata.go
@@ -9,7 +9,7 @@ import (
 
 type Metadata interface {
 	ContentLength() int64
-	LastModified() *time.Time
+	LastModified() time.Time
 	Path() string
 }
 
@@ -19,10 +19,10 @@ type MetadataWrapper struct {
 
 func (m MetadataWrapper) MarshalJSON() ([]byte, error) {
 	type metadataJSON struct {
-		FileSize int64      `json:"filesize"`
-		Path     string     `json:"path"`
-		Modified *time.Time `json:"modified"`
-		MimeType string     `json:"mimetype"`
+		FileSize int64     `json:"filesize"`
+		Path     string    `json:"path"`
+		Modified time.Time `json:"modified"`
+		MimeType string    `json:"mimetype"`
 	}
 
 	filePath := m.Metadata.Path()

--- a/apps/platform/pkg/types/file/localfilemetadata.go
+++ b/apps/platform/pkg/types/file/localfilemetadata.go
@@ -18,9 +18,8 @@ func (fm *localFileMeta) ContentLength() int64 {
 	return fm.fileInfo.Size()
 }
 
-func (fm *localFileMeta) LastModified() *time.Time {
-	t := fm.fileInfo.ModTime()
-	return &t
+func (fm *localFileMeta) LastModified() time.Time {
+	return fm.fileInfo.ModTime()
 }
 
 func (fm *localFileMeta) Path() string {


### PR DESCRIPTION
# What does this PR do?

1. Instead of creating a one-off wrapper for workspace file metadata, this PR just makes the `meta.UserFileMetadata` implement the `file.Metadata` interface.

2. Store and Pass `time.Time` as values instead of pointers. As suggested here... https://pkg.go.dev/time#Time

> Programs using times should typically store and pass them as values, not pointers. That is, time variables and struct fields should be of type [time.Time](https://pkg.go.dev/time#Time), not *time.Time.

NOTE: This change is needed for another change that will simplify managing files in the studio. (And allow for managing component pack files)