### PR TITLE
refactor: remove session argument from GetFieldMetadata

### DIFF
--- a/apps/platform/pkg/datasource/metadata.go
+++ b/apps/platform/pkg/datasource/metadata.go
@@ -10,7 +10,7 @@ import (
 	"github.com/thecloudmasters/uesio/pkg/types/wire"
 )
 
-func GetFieldMetadata(f *meta.Field, session *sess.Session) *wire.FieldMetadata {
+func GetFieldMetadata(f *meta.Field) *wire.FieldMetadata {
 	fieldMetadata := &wire.FieldMetadata{
 		Name:                   f.Name,
 		Namespace:              f.Namespace,
@@ -249,7 +249,7 @@ func LoadAllFieldsMetadata(collectionKey string, collectionMetadata *wire.Collec
 	AddAllBuiltinFields(&fields, collectionKey)
 
 	for _, field := range fields {
-		collectionMetadata.SetField(GetFieldMetadata(field, session))
+		collectionMetadata.SetField(GetFieldMetadata(field))
 	}
 	return nil
 }
@@ -258,10 +258,10 @@ func LoadFieldsMetadata(keys []string, collectionKey string, collectionMetadata 
 
 	// Always add metadata for id and unique key
 	idFieldMeta, _ := GetBuiltinField(commonfields.Id, collectionKey)
-	collectionMetadata.SetField(GetFieldMetadata(&idFieldMeta, session))
+	collectionMetadata.SetField(GetFieldMetadata(&idFieldMeta))
 
 	uniqueKeyFieldMeta, _ := GetBuiltinField(commonfields.UniqueKey, collectionKey)
-	collectionMetadata.SetField(GetFieldMetadata(&uniqueKeyFieldMeta, session))
+	collectionMetadata.SetField(GetFieldMetadata(&uniqueKeyFieldMeta))
 
 	fields := []meta.BundleableItem{}
 	for _, key := range keys {
@@ -270,7 +270,7 @@ func LoadFieldsMetadata(keys []string, collectionKey string, collectionMetadata 
 			// Check if this field is built-in, if so, handle its metadata here
 			builtInField, isBuiltIn := GetBuiltinField(key, collectionKey)
 			if isBuiltIn {
-				collectionMetadata.SetField(GetFieldMetadata(&builtInField, session))
+				collectionMetadata.SetField(GetFieldMetadata(&builtInField))
 				continue
 			}
 			field, err := meta.NewField(collectionKey, meta.GetFullyQualifiedKey(key, collectionMetadata.Namespace))
@@ -297,7 +297,7 @@ func LoadFieldsMetadata(keys []string, collectionKey string, collectionMetadata 
 		if field.Type == "" {
 			continue
 		}
-		collectionMetadata.SetField(GetFieldMetadata(field, session))
+		collectionMetadata.SetField(GetFieldMetadata(field))
 	}
 	return nil
 }

--- a/apps/platform/pkg/datasource/metadata_test.go
+++ b/apps/platform/pkg/datasource/metadata_test.go
@@ -6,18 +6,10 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/thecloudmasters/uesio/pkg/meta"
-	"github.com/thecloudmasters/uesio/pkg/sess"
 	"github.com/thecloudmasters/uesio/pkg/types/wire"
 )
 
 func TestGetFieldMetadata(t *testing.T) {
-	session := &sess.Session{}
-	site := &meta.Site{}
-	session.SetSiteSession(sess.NewSiteSession(site, &meta.User{}))
-	session.SetLabels(map[string]string{
-		"luigi/foo.bar": "Bar",
-		"luigi/foo.baz": "Baz",
-	})
 	builtIn := meta.BuiltIn{}
 	bundleableBase := meta.BundleableBase{
 		Name:      "fieldname",
@@ -206,7 +198,7 @@ func TestGetFieldMetadata(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equalf(t, tt.want, GetFieldMetadata(tt.input, session), "GetFieldMetadata(%v)", tt.input)
+			assert.Equalf(t, tt.want, GetFieldMetadata(tt.input), "GetFieldMetadata(%v)", tt.input)
 		})
 	}
 }


### PR DESCRIPTION
# What does this PR do?

Removes the session argument from GetFieldMetadata

At one point we required the session to be passed into the GetFieldMetadata function. I think it may have been related to merging in labels at one point. However, I think we should handle this in a different way if we every do implement that functionality.