### PR TITLE
refactor: cleanup errors and add switch statements

### DIFF
--- a/apps/cli/pkg/auth/login.go
+++ b/apps/cli/pkg/auth/login.go
@@ -26,7 +26,7 @@ type LoginMethodHandler struct {
 func parseKey(key string) (string, string, error) {
 	keyArray := strings.Split(key, ".")
 	if len(keyArray) != 2 {
-		return "", "", errors.New("Invalid Key: " + key)
+		return "", "", fmt.Errorf("invalid key: %s", key)
 	}
 	return keyArray[0], keyArray[1], nil
 }
@@ -238,7 +238,7 @@ func Login() (*UserMergeData, error) {
 	}
 
 	if sessid == "" {
-		return nil, errors.New("No cookie found in login response")
+		return nil, errors.New("no cookie found in login response")
 	}
 
 	err = config.SetSessionID(sessid)

--- a/apps/cli/pkg/cmd/site.go
+++ b/apps/cli/pkg/cmd/site.go
@@ -41,7 +41,7 @@ func siteUse(cmd *cobra.Command, args []string) error {
 	err := site.UseBundle(siteName, newBundleVersion)
 	if err != nil {
 
-		return fmt.Errorf("Unable to update site to use the requested bundle: %w", err)
+		return fmt.Errorf("unable to update site to use the requested bundle: %w", err)
 	}
 	fmt.Printf("Successfully updated site %s to use bundle: %s\n", siteName, newBundleVersion)
 	return nil

--- a/apps/cli/pkg/command/generate.go
+++ b/apps/cli/pkg/command/generate.go
@@ -3,7 +3,6 @@ package command
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -60,7 +59,7 @@ func Generate(key string) error {
 
 	botParams := &meta.BotParamsResponse{}
 	if err = call.GetJSON(paramsURL, sessionId, botParams); err != nil {
-		return errors.New("unable to retrieve metadata for generator '" + key + "': " + err.Error())
+		return fmt.Errorf("unable to retrieve metadata for generator '%s': %w", key, err)
 	}
 
 	answers, err := param.AskMany(botParams, app, version, sessionId)

--- a/apps/cli/pkg/command/logout.go
+++ b/apps/cli/pkg/command/logout.go
@@ -14,9 +14,9 @@ func Logout() error {
 	}
 
 	if user == nil {
-		fmt.Println("No current session found")
+		fmt.Println("no current session found")
 		return nil
 	}
-	fmt.Println("Successfully logged out user")
+	fmt.Println("successfully logged out user")
 	return nil
 }

--- a/apps/cli/pkg/command/site/siteDeploy.go
+++ b/apps/cli/pkg/command/site/siteDeploy.go
@@ -1,7 +1,6 @@
 package site
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
@@ -18,10 +17,10 @@ func UseBundle(siteName, newBundleVersion string) error {
 	// Verify that the requested site exists
 	siteExists, err := wire.DoesSiteExist(app.ID, siteName)
 	if err != nil {
-		return errors.New("unable to verify that the requested site exists")
+		return fmt.Errorf("unable to verify that the requested site exists: %s", siteName)
 	}
 	if !siteExists {
-		return errors.New("the requested site does not exist: " + siteName)
+		return fmt.Errorf("the requested site does not exist: %s", siteName)
 	}
 
 	// The bundle version's unique key is appFullName:major:minor:patch

--- a/apps/cli/pkg/command/upsert.go
+++ b/apps/cli/pkg/command/upsert.go
@@ -47,7 +47,7 @@ func getImportPayload(jobType, dataFile string) (io.Reader, error) {
 	if jobType == "UPLOADFILES" {
 		return zip.ZipDir(dataFile), nil
 	}
-	return nil, errors.New("Invalid Job Type: " + jobType)
+	return nil, fmt.Errorf("invalid job type: %s", jobType)
 }
 
 func runBatch(prefix, sessionId, dataFile, jobID string, spec *meta.JobSpecRequest) (*bulk.BatchResponse, error) {
@@ -99,7 +99,7 @@ func getSpec(options *UpsertOptions) (*meta.JobSpecRequest, error) {
 	}
 
 	if spec.Collection == "" {
-		return nil, errors.New("No collection specified")
+		return nil, errors.New("no collection specified")
 	}
 
 	if spec.JobType == "IMPORT" {
@@ -129,7 +129,7 @@ func UpsertToWorkspace(options *UpsertOptions) error {
 	}
 
 	if workspace == "" {
-		return errors.New("No active workspace is set. Use \"uesio work\" to set one.")
+		return errors.New("no active workspace is set -- use \"uesio work\" to set one")
 	}
 
 	return Upsert(getUrlPrefix("workspace", app, workspace), options)
@@ -153,7 +153,7 @@ func UpsertToSite(options *UpsertOptions) error {
 	}
 
 	if site == "" {
-		return errors.New("No active site is set. Use \"uesio siteadmin\" to set one.")
+		return errors.New("no active site is set -- use \"uesio siteadmin\" to set one")
 	}
 
 	return Upsert(getUrlPrefix("siteadmin", app, site), options)
@@ -166,7 +166,7 @@ func Upsert(prefix string, options *UpsertOptions) error {
 	}
 
 	if options.DataFile == "" {
-		return errors.New("No Data File Specified")
+		return errors.New("no data file specified")
 	}
 
 	fmt.Println("Running Upsert Command")

--- a/apps/cli/pkg/command/workspace/create.go
+++ b/apps/cli/pkg/command/workspace/create.go
@@ -37,7 +37,7 @@ func Create(newWorkspace string) error {
 	// Invoke workspace creation API to create the workspace
 	_, err = wire.CreateNewWorkspace(appObject.ID, newWorkspace)
 	if err != nil {
-		return errors.New("unable to create new workspace for app: " + err.Error())
+		return fmt.Errorf("unable to create new workspace for app: %w", err)
 	}
 
 	// Set the current workspace as the new workspace

--- a/apps/cli/pkg/command/workspace/deploy.go
+++ b/apps/cli/pkg/command/workspace/deploy.go
@@ -30,7 +30,7 @@ func Deploy() error {
 	}
 
 	if workspace == "" {
-		return errors.New("No active workspace is set. Use \"uesio work\" to set one.")
+		return errors.New("no active workspace is set -- use \"uesio work\" to set one")
 	}
 
 	sessid, err := config.GetSessionID()

--- a/apps/cli/pkg/command/workspace/retrieve.go
+++ b/apps/cli/pkg/command/workspace/retrieve.go
@@ -43,7 +43,7 @@ func Retrieve(options *RetrieveOptions) error {
 	}
 
 	if workspace == "" {
-		return errors.New("No active workspace is set. Use \"uesio work\" to set one.")
+		return errors.New("no active workspace is set -- use \"uesio work\" to set one")
 	}
 
 	if options.OnlyTypes {

--- a/apps/cli/pkg/command/workspace/truncate.go
+++ b/apps/cli/pkg/command/workspace/truncate.go
@@ -29,7 +29,7 @@ func Truncate() error {
 	}
 
 	if workspace == "" {
-		return errors.New("No active workspace is set. Use \"uesio work\" to set one.")
+		return errors.New("no active workspace is set -- use \"uesio work\" to set one")
 	}
 
 	sessionId, err := config.GetSessionID()

--- a/apps/cli/pkg/config/app.go
+++ b/apps/cli/pkg/config/app.go
@@ -1,7 +1,7 @@
 package config
 
 import (
-	"errors"
+	"fmt"
 
 	"github.com/thecloudmasters/cli/pkg/localbundlestore"
 	"github.com/thecloudmasters/uesio/pkg/bundlestore"
@@ -32,7 +32,7 @@ func GetVersion(namespace string) (string, error) {
 
 	versionInfo, ok := def.Dependencies[namespace]
 	if !ok {
-		return "", errors.New("That namespace is not installed: " + namespace)
+		return "", fmt.Errorf("that namespace is not installed: %s", namespace)
 	}
 
 	return versionInfo.Version, nil

--- a/apps/cli/pkg/config/siteadmin/siteadmin.go
+++ b/apps/cli/pkg/config/siteadmin/siteadmin.go
@@ -1,7 +1,7 @@
 package siteadmin
 
 import (
-	"errors"
+	"fmt"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/thecloudmasters/cli/pkg/config"
@@ -39,7 +39,7 @@ func SetSiteAdminPrompt(appId string) (string, error) {
 		return options[0], SetSiteAdmin(options[0])
 	}
 	if len(options) == 0 {
-		return "", errors.New("unable to create new workspace for app: " + err.Error())
+		return "", fmt.Errorf("unable to create new workspace for app: %w", err)
 	}
 
 	err = survey.AskOne(&survey.Select{

--- a/apps/cli/pkg/config/ws/ws.go
+++ b/apps/cli/pkg/config/ws/ws.go
@@ -1,7 +1,7 @@
 package ws
 
 import (
-	"errors"
+	"fmt"
 
 	"github.com/AlecAivazis/survey/v2"
 
@@ -61,7 +61,7 @@ func SetWorkspacePrompt(appId string) (string, error) {
 		// Invoke workspace creation API to create the new workspace
 		_, err := wire.CreateNewWorkspace(appID, newWorkspaceName)
 		if err != nil {
-			return "", errors.New("unable to create new workspace for app: " + err.Error())
+			return "", fmt.Errorf("unable to create new workspace for app: %w", err)
 		}
 		return newWorkspaceName, SetWorkspace(newWorkspaceName)
 	}

--- a/apps/cli/pkg/pack/globalsplugin.go
+++ b/apps/cli/pkg/pack/globalsplugin.go
@@ -2,8 +2,9 @@ package pack
 
 import (
 	"errors"
-	"github.com/thecloudmasters/cli/pkg/goutils"
 	"strings"
+
+	"github.com/thecloudmasters/cli/pkg/goutils"
 
 	"github.com/evanw/esbuild/pkg/api"
 )
@@ -36,7 +37,7 @@ func GetGlobalsPlugin(globalsMap map[string]string) api.Plugin {
 				func(args api.OnLoadArgs) (api.OnLoadResult, error) {
 					match, ok := globalsMap[args.Path]
 					if !ok {
-						return api.OnLoadResult{}, errors.New("Invalid Import")
+						return api.OnLoadResult{}, errors.New("invalid import")
 					}
 					contents := "module.exports = " + match
 					return api.OnLoadResult{

--- a/apps/cli/pkg/param/param.go
+++ b/apps/cli/pkg/param/param.go
@@ -123,7 +123,7 @@ func mergeParam(templateString string, answers map[string]interface{}) (string, 
 	answerFunc := func(m map[string]interface{}, key string) (interface{}, error) {
 		val, ok := answers[key]
 		if !ok {
-			return nil, errors.New("missing answer " + key)
+			return nil, fmt.Errorf("missing answer: %s", key)
 		}
 		return val, nil
 	}
@@ -310,7 +310,7 @@ func Ask(param meta.BotParamResponse, app, version, sessid string, answers map[s
 		}
 		answers[param.Name] = answer
 	default:
-		return errors.New("Invalid Param Type: " + param.Type)
+		return fmt.Errorf("invalid param type: %s", param.Type)
 	}
 
 	return nil

--- a/apps/cli/pkg/print/print.go
+++ b/apps/cli/pkg/print/print.go
@@ -12,7 +12,7 @@ func PrintUserSummary(user *auth.UserMergeData) string {
 
 func PrintUser(user *auth.UserMergeData) {
 	if user == nil {
-		fmt.Println("No user set")
+		fmt.Println("no user set")
 		return
 	}
 	fmt.Println(PrintUserSummary(user))
@@ -20,16 +20,16 @@ func PrintUser(user *auth.UserMergeData) {
 
 func PrintHost(host string) {
 	if host == "" {
-		fmt.Println("No host set")
+		fmt.Println("no host set")
 		return
 	}
-	fmt.Println("Host: " + host)
+	fmt.Println("host: " + host)
 }
 
 func PrintWorkspace(workspaceName string) {
 	if workspaceName == "" {
-		fmt.Println("No active workspace set")
+		fmt.Println("no active workspace set")
 		return
 	}
-	fmt.Println("Workspace: " + workspaceName)
+	fmt.Println("workspace: " + workspaceName)
 }

--- a/apps/cli/pkg/wire/load.go
+++ b/apps/cli/pkg/wire/load.go
@@ -80,7 +80,7 @@ func Load(collectionName string, options *LoadOptions) (wire.Collection, error) 
 	}
 
 	if len(loadResponse.Wires) != 1 {
-		return nil, errors.New("Wrong number of responses returned")
+		return nil, errors.New("wrong number of responses returned")
 	}
 
 	return loadResponse.Wires[0].Data, nil

--- a/apps/cli/pkg/wire/save.go
+++ b/apps/cli/pkg/wire/save.go
@@ -99,7 +99,7 @@ func Save(collectionName string, changes []map[string]interface{}, saveOptions S
 	}
 
 	if len(saveResponse.Wires) != 1 {
-		return nil, errors.New("Wrong number of responses returned")
+		return nil, errors.New("wrong number of responses returned")
 	}
 
 	singleResponse := saveResponse.Wires[0]
@@ -112,7 +112,7 @@ func Save(collectionName string, changes []map[string]interface{}, saveOptions S
 			}
 			errString = errString + saveErr.Error()
 		}
-		return nil, errors.New("Error saving record: " + errString)
+		return nil, fmt.Errorf("error saving record: %s", errString)
 	}
 
 	results := []map[string]interface{}{}

--- a/apps/cli/pkg/zip/zip.go
+++ b/apps/cli/pkg/zip/zip.go
@@ -53,7 +53,7 @@ func ZipDir(localPath string) io.Reader {
 		}
 		err := filepath.WalkDir(localPath, walker)
 		if err != nil {
-			fmt.Println("Error Zipping Bundle Dir: " + err.Error())
+			fmt.Println("error zipping bundle dir: " + err.Error())
 		}
 
 		w.Close()

--- a/apps/platform-integration-tests/hurl_specs/google_login.hurl
+++ b/apps/platform-integration-tests/hurl_specs/google_login.hurl
@@ -221,4 +221,4 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/ue
 }
 HTTP 400
 [Asserts]
-body contains "Login isn't currently supported for workspaces"
+body contains "login isn't currently supported for workspaces"

--- a/apps/platform-integration-tests/hurl_specs/platform_login.hurl
+++ b/apps/platform-integration-tests/hurl_specs/platform_login.hurl
@@ -7,7 +7,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {}
 HTTP 400
 [Asserts]
-body contains "You must enter a username"
+body contains "you must enter a username"
 
 # Try to login without providing password
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/uesio/core/platform/login
@@ -16,4 +16,4 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 }
 HTTP 400
 [Asserts]
-body contains "You must enter a password"
+body contains "you must enter a password"

--- a/apps/platform-integration-tests/hurl_specs/prevent_querying_secret_store_values.hurl
+++ b/apps/platform-integration-tests/hurl_specs/prevent_querying_secret_store_values.hurl
@@ -54,7 +54,7 @@ Accept: application/json
 HTTP 200
 [Asserts]
 jsonpath "$.wires[0].data[*]" isEmpty
-jsonpath "$.wires[0].errors[0].message" contains "Your profile has no access to the uesio/core.secretstorevalue collection"
+jsonpath "$.wires[0].errors[0].message" contains "your profile has no access to the uesio/core.secretstorevalue collection"
 
 # Invoke a bot that runs an integration action that fetches a secret which we SHOULD have access to
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/uesio/tests/dev/bots/call/uesio/tests/secret_access_tester

--- a/apps/platform-integration-tests/hurl_specs/required_validation.hurl
+++ b/apps/platform-integration-tests/hurl_specs/required_validation.hurl
@@ -28,7 +28,7 @@ Accept: application/json
 HTTP 200
 [Asserts]
 jsonpath "$.wires[0].errors" count == 1
-jsonpath "$.wires[0].errors[0].message" contains "Field: Genus is required"
+jsonpath "$.wires[0].errors[0].message" contains "field: Genus is required"
 jsonpath "$.wires[0].errors[0].fieldid" == "uesio/tests.genus"
 
 # Test try to INSERT required field as empty string
@@ -52,7 +52,7 @@ Accept: application/json
 HTTP 200
 [Asserts]
 jsonpath "$.wires[0].errors" count == 1
-jsonpath "$.wires[0].errors[0].message" contains "Field: Genus is required"
+jsonpath "$.wires[0].errors[0].message" contains "field: Genus is required"
 jsonpath "$.wires[0].errors[0].fieldid" == "uesio/tests.genus"
 
 
@@ -110,7 +110,7 @@ Accept: application/json
 HTTP 200
 [Asserts]
 jsonpath "$.wires[0].errors" count == 1
-jsonpath "$.wires[0].errors[0].message" contains "Field: Genus is required"
+jsonpath "$.wires[0].errors[0].message" contains "field: Genus is required"
 jsonpath "$.wires[0].errors[0].fieldid" == "uesio/tests.genus"
 
 # Test try to UPDATE nulling with empty string a required field on changes
@@ -135,5 +135,5 @@ Accept: application/json
 HTTP 200
 [Asserts]
 jsonpath "$.wires[0].errors" count == 1
-jsonpath "$.wires[0].errors[0].message" contains "Field: Genus is required"
+jsonpath "$.wires[0].errors[0].message" contains "field: Genus is required"
 jsonpath "$.wires[0].errors[0].fieldid" == "uesio/tests.genus"

--- a/apps/platform-integration-tests/hurl_specs/runagent.hurl
+++ b/apps/platform-integration-tests/hurl_specs/runagent.hurl
@@ -50,7 +50,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/ue
 }
 HTTP 400
 [Asserts]
-body contains "Bad Key for Agent: bad_agent_id"
+body contains "bad key for agent: bad_agent_id"
 
 # Invoke with correctly formatted bad agent id
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/uesio/tests/dev/bots/call/uesio/aikit/runagent
@@ -62,7 +62,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/ue
 }
 HTTP 400
 [Asserts]
-body contains "Couldn't find item from platform load: Collection=uesio/studio.agent, Conditions=uesio/core.uniquekey :: uesio/tests:dev:bad_agent_id"
+body contains "couldn't find item from platform load: Collection=uesio/studio.agent, Conditions=uesio/core.uniquekey :: uesio/tests:dev:bad_agent_id"
 
 # Invoke with good agent id, but incompatible model
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/uesio/tests/dev/bots/call/uesio/aikit/runagent

--- a/apps/platform-integration-tests/hurl_specs/viewparams.hurl
+++ b/apps/platform-integration-tests/hurl_specs/viewparams.hurl
@@ -109,7 +109,7 @@ Accept: application/json
 HTTP 200
 [Asserts]
 jsonpath "$.wires[0].data[*]" isEmpty
-jsonpath "$.wires[0].errors[0].message" contains "Invalid Condition, param 'numbervalue' was not provided"
+jsonpath "$.wires[0].errors[0].message" contains "invalid condition, param 'numbervalue' was not provided"
 
 # Do a route load to verify view param handling is the same
 GET {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/uesio/tests/dev/routes/path/uesio/tests/view_params?checkboxvalue=true&numbervalue=4

--- a/apps/platform-integration-tests/hurl_specs/wire_load.hurl
+++ b/apps/platform-integration-tests/hurl_specs/wire_load.hurl
@@ -407,4 +407,4 @@ HTTP 200
 jsonpath "$.wires[0].data[*]" count == 2
 jsonpath "$.wires[0].errors[0].message" not exists
 jsonpath "$.wires[1].data[*]" isEmpty
-jsonpath "$.wires[1].errors[0].message" contains "No metadata provided for field: uesio/tests.non_existing_field in collection: animal"
+jsonpath "$.wires[1].errors[0].message" contains "no metadata provided for field: uesio/tests.non_existing_field in collection: animal"

--- a/apps/platform-integration-tests/hurl_specs/wire_load_novaluebehavior_condition.hurl
+++ b/apps/platform-integration-tests/hurl_specs/wire_load_novaluebehavior_condition.hurl
@@ -30,7 +30,7 @@ Accept: application/json
 HTTP 200
 [Asserts]
 jsonpath "$.wires[0].data[*]" isEmpty
-jsonpath "$.wires[0].errors[0].message" contains "Invalid Condition, param 'genus' was not provided"
+jsonpath "$.wires[0].errors[0].message" contains "invalid condition, param 'genus' was not provided"
 
 # Test again a wire load with novaluebehavor property set to deactivate on the condition
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/uesio/tests/dev/wires/load

--- a/apps/platform-integration-tests/hurl_specs/wire_load_studio_users.hurl
+++ b/apps/platform-integration-tests/hurl_specs/wire_load_studio_users.hurl
@@ -165,7 +165,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/wires/s
 HTTP 200
 [Asserts]
 jsonpath "$.wires[0].errors" count == 1
-jsonpath "$.wires[0].errors[0].message" contains "User does not have parent access to write to this record: uesio:testorguser of collection: uesio/core.organizationuser"
+jsonpath "$.wires[0].errors[0].message" contains "user does not have parent access to write to this record: uesio:testorguser of collection: uesio/core.organizationuser"
 
 # now, login as Ben and do the same thing,
 # which should succeed since ben is the owner of the org and has write access

--- a/apps/platform-integration-tests/hurl_specs/wire_load_userfile.hurl
+++ b/apps/platform-integration-tests/hurl_specs/wire_load_userfile.hurl
@@ -157,7 +157,7 @@ jsonpath "$.success" == true
 GET {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/uesio/tests/dev/userfiles/download?userfileid={{attachmentid}}
 HTTP 404
 [Asserts]
-body startsWith "Couldn't find item from platform load: Collection=uesio/core.userfile, Conditions=uesio/core.id :: {{attachmentid}}"
+body startsWith "couldn't find item from platform load: Collection=uesio/core.userfile, Conditions=uesio/core.id :: {{attachmentid}}"
 
 # Verify 400 when invalid userfileid format
 GET {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/uesio/tests/dev/userfiles/download?userfileid=my-bad-id

--- a/apps/platform-integration-tests/hurl_specs/wire_save.hurl
+++ b/apps/platform-integration-tests/hurl_specs/wire_save.hurl
@@ -205,5 +205,5 @@ jsonpath "$.wires[0].changes['temp1']['uesio/tests.species']" == "Flavious"
 jsonpath "$.wires[0].changes['temp1']['uesio/tests.genus']" not exists
 jsonpath "$.wires[0].errors[0]['recordid']" == "temp1"
 jsonpath "$.wires[0].errors[0]['fieldid']" == "uesio/tests.genus"
-jsonpath "$.wires[0].errors[0]['message']" == "Field: Genus is required"
+jsonpath "$.wires[0].errors[0]['message']" == "field: Genus is required"
 

--- a/apps/platform-integration-tests/hurl_specs/wire_save_userfile.hurl
+++ b/apps/platform-integration-tests/hurl_specs/wire_save_userfile.hurl
@@ -183,12 +183,12 @@ jsonpath "$.success" == true
 GET {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/uesio/tests/dev/userfiles/download?userfileid={{attachmentid}}
 HTTP 404
 [Asserts]
-body startsWith "Couldn't find item from platform load: Collection=uesio/core.userfile, Conditions=uesio/core.id :: {{attachmentid}}"
+body startsWith "couldn't find item from platform load: Collection=uesio/core.userfile, Conditions=uesio/core.id :: {{attachmentid}}"
 
 GET {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/uesio/tests/dev/userfiles/download?userfileid={{attachmentid2}}
 HTTP 404
 [Asserts]
-body startsWith "Couldn't find item from platform load: Collection=uesio/core.userfile, Conditions=uesio/core.id :: {{attachmentid2}}"
+body startsWith "couldn't find item from platform load: Collection=uesio/core.userfile, Conditions=uesio/core.id :: {{attachmentid2}}"
 
 
 # Now upload an attachment connected to a file field, but invalid field
@@ -238,7 +238,7 @@ jsonpath "$.success" == true
 GET {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/uesio/tests/dev/userfiles/download?userfileid={{attachmentid3}}
 HTTP 404
 [Asserts]
-body startsWith "Couldn't find item from platform load: Collection=uesio/core.userfile, Conditions=uesio/core.id :: {{attachmentid3}}"
+body startsWith "couldn't find item from platform load: Collection=uesio/core.userfile, Conditions=uesio/core.id :: {{attachmentid3}}"
 
 # Now test an insert with data and invalid field
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/uesio/tests/dev/wires/save
@@ -264,7 +264,7 @@ Accept: application/json
 HTTP 200
 [Asserts]
 jsonpath "$.wires[0].errors" count == 1
-jsonpath "$.wires[0].errors[0].message" contains "No metadata provided for field: uesio/tests.invalidfield in collection: animal"
+jsonpath "$.wires[0].errors[0].message" contains "no metadata provided for field: uesio/tests.invalidfield in collection: animal"
 
 # Now test with a valid field
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/uesio/tests/dev/wires/save
@@ -345,7 +345,7 @@ jsonpath "$.success" == true
 GET {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/uesio/tests/dev/userfiles/download?userfileid={{attachmentid4}}
 HTTP 404
 [Asserts]
-body startsWith "Couldn't find item from platform load: Collection=uesio/core.userfile, Conditions=uesio/core.id :: {{attachmentid4}}"
+body startsWith "couldn't find item from platform load: Collection=uesio/core.userfile, Conditions=uesio/core.id :: {{attachmentid4}}"
 
 # Now query the field and make sure it's gone
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/uesio/tests/dev/wires/load

--- a/apps/platform-integration-tests/hurl_specs/workspace_context.hurl
+++ b/apps/platform-integration-tests/hurl_specs/workspace_context.hurl
@@ -89,7 +89,7 @@ GET {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/routes/p
 Accept: application/json
 HTTP 200
 [Asserts]
-jsonpath "$.dependencies.wire[0].errors[0].message" contains "could not get workspace context: workspace uesio/tests:dev does not exist or you don't have access to modify it."
+jsonpath "$.dependencies.wire[0].errors[0].message" contains "could not get workspace context: workspace uesio/tests:dev does not exist or you don't have access to modify it"
 
 # Try get config values for the dev workspace
 GET {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/uesio/tests/dev/configvalues

--- a/apps/platform/pkg/adapt/adapter.go
+++ b/apps/platform/pkg/adapt/adapter.go
@@ -2,7 +2,7 @@ package adapt
 
 import (
 	"context"
-	"errors"
+	"fmt"
 
 	"github.com/thecloudmasters/uesio/pkg/types/wire"
 )
@@ -25,7 +25,7 @@ func GetAdapter(adapterType string) (Adapter, error) {
 
 	adapter, ok := adapterMap[adapterType]
 	if !ok {
-		return nil, errors.New("No adapter found of this type: " + adapterType)
+		return nil, fmt.Errorf("no adapter found of this type: %s", adapterType)
 	}
 	return adapter, nil
 }

--- a/apps/platform/pkg/adapt/postgresio/conditions.go
+++ b/apps/platform/pkg/adapt/postgresio/conditions.go
@@ -228,7 +228,7 @@ func processValueCondition(condition wire.LoadRequestCondition, collectionMetada
 
 	case "IS_BLANK":
 		if fieldType == "CHECKBOX" || fieldType == "TIMESTAMP" {
-			builder.addQueryPart(fmt.Sprintf("%s IS NULL", fieldName))
+			builder.addQueryPart(fieldName + " IS NULL")
 		} else if isTextType {
 			builder.addQueryPart(fmt.Sprintf("((%s IS NULL) OR (%s = 'null') OR (%s = ''))", fieldName, fieldName, fieldName))
 		} else if fieldType == "STRUCT" {
@@ -238,7 +238,7 @@ func processValueCondition(condition wire.LoadRequestCondition, collectionMetada
 		}
 	case "IS_NOT_BLANK":
 		if fieldType == "CHECKBOX" || fieldType == "TIMESTAMP" {
-			builder.addQueryPart(fmt.Sprintf("%s IS NOT NULL", fieldName))
+			builder.addQueryPart(fieldName + " IS NOT NULL")
 		} else if isTextType {
 			builder.addQueryPart(fmt.Sprintf("((%s IS NOT NULL) AND (%s != 'null') AND (%s != ''))", fieldName, fieldName, fieldName))
 		} else if fieldType == "STRUCT" {

--- a/apps/platform/pkg/adapt/postgresio/connection.go
+++ b/apps/platform/pkg/adapt/postgresio/connection.go
@@ -38,7 +38,7 @@ func (c *Connection) GetCredentials() *wire.Credentials {
 
 func (c *Connection) BeginTransaction() error {
 	if c.transaction != nil {
-		return errors.New("A transaction on this connection has already started")
+		return errors.New("a transaction on this connection has already started")
 	}
 	client, err := connectForSave(c.ctx, c.credentials)
 	if err != nil {

--- a/apps/platform/pkg/adapt/postgresio/dateconditions.go
+++ b/apps/platform/pkg/adapt/postgresio/dateconditions.go
@@ -34,7 +34,7 @@ func processDateRangeCondition(condition wire.LoadRequestCondition, fieldName, f
 
 	value, ok := condition.Value.(string)
 	if !ok {
-		return errors.New("Invalid date range value")
+		return errors.New("invalid date range value")
 	}
 
 	if value == "THIS_WEEK" {

--- a/apps/platform/pkg/adapt/postgresio/get_tokens.go
+++ b/apps/platform/pkg/adapt/postgresio/get_tokens.go
@@ -1,7 +1,7 @@
 package postgresio
 
 import (
-	"errors"
+	"fmt"
 
 	"github.com/jackc/pgx/v5"
 
@@ -15,7 +15,7 @@ func (c *Connection) GetRecordAccessTokens(recordID string, session *sess.Sessio
 	defer c.mux.Unlock()
 	rows, err := c.GetClient().Query(c.ctx, TOKEN_QUERY, recordID, session.GetTenantID())
 	if err != nil {
-		return nil, errors.New("Failed to load tokens:" + err.Error())
+		return nil, fmt.Errorf("failed to load tokens: %w", err)
 	}
 	return pgx.CollectRows(rows, func(row pgx.CollectableRow) (string, error) {
 		var token string

--- a/apps/platform/pkg/adapt/postgresio/publish.go
+++ b/apps/platform/pkg/adapt/postgresio/publish.go
@@ -1,8 +1,6 @@
 package postgresio
 
-import (
-	"errors"
-)
+import "fmt"
 
 // Publish sends a message on a given channel
 func (c *Connection) Publish(channelName, payload string) error {
@@ -10,7 +8,7 @@ func (c *Connection) Publish(channelName, payload string) error {
 	defer c.mux.Unlock()
 	db := c.GetClient()
 	if _, err := db.Exec(c.ctx, "select pg_notify($1, $2)", channelName, payload); err != nil {
-		return errors.New("unable to publish message: " + err.Error())
+		return fmt.Errorf("unable to publish message: %w", err)
 	}
 	return nil
 }

--- a/apps/platform/pkg/auth/auth.go
+++ b/apps/platform/pkg/auth/auth.go
@@ -2,7 +2,7 @@ package auth
 
 import (
 	"context"
-	"errors"
+	"fmt"
 	"log/slog"
 	"net"
 	"net/http"
@@ -33,13 +33,14 @@ func init() {
 	storageType := os.Getenv("UESIO_SESSION_STORE")
 
 	var store session.Store
-	if storageType == "filesystem" {
+	switch storageType {
+	case "filesystem":
 		store = NewFSSessionStore()
-	} else if storageType == "redis" {
+	case "redis":
 		store = NewRedisSessionStore()
-	} else if storageType == "" || storageType == "memory" {
+	case "", "memory":
 		store = session.NewInMemStore()
-	} else {
+	default:
 		panic("UESIO_SESSION_STORE is an unrecognized value: " + storageType)
 	}
 
@@ -99,7 +100,7 @@ func getAuthType(authTypeName string, session *sess.Session) (AuthenticationType
 	}
 	authType, ok := authTypeMap[mergedType]
 	if !ok {
-		return nil, errors.New("No adapter found of this auth type: " + mergedType)
+		return nil, fmt.Errorf("no adapter found of this auth type: %s", mergedType)
 	}
 	return authType, nil
 }
@@ -205,7 +206,7 @@ func getSiteFromDomain(domainType, domainValue string) (*meta.Site, error) {
 		return nil, err
 	}
 	if site == nil {
-		return nil, errors.New("No Site Found: " + domainType + " : " + domainValue)
+		return nil, fmt.Errorf("no site found: %s : %s", domainType, domainValue)
 	}
 
 	err = setHostCache(domainType, domainValue, site)
@@ -421,12 +422,12 @@ func GetPayloadValue(payload map[string]any, key string) (string, error) {
 
 	value, ok := payload[key]
 	if !ok {
-		return "", errors.New("key '" + key + "' not present in payload")
+		return "", fmt.Errorf("key '%s' not present in payload", key)
 	}
 
 	stringValue, ok := value.(string)
 	if !ok {
-		return "", errors.New("The value for " + key + " is not a string")
+		return "", fmt.Errorf("the value for %s is not a string", key)
 	}
 
 	return stringValue, nil
@@ -439,7 +440,7 @@ func GetRequiredPayloadValue(payload map[string]any, key string) (string, error)
 		return "", err
 	}
 	if value == "" {
-		return "", errors.New("missing required value: " + key)
+		return "", fmt.Errorf("missing required value: %s", key)
 	}
 	return value, nil
 }

--- a/apps/platform/pkg/auth/cache.go
+++ b/apps/platform/pkg/auth/cache.go
@@ -1,7 +1,6 @@
 package auth
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
@@ -82,7 +81,7 @@ func InvalidateHostCache() error {
 func getHostKeyFromDomainId(id string) (string, error) {
 	idParts := strings.Split(id, ":")
 	if len(idParts) != 2 {
-		return "", errors.New("Bad Domain ID: " + id)
+		return "", fmt.Errorf("bad domain id: %s", id)
 	}
 	return getHostKey(idParts[1], idParts[0]), nil
 }

--- a/apps/platform/pkg/auth/google/googleauth.go
+++ b/apps/platform/pkg/auth/google/googleauth.go
@@ -85,7 +85,7 @@ func (c *Connection) Validate(payload map[string]any) (*idtoken.Payload, error) 
 }
 
 func (c *Connection) RequestLogin(w http.ResponseWriter, r *http.Request) {
-	ctlutil.HandleError(w, errors.New("Requesting login is not supported by this auth source type"))
+	ctlutil.HandleError(w, errors.New("requesting login is not supported by this auth source type"))
 }
 
 func (c *Connection) Login(w http.ResponseWriter, r *http.Request) {
@@ -142,10 +142,10 @@ func (c *Connection) Signup(signupMethod *meta.SignupMethod, payload map[string]
 	return c.callListenerBot(signupMethod.SignupBot, payload)
 }
 func (c *Connection) ResetPassword(payload map[string]any, authenticated bool) (*meta.LoginMethod, error) {
-	return nil, exceptions.NewBadRequestException("Google login: unfortunately you cannot change the password", nil)
+	return nil, exceptions.NewBadRequestException("google login: unfortunately you cannot change the password", nil)
 }
 func (c *Connection) ConfirmResetPassword(payload map[string]any) (*meta.User, error) {
-	return nil, exceptions.NewBadRequestException("Google login: unfortunately you cannot change the password", nil)
+	return nil, exceptions.NewBadRequestException("google login: unfortunately you cannot change the password", nil)
 }
 func (c *Connection) CreateLogin(signupMethod *meta.SignupMethod, payload map[string]any, user *meta.User) error {
 	validated, err := c.Validate(payload)
@@ -160,5 +160,5 @@ func (c *Connection) CreateLogin(signupMethod *meta.SignupMethod, payload map[st
 	}, c.connection, c.session)
 }
 func (c *Connection) ConfirmSignUp(signupMethod *meta.SignupMethod, payload map[string]any) error {
-	return exceptions.NewBadRequestException("Google login: unfortunately you cannot change the password", nil)
+	return exceptions.NewBadRequestException("google login: unfortunately you cannot change the password", nil)
 }

--- a/apps/platform/pkg/auth/login.go
+++ b/apps/platform/pkg/auth/login.go
@@ -67,7 +67,7 @@ func GetLoginRedirectResponse(w http.ResponseWriter, r *http.Request, user *meta
 
 	if redirectPath == "" {
 		if redirectKey == "" {
-			return nil, errors.New("No redirect route specified")
+			return nil, errors.New("no redirect route specified")
 		}
 		redirectNamespace, redirectRoute, err = meta.ParseKey(redirectKey)
 		if err != nil {
@@ -108,7 +108,7 @@ func ResetPasswordRedirectResponse(w http.ResponseWriter, r *http.Request, user 
 func GetUserFromFederationID(authSourceID string, federationID string, connection wire.Connection, session *sess.Session) (*meta.User, *meta.LoginMethod, error) {
 
 	if session.GetWorkspace() != nil {
-		return nil, nil, exceptions.NewBadRequestException("Login isn't currently supported for workspaces", nil)
+		return nil, nil, exceptions.NewBadRequestException("login isn't currently supported for workspaces", nil)
 	}
 
 	adminSession := sess.GetAnonSessionFrom(session)
@@ -116,16 +116,16 @@ func GetUserFromFederationID(authSourceID string, federationID string, connectio
 	// 4. Check for Existing User
 	loginMethod, err := GetLoginMethod(federationID, authSourceID, connection, adminSession)
 	if err != nil {
-		return nil, nil, errors.New("Failed Getting Login Method Data: " + err.Error())
+		return nil, nil, fmt.Errorf("failed getting login method data: %w", err)
 	}
 
 	if loginMethod == nil {
-		return nil, nil, exceptions.NewNotFoundException("No account found with this login method")
+		return nil, nil, exceptions.NewNotFoundException("no account found with this login method")
 	}
 
 	user, err := GetUserByID(loginMethod.User.ID, adminSession, nil)
 	if err != nil {
-		return nil, nil, exceptions.NewNotFoundException("failed Getting user Data: " + err.Error())
+		return nil, nil, exceptions.NewNotFoundException("failed getting user data: " + err.Error())
 	}
 
 	return user, loginMethod, nil

--- a/apps/platform/pkg/auth/mock/mockauth.go
+++ b/apps/platform/pkg/auth/mock/mockauth.go
@@ -35,7 +35,7 @@ type Connection struct {
 }
 
 func (c *Connection) RequestLogin(w http.ResponseWriter, r *http.Request) {
-	ctlutil.HandleError(w, errors.New("Requesting login is not supported by this auth source type"))
+	ctlutil.HandleError(w, errors.New("requesting login is not supported by this auth source type"))
 }
 
 func (c *Connection) Login(w http.ResponseWriter, r *http.Request) {
@@ -58,22 +58,22 @@ func (c *Connection) Login(w http.ResponseWriter, r *http.Request) {
 func (c *Connection) DoLogin(payload map[string]any) (*meta.User, *meta.LoginMethod, error) {
 	federationID, err := auth.GetPayloadValue(payload, "token")
 	if err != nil {
-		return nil, nil, fmt.Errorf("Mock login: %w", err)
+		return nil, nil, fmt.Errorf("mock login: %w", err)
 	}
 	return auth.GetUserFromFederationID(c.authSource.GetKey(), federationID, c.connection, c.session)
 }
 func (c *Connection) Signup(signupMethod *meta.SignupMethod, payload map[string]any, username string) error {
-	return errors.New("Mock login: unfortunately you cannot sign up for mock login")
+	return errors.New("mock login: unfortunately you cannot sign up for mock login")
 }
 func (c *Connection) ResetPassword(payload map[string]any, authenticated bool) (*meta.LoginMethod, error) {
-	return nil, errors.New("Mock login: unfortunately you cannot change the password")
+	return nil, errors.New("mock login: unfortunately you cannot change the password")
 }
 func (c *Connection) ConfirmResetPassword(payload map[string]any) (*meta.User, error) {
-	return nil, errors.New("Mock login: unfortunately you cannot change the password")
+	return nil, errors.New("mock login: unfortunately you cannot change the password")
 }
 func (c *Connection) CreateLogin(signupMethod *meta.SignupMethod, payload map[string]any, user *meta.User) error {
-	return errors.New("Mock login: unfortunately you cannot create a login")
+	return errors.New("mock login: unfortunately you cannot create a login")
 }
 func (c *Connection) ConfirmSignUp(signupMethod *meta.SignupMethod, payload map[string]any) error {
-	return errors.New("Mock login: unfortunately you cannot change the password")
+	return errors.New("mock login: unfortunately you cannot change the password")
 }

--- a/apps/platform/pkg/auth/platform/platform.go
+++ b/apps/platform/pkg/auth/platform/platform.go
@@ -57,7 +57,7 @@ var tests = []PasswordTest{
 	{"[A-Z]", "password must have at least 1 upper case character"},
 	{"[0-9]", "password must have at least 1 number"},
 	{"[" + regexp.QuoteMeta(PasswordPolicyAllowedSymbols) + "]",
-		fmt.Sprintf("password must have at least 1 special character: %s", PasswordPolicyAllowedSymbols)},
+		"password must have at least 1 special character: " + PasswordPolicyAllowedSymbols},
 }
 
 // NOTE: Hypen must be at beginning or end of the list to avoid being treated as a range when used in regex.

--- a/apps/platform/pkg/auth/platform/platform.go
+++ b/apps/platform/pkg/auth/platform/platform.go
@@ -35,7 +35,7 @@ func (a *Auth) GetAuthConnection(credentials *wire.Credentials, authSource *meta
 }
 
 func generateCode() string {
-	return strings.Replace(strings.Trim(fmt.Sprint(rand.Perm(6)), "[]"), " ", "", -1)
+	return strings.ReplaceAll(strings.Trim(fmt.Sprint(rand.Perm(6)), "[]"), " ", "")
 }
 
 func getExpireTimestamp() int64 {
@@ -110,7 +110,7 @@ func (c *Connection) callListenerBot(botKey, code string, payload map[string]any
 }
 
 func (c *Connection) RequestLogin(w http.ResponseWriter, r *http.Request) {
-	ctlutil.HandleError(w, errors.New("Requesting login is not supported by this auth source type"))
+	ctlutil.HandleError(w, errors.New("requesting login is not supported by this auth source type"))
 }
 
 func (c *Connection) Login(w http.ResponseWriter, r *http.Request) {
@@ -147,29 +147,29 @@ func (c *Connection) DoLogin(payload map[string]any) (*meta.User, *meta.LoginMet
 
 	username, err := auth.GetRequiredPayloadValue(payload, "username")
 	if err != nil {
-		return nil, nil, exceptions.NewBadRequestException("You must enter a username", nil)
+		return nil, nil, exceptions.NewBadRequestException("you must enter a username", nil)
 	}
 	plainPassword, err := auth.GetRequiredPayloadValue(payload, "password")
 	if err != nil {
-		return nil, nil, exceptions.NewBadRequestException("You must enter a password", nil)
+		return nil, nil, exceptions.NewBadRequestException("you must enter a password", nil)
 	}
 
 	loginmethod, err := auth.GetLoginMethod(username, c.authSource.GetKey(), c.connection, c.session)
 	if err != nil {
-		return nil, nil, exceptions.NewBadRequestException("Failed getting login method data", err)
+		return nil, nil, exceptions.NewBadRequestException("failed getting login method data", err)
 	}
 
 	if loginmethod == nil {
-		return nil, nil, exceptions.NewBadRequestException("No account found with this login method", nil)
+		return nil, nil, exceptions.NewBadRequestException("no account found with this login method", nil)
 	}
 
 	if loginmethod.VerificationCode != "" {
-		return nil, nil, exceptions.NewUnauthorizedException("Unable to login - your email address has not yet been verified. Please verify your email and then try again.")
+		return nil, nil, exceptions.NewUnauthorizedException("unable to login - your email address has not yet been verified")
 	}
 
 	err = bcrypt.CompareHashAndPassword([]byte(loginmethod.Hash), []byte(plainPassword))
 	if err != nil {
-		return nil, nil, exceptions.NewUnauthorizedException("The password you are trying to log in with is incorrect")
+		return nil, nil, exceptions.NewUnauthorizedException("the password you are trying to log in with is incorrect")
 	}
 
 	user, err := auth.GetUserByID(loginmethod.User.ID, c.session, c.connection)
@@ -245,7 +245,7 @@ func (c *Connection) Signup(signupMethod *meta.SignupMethod, payload map[string]
 func (c *Connection) ResetPassword(payload map[string]any, authenticated bool) (*meta.LoginMethod, error) {
 	username, err := auth.GetPayloadValue(payload, "username")
 	if err != nil {
-		return nil, exceptions.NewBadRequestException("Unable to reset password: you must provide a username", nil)
+		return nil, exceptions.NewBadRequestException("unable to reset password: you must provide a username", nil)
 	}
 
 	user, err := auth.GetUserByKey(username, c.session, c.connection)
@@ -259,7 +259,7 @@ func (c *Connection) ResetPassword(payload map[string]any, authenticated bool) (
 	}
 
 	if loginmethod == nil {
-		return nil, exceptions.NewBadRequestException("No account found with this login method", nil)
+		return nil, exceptions.NewBadRequestException("no account found with this login method", nil)
 	}
 
 	code := generateCode()
@@ -304,44 +304,44 @@ func (c *Connection) ResetPassword(payload map[string]any, authenticated bool) (
 func (c *Connection) ConfirmResetPassword(payload map[string]any) (*meta.User, error) {
 	username, err := auth.GetPayloadValue(payload, "username")
 	if err != nil {
-		return nil, exceptions.NewBadRequestException("A username must be provided", nil)
+		return nil, exceptions.NewBadRequestException("a username must be provided", nil)
 	}
 
 	verificationCode, err := auth.GetPayloadValue(payload, "verificationcode")
 	if err != nil {
-		return nil, exceptions.NewBadRequestException("A verification code must be provided", nil)
+		return nil, exceptions.NewBadRequestException("a verification code must be provided", nil)
 	}
 
 	newPassword, err := auth.GetPayloadValue(payload, "newpassword")
 	if err != nil {
-		return nil, exceptions.NewBadRequestException("A new password must be provided", nil)
+		return nil, exceptions.NewBadRequestException("a new password must be provided", nil)
 	}
 
 	err = passwordPolicyValidation(newPassword)
 	if err != nil {
-		return nil, exceptions.NewBadRequestException("This password does not meet the password policy requirements", err)
+		return nil, exceptions.NewBadRequestException("this password does not meet the password policy requirements", err)
 	}
 
 	loginmethod, err := auth.GetLoginMethod(username, c.authSource.GetKey(), c.connection, c.session)
 	if err != nil {
-		return nil, errors.New("Failed Getting Login Method Data: " + err.Error())
+		return nil, fmt.Errorf("failed getting login method data: %w", err)
 	}
 
 	if loginmethod == nil {
-		return nil, exceptions.NewBadRequestException("Unable to find this login method", nil)
+		return nil, exceptions.NewBadRequestException("unable to find this login method", nil)
 	}
 
 	if isExpired(loginmethod.VerificationExpires) {
-		return nil, exceptions.NewBadRequestException("The provided verification code has expired.", nil)
+		return nil, exceptions.NewBadRequestException("the provided verification code has expired", nil)
 	}
 
 	if loginmethod.VerificationCode != verificationCode {
-		return nil, exceptions.NewBadRequestException("The provided verification code does not match.", nil)
+		return nil, exceptions.NewBadRequestException("the provided verification code does not match", nil)
 	}
 
 	hash, err := bcrypt.GenerateFromPassword([]byte(newPassword), bcrypt.DefaultCost)
 	if err != nil {
-		return nil, exceptions.NewBadRequestException("The new password could not be used, please try another password", nil)
+		return nil, exceptions.NewBadRequestException("the new password could not be used, please try another password", nil)
 	}
 
 	loginmethod.Hash = string(hash)
@@ -422,33 +422,33 @@ func (c *Connection) CreateLogin(signupMethod *meta.SignupMethod, payload map[st
 func (c *Connection) ConfirmSignUp(signupMethod *meta.SignupMethod, payload map[string]any) error {
 	username, err := auth.GetRequiredPayloadValue(payload, "username")
 	if err != nil {
-		return exceptions.NewBadRequestException("Username not provided", nil)
+		return exceptions.NewBadRequestException("username not provided", nil)
 	}
 
 	verificationCode, err := auth.GetRequiredPayloadValue(payload, "verificationcode")
 	if err != nil {
-		return exceptions.NewBadRequestException("Verification code not provided", nil)
+		return exceptions.NewBadRequestException("verification code not provided", nil)
 	}
 
 	loginmethod, err := auth.GetLoginMethod(username, c.authSource.GetKey(), c.connection, c.session)
 	if err != nil {
-		return errors.New("Failed Getting Login Method Data: " + err.Error())
+		return fmt.Errorf("failed getting login method data: %w", err)
 	}
 
 	if loginmethod == nil {
-		return errors.New("No account found with this login method")
+		return errors.New("no account found with this login method")
 	}
 
 	if loginmethod.VerificationCode == "" {
-		return exceptions.NewBadRequestException("This account is already verified", nil)
+		return exceptions.NewBadRequestException("this account is already verified", nil)
 	}
 
 	if isExpired(loginmethod.VerificationExpires) {
-		return exceptions.NewBadRequestException("The code is expired, please request a new one", nil)
+		return exceptions.NewBadRequestException("the code is expired, please request a new one", nil)
 	}
 
 	if loginmethod.VerificationCode != verificationCode {
-		return exceptions.NewBadRequestException("The codes do not match", nil)
+		return exceptions.NewBadRequestException("the codes do not match", nil)
 	}
 
 	loginmethod.VerificationCode = ""

--- a/apps/platform/pkg/auth/platform/platform_test.go
+++ b/apps/platform/pkg/auth/platform/platform_test.go
@@ -21,32 +21,32 @@ func Test_passwordPolicyValidation(t *testing.T) {
 		{
 			name:     "Invalid Password - Too Short",
 			password: "Short1!",
-			expected: fmt.Errorf("at least 8 characters"),
+			expected: errors.New("at least 8 characters"),
 		},
 		{
 			name:     "Invalid Password - No Uppercase",
 			password: "invalidpassword123!",
-			expected: fmt.Errorf("at least 1 upper case"),
+			expected: errors.New("at least 1 upper case"),
 		},
 		{
 			name:     "Invalid Password - No Lowercase",
 			password: "INVALIDPASSWORD123!",
-			expected: fmt.Errorf("at least 1 lower case"),
+			expected: errors.New("at least 1 lower case"),
 		},
 		{
 			name:     "Invalid Password - No special character",
 			password: "ValidPassword123",
-			expected: fmt.Errorf("at least 1 special character"),
+			expected: errors.New("at least 1 special character"),
 		},
 		{
 			name:     "Invalid Password - Invalid special character (space)",
 			password: "Valid Password123",
-			expected: fmt.Errorf("at least 1 special character"),
+			expected: errors.New("at least 1 special character"),
 		},
 		{
 			name:     "Invalid Password - No number",
 			password: "ValidPassword!",
-			expected: fmt.Errorf("at least 1 number"),
+			expected: errors.New("at least 1 number"),
 		},
 	}
 

--- a/apps/platform/pkg/auth/platform/platform_test.go
+++ b/apps/platform/pkg/auth/platform/platform_test.go
@@ -1,7 +1,7 @@
 package platform
 
 import (
-	"fmt"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"

--- a/apps/platform/pkg/auth/redis-session-store.go
+++ b/apps/platform/pkg/auth/redis-session-store.go
@@ -1,7 +1,6 @@
 package auth
 
 import (
-	"fmt"
 	"log/slog"
 
 	"github.com/icza/session"

--- a/apps/platform/pkg/auth/redis-session-store.go
+++ b/apps/platform/pkg/auth/redis-session-store.go
@@ -33,7 +33,7 @@ func (s *RedisSessionStore) Get(id string) session.Session {
 // for when the server is restarted
 func (s *RedisSessionStore) Add(sess session.Session) {
 	if err := s.cacheManager.Set(sess.ID(), sess); err != nil {
-		slog.Error(fmt.Sprintf("error adding session to redis: %s", err.Error()))
+		slog.Error("error adding session to redis: " + err.Error())
 	}
 }
 
@@ -41,7 +41,7 @@ func (s *RedisSessionStore) Add(sess session.Session) {
 // Will remove it from both the memory store and the FS
 func (s *RedisSessionStore) Remove(sess session.Session) {
 	if err := s.cacheManager.Del(sess.ID()); err != nil {
-		slog.Error(fmt.Sprintf("error removing Redis session: %s", err.Error()))
+		slog.Error("error removing Redis session: " + err.Error())
 	}
 }
 

--- a/apps/platform/pkg/auth/samlauth/samlauth.go
+++ b/apps/platform/pkg/auth/samlauth/samlauth.go
@@ -87,7 +87,7 @@ func (c *Connection) getSPInternal(requestURL string) (*samlsp.Middleware, error
 
 	if metadataXML == "" {
 		if metadataXMLURL == "" {
-			return nil, errors.New("You must provide a metadata xml value or url value.")
+			return nil, errors.New("you must provide a metadata xml value or url value")
 		}
 
 		idpMetadataURL, err := url.Parse(metadataXMLURL)

--- a/apps/platform/pkg/auth/session.go
+++ b/apps/platform/pkg/auth/session.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/icza/session"
@@ -18,7 +19,7 @@ func GetUserFromAuthToken(token string, site *meta.Site) (*meta.User, error) {
 	// Split the token on the ":" character
 	cutToken, ok := strings.CutPrefix(token, "ues_")
 	if !ok {
-		return nil, errors.New("The api key you are trying to log in with is invalid")
+		return nil, errors.New("the api key you are trying to log in with is invalid")
 	}
 	id := cutToken[:8]
 	key := cutToken[8:]
@@ -26,11 +27,11 @@ func GetUserFromAuthToken(token string, site *meta.Site) (*meta.User, error) {
 	adminSession := sess.GetAnonSession(context.Background(), site)
 	loginmethod, err := GetLoginMethod(id, "uesio/core.apikey", nil, adminSession)
 	if err != nil || loginmethod == nil {
-		return nil, exceptions.NewBadRequestException("The api key you are trying to log in with does not exist", nil)
+		return nil, exceptions.NewBadRequestException("the api key you are trying to log in with does not exist", nil)
 	}
 	err = bcrypt.CompareHashAndPassword([]byte(loginmethod.Hash), []byte(key))
 	if err != nil {
-		return nil, exceptions.NewUnauthorizedException("The api key you are trying to log in with is invalid")
+		return nil, exceptions.NewUnauthorizedException("the api key you are trying to log in with is invalid")
 	}
 
 	return GetUserByID(loginmethod.User.ID, adminSession, nil)
@@ -44,7 +45,7 @@ func GetUserFromBrowserSession(browserSession session.Session, site *meta.Site) 
 	browserSessionUser := sess.GetSessionAttribute(browserSession, "UserID")
 	// Check to make sure our session site matches the site from our domain.
 	if browserSessionSite != site.GetFullName() {
-		return nil, errors.New("Sites mismatch for user: " + browserSessionUser)
+		return nil, fmt.Errorf("sites mismatch for user: %s", browserSessionUser)
 	}
 	return GetCachedUserByID(browserSessionUser, site)
 }
@@ -57,11 +58,11 @@ func GetSessionFromUser(sessionID string, user *meta.User, site *meta.Site) (*se
 func HydrateUserPermissions(user *meta.User, session *sess.Session) error {
 	profileKey := user.Profile
 	if profileKey == "" {
-		return errors.New("No profile found in session")
+		return errors.New("no profile found in session")
 	}
 	profile, err := datasource.LoadAndHydrateProfile(profileKey, session)
 	if err != nil {
-		return errors.New("Error Loading Profile: " + profileKey + " : " + err.Error())
+		return fmt.Errorf("error loading profile: %s : %w", profileKey, err)
 	}
 	user.Permissions = profile.FlattenPermissions()
 	user.ProfileRef = profile

--- a/apps/platform/pkg/auth/signup.go
+++ b/apps/platform/pkg/auth/signup.go
@@ -56,7 +56,7 @@ func signupWithConnection(signupMethod *meta.SignupMethod, payload map[string]an
 	}
 
 	if !matchesRegex(username, signupMethod.UsernameRegex) {
-		return nil, exceptions.NewBadRequestException(fmt.Sprintf("Signup failed - username does not match required pattern: %s", signupMethod.UsernameFormatExplanation), nil)
+		return nil, exceptions.NewBadRequestException("Signup failed - username does not match required pattern: "+signupMethod.UsernameFormatExplanation, nil)
 	}
 
 	err = authconn.Signup(signupMethod, payload, username)

--- a/apps/platform/pkg/auth/signup.go
+++ b/apps/platform/pkg/auth/signup.go
@@ -1,7 +1,6 @@
 package auth
 
 import (
-	"fmt"
 	"regexp"
 
 	"github.com/thecloudmasters/uesio/pkg/datasource"

--- a/apps/platform/pkg/auth/site.go
+++ b/apps/platform/pkg/auth/site.go
@@ -52,7 +52,7 @@ func querySiteFromDomain(domainType, domain string) (*meta.Site, error) {
 
 func GetPublicUser(site *meta.Site, connection wire.Connection) (*meta.User, error) {
 	if site == nil {
-		return nil, errors.New("No Site Provided")
+		return nil, errors.New("no site provided")
 	}
 	return GetUserByKey("guest", sess.GetAnonSession(context.Background(), site), connection)
 }
@@ -67,7 +67,7 @@ func GetPublicSession(site *meta.Site, connection wire.Connection) (*sess.Sessio
 
 func GetSystemUser(site *meta.Site, connection wire.Connection) (*meta.User, error) {
 	if site == nil {
-		return nil, errors.New("No Site Provided")
+		return nil, errors.New("no site provided")
 	}
 	return GetUserByKey("system", sess.GetAnonSession(context.Background(), site), connection)
 }

--- a/apps/platform/pkg/bot/declarativedialect/declarativedialect.go
+++ b/apps/platform/pkg/bot/declarativedialect/declarativedialect.go
@@ -25,16 +25,16 @@ func createRecordStep(stepDef *yaml.Node, api any) error {
 	// Make sure our api is capable of saving
 	saveAPI, ok := api.(BotSaveable)
 	if !ok {
-		return errors.New("You can create a record in this declarative context")
+		return errors.New("you can create a record in this declarative context")
 	}
 	collection := meta.GetNodeValueAsString(stepDef, "collection")
 	if collection == "" {
-		return errors.New("No collection specified to create record step")
+		return errors.New("no collection specified to create record step")
 	}
 
 	record, err := meta.GetMapNode(stepDef, "record")
 	if err != nil {
-		return errors.New("No record provided to create record step")
+		return errors.New("no record provided to create record step")
 	}
 
 	var item wire.Item
@@ -50,10 +50,10 @@ func createRecordStep(stepDef *yaml.Node, api any) error {
 func runSteps(def *yaml.Node, api any) error {
 	steps, err := meta.GetMapNode(def, "steps")
 	if err != nil {
-		return errors.New("No steps found in declarative bot")
+		return errors.New("no steps found in declarative bot")
 	}
 	if steps == nil || steps.Kind != yaml.SequenceNode {
-		return errors.New("Invalid steps node in declarative bot")
+		return errors.New("invalid steps node in declarative bot")
 	}
 	for i := range steps.Content {
 		err := runStep(steps.Content[i], api)
@@ -70,7 +70,7 @@ func runStep(stepDef *yaml.Node, api any) error {
 	case "CREATE_RECORD":
 		return createRecordStep(stepDef, api)
 	default:
-		return errors.New("Invalid Step Type")
+		return errors.New("invalid step type")
 	}
 }
 
@@ -94,21 +94,21 @@ func (b *DeclarativeDialect) CallBot(bot *meta.Bot, params map[string]any, conne
 }
 
 func (b *DeclarativeDialect) CallGeneratorBot(bot *meta.Bot, create bundlestore.FileCreator, params map[string]any, connection wire.Connection, session *sess.Session) (map[string]any, error) {
-	return nil, errors.New("Declarative Dialect not implemented yet.")
+	return nil, errors.New("declarative dialect not implemented yet")
 }
 
 func (b *DeclarativeDialect) RouteBot(bot *meta.Bot, route *meta.Route, request *http.Request, connection wire.Connection, session *sess.Session) (*meta.Route, error) {
-	return nil, errors.New("Declarative Dialect not implemented yet.")
+	return nil, errors.New("declarative dialect not implemented yet")
 }
 
 func (b *DeclarativeDialect) LoadBot(bot *meta.Bot, op *wire.LoadOp, connection wire.Connection, session *sess.Session) error {
-	return errors.New("Declarative Dialect not implemented yet.")
+	return errors.New("declarative dialect not implemented yet")
 }
 
 func (b *DeclarativeDialect) SaveBot(bot *meta.Bot, op *wire.SaveOp, connection wire.Connection, session *sess.Session) error {
-	return errors.New("Declarative Dialect not implemented yet.")
+	return errors.New("declarative dialect not implemented yet")
 }
 
 func (b *DeclarativeDialect) RunIntegrationActionBot(bot *meta.Bot, ic *wire.IntegrationConnection, actionName string, params map[string]any) (any, error) {
-	return nil, errors.New("Declarative Dialect not implemented yet.")
+	return nil, errors.New("declarative dialect not implemented yet")
 }

--- a/apps/platform/pkg/bot/dialects.go
+++ b/apps/platform/pkg/bot/dialects.go
@@ -1,7 +1,7 @@
 package bot
 
 import (
-	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/thecloudmasters/uesio/pkg/bundlestore"
@@ -19,11 +19,11 @@ func RegisterBotDialect(name string, dialect BotDialect) {
 func GetBotDialect(botDialectName string) (BotDialect, error) {
 	dialectKey, ok := meta.GetBotDialects()[botDialectName]
 	if !ok {
-		return nil, errors.New("Invalid bot dialect name: " + botDialectName)
+		return nil, fmt.Errorf("invalid bot dialect name: %s", botDialectName)
 	}
 	dialect, ok := botDialectMap[dialectKey]
 	if !ok {
-		return nil, errors.New("No dialect found for this bot: " + botDialectName)
+		return nil, fmt.Errorf("no dialect found for this bot: %s", botDialectName)
 	}
 	return dialect, nil
 }

--- a/apps/platform/pkg/bot/jsdialect/bothttpapi.go
+++ b/apps/platform/pkg/bot/jsdialect/bothttpapi.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
-	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -186,7 +186,7 @@ func (api *BotHttpAPI) Request(req *BotHttpRequest) *BotHttpResponse {
 	// Read the full body into a byte array, so we can cache / parse
 	responseData, responseError := io.ReadAll(httpResp.Body)
 	if responseError != nil {
-		return ServerError(errors.New("unable to read response body: " + responseError.Error()))
+		return ServerError(fmt.Errorf("unable to read response body: %w", responseError))
 	}
 
 	contentType := httpResp.Header.Get("Content-Type")

--- a/apps/platform/pkg/bot/jsdialect/bothttpapi_test.go
+++ b/apps/platform/pkg/bot/jsdialect/bothttpapi_test.go
@@ -713,7 +713,8 @@ func Test_Request(t *testing.T) {
 				},
 				requestAsserts: func(t *testing.T, request *http.Request) {
 					// If this is a request for the access token, respond accordingly
-					if request.URL.Path == "/oauth/token" {
+					switch request.URL.Path {
+					case "/oauth/token":
 						assert.Equal(t, "POST", request.Method)
 						err := request.ParseForm()
 						assert.Nil(t, err)
@@ -729,12 +730,12 @@ func Test_Request(t *testing.T) {
 						serveResponseBody = string(accessTokenResponse)
 						serveContentType = "application/json"
 						serveStatusCode = 200
-					} else if request.URL.Path == "/array" {
+					case "/array":
 						assert.Equal(t, "GET", request.Method)
 						assert.Equal(t, "Bearer abcd1234", request.Header.Get("Authorization"))
 						serveResponseBody = `[{"foo":"bar"},{"hello":"world"}]`
 						serveContentType = "text/json"
-					} else {
+					default:
 						assert.Fail(t, "unexpected request")
 					}
 				},
@@ -832,7 +833,8 @@ func Test_Request(t *testing.T) {
 				},
 				requestAsserts: func(t *testing.T, request *http.Request) {
 					// If this is a request for the access token, respond accordingly
-					if request.URL.Path == "/oauth/token" {
+					switch request.URL.Path {
+					case "/oauth/token":
 						assert.Equal(t, "POST", request.Method)
 						err := request.ParseForm()
 						assert.Nil(t, err)
@@ -849,7 +851,7 @@ func Test_Request(t *testing.T) {
 						serveResponseBody = string(accessTokenResponse)
 						serveContentType = "application/json"
 						serveStatusCode = 200
-					} else if request.URL.Path == "/array" {
+					case "/array":
 						assert.Equal(t, "GET", request.Method)
 						// If we get called with the old token, return 401
 						if request.Header.Get("Authorization") == "Bearer oldtoken" {
@@ -864,7 +866,7 @@ func Test_Request(t *testing.T) {
 							serveContentType = "text/json"
 							serveStatusCode = http.StatusOK
 						}
-					} else {
+					default:
 						assert.Fail(t, "unexpected request")
 					}
 				},

--- a/apps/platform/pkg/bot/jsdialect/generatorbot.go
+++ b/apps/platform/pkg/bot/jsdialect/generatorbot.go
@@ -461,7 +461,7 @@ func mergeNode(node *yaml.Node, params map[string]any) error {
 					// If newNode is not a scalar, then we have to be sure it was the
 					// entire merge.
 					if matchExpression != node.Value {
-						return errors.New("cannot merge a sequence or map into a multipart template: " + matchExpression + " : " + node.Value)
+						return fmt.Errorf("cannot merge a sequence or map into a multipart template: %s : %s", matchExpression, node.Value)
 					}
 
 					// Replace that crap

--- a/apps/platform/pkg/bot/params.go
+++ b/apps/platform/pkg/bot/params.go
@@ -51,11 +51,12 @@ func GetBotParams(namespace, name, metadataType string, session *sess.Session) (
 	}
 
 	var robot *meta.Bot
-	if metadataType == "GENERATOR" {
+	switch metadataType {
+	case "GENERATOR":
 		robot = meta.NewGeneratorBot(namespace, name)
-	} else if metadataType == "LISTENER" {
+	case "LISTENER":
 		robot = meta.NewListenerBot(namespace, name)
-	} else if metadataType == "RUNACTION" {
+	case "RUNACTION":
 		robot = meta.NewRunActionBot(namespace, name)
 	}
 

--- a/apps/platform/pkg/bot/params.go
+++ b/apps/platform/pkg/bot/params.go
@@ -47,7 +47,7 @@ func GetParamResponse(params meta.BotParams) meta.BotParamsResponse {
 func GetBotParams(namespace, name, metadataType string, session *sess.Session) (meta.BotParamsResponse, error) {
 
 	if metadataType != "GENERATOR" && metadataType != "LISTENER" && metadataType != "RUNACTION" {
-		return nil, exceptions.NewBadRequestException(fmt.Sprintf("Wrong bot type: %s", metadataType), nil)
+		return nil, exceptions.NewBadRequestException("Wrong bot type: "+metadataType, nil)
 	}
 
 	var robot *meta.Bot

--- a/apps/platform/pkg/bot/params.go
+++ b/apps/platform/pkg/bot/params.go
@@ -1,8 +1,6 @@
 package bot
 
 import (
-	"fmt"
-
 	"github.com/thecloudmasters/uesio/pkg/bundle"
 	"github.com/thecloudmasters/uesio/pkg/meta"
 	"github.com/thecloudmasters/uesio/pkg/sess"

--- a/apps/platform/pkg/bot/systemdialect/systembot_after_app.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_after_app.go
@@ -1,7 +1,7 @@
 package systemdialect
 
 import (
-	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/thecloudmasters/uesio/pkg/datasource"
@@ -46,7 +46,7 @@ func runStarterTemplate(appInsert *wire.ChangeItem, connection wire.Connection, 
 
 	starterTemplateParts := strings.Split(starterTemplate, ":")
 	if len(starterTemplateParts) != 2 {
-		return errors.New("Invalid starter template: " + starterTemplate)
+		return fmt.Errorf("invalid starter template: %s", starterTemplate)
 	}
 	starterApp := starterTemplateParts[0]
 	starterAppVersion := starterTemplateParts[1]

--- a/apps/platform/pkg/bot/systemdialect/systembot_after_bundle.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_after_bundle.go
@@ -48,7 +48,7 @@ func cleanBundleFiles(request *wire.SaveOp, connection wire.Connection, session 
 	}
 
 	if len(bundleDependency) > 0 {
-		return errors.New("Tried to delete a Bundle that is in use")
+		return errors.New("tried to delete a Bundle that is in use")
 	}
 
 	return clearFilesForBundles(uniqueKeys, session)

--- a/apps/platform/pkg/bot/systemdialect/systembot_after_bundledependency.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_after_bundledependency.go
@@ -1,7 +1,7 @@
 package systemdialect
 
 import (
-	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/thecloudmasters/uesio/pkg/constant/commonfields"
@@ -14,7 +14,7 @@ import (
 func parseKey(key string) (string, string, error) {
 	keyArray := strings.Split(key, ":")
 	if len(keyArray) != 3 {
-		return "", "", errors.New("Invalid Bundle Dep Key: " + key)
+		return "", "", fmt.Errorf("invalid bundle dep key: %s", key)
 	}
 	return keyArray[0], keyArray[2], nil
 }

--- a/apps/platform/pkg/bot/systemdialect/systembot_after_collection.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_after_collection.go
@@ -1,7 +1,7 @@
 package systemdialect
 
 import (
-	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/thecloudmasters/uesio/pkg/constant/commonfields"
@@ -15,7 +15,7 @@ func parseUniquekeyToCollectionKey(uniquekey string) (string, error) {
 	//ben/greenlink:dev:companymember to ben/greenlink.companymember
 	keyArray := strings.Split(uniquekey, ":")
 	if len(keyArray) != 3 {
-		return "", errors.New("Invalid Collection Key: " + uniquekey)
+		return "", fmt.Errorf("invalid collection key: %s", uniquekey)
 	}
 
 	return keyArray[0] + "." + keyArray[2], nil

--- a/apps/platform/pkg/bot/systemdialect/systembot_after_field.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_after_field.go
@@ -3,6 +3,7 @@ package systemdialect
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/thecloudmasters/uesio/pkg/datasource"
 	"github.com/thecloudmasters/uesio/pkg/formula"
@@ -136,7 +137,7 @@ func runFieldAfterSaveBot(request *wire.SaveOp, connection wire.Connection, sess
 
 			_, err = formula.UesioLanguage.Evaluate(expression, testEval)
 			if err != nil {
-				return errors.New("Field: invalid expression:" + err.Error())
+				return fmt.Errorf("field: invalid expression: %w", err)
 			}
 
 			for key := range testEval.fieldKeys {
@@ -146,7 +147,7 @@ func runFieldAfterSaveBot(request *wire.SaveOp, connection wire.Connection, sess
 				}
 
 				if field.IsFormula {
-					return errors.New("Field: invalid expression: Formula field cannot reference another formula field")
+					return errors.New("field: invalid expression: formula field cannot reference another formula field")
 				}
 
 			}

--- a/apps/platform/pkg/bot/systemdialect/systembot_after_integration_type.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_after_integration_type.go
@@ -1,7 +1,7 @@
 package systemdialect
 
 import (
-	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/thecloudmasters/uesio/pkg/constant/commonfields"
@@ -15,7 +15,7 @@ func parseUniquekeyToIntegrationTypeKey(uniquekey string) (string, error) {
 	//luigi/app:dev:salesforce to luigi/app.salesforce
 	keyArray := strings.Split(uniquekey, ":")
 	if len(keyArray) != 3 {
-		return "", errors.New("invalid integration type key: " + uniquekey)
+		return "", fmt.Errorf("invalid integration type key: %s", uniquekey)
 	}
 
 	return keyArray[0] + "." + keyArray[2], nil

--- a/apps/platform/pkg/bot/systemdialect/systembot_after_site.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_after_site.go
@@ -2,6 +2,7 @@ package systemdialect
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/thecloudmasters/uesio/pkg/auth"
 	"github.com/thecloudmasters/uesio/pkg/constant/commonfields"
@@ -133,7 +134,7 @@ func runSiteAfterSaveBot(request *wire.SaveOp, connection wire.Connection, sessi
 			return errors.New("unable to get site unique key, cannot truncate data")
 		}
 		if err = connection.TruncateTenantData(sess.MakeSiteTenantID(siteUniqueKey)); err != nil {
-			return errors.New("unable to truncate site data: " + err.Error())
+			return fmt.Errorf("unable to truncate site data: %w", err)
 		}
 		return nil
 	})

--- a/apps/platform/pkg/bot/systemdialect/systembot_after_sitedomain.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_after_sitedomain.go
@@ -177,7 +177,7 @@ func enforceMaxDomainsLimit(request *wire.SaveOp, connection wire.Connection, se
 		// Lookup the limit
 		limitDomains, err3 := limits.GetLimitDomainsPerUser(userId, session)
 		if err3 != nil {
-			return errors.New("unable to determine the limit for max domains for user: " + uniqueUserIds[userId])
+			return fmt.Errorf("unable to determine the limit for max domains for user: %s", uniqueUserIds[userId])
 		}
 		// Compute all the variables that go into the equation
 		existingDomains, hasDomains := currentDomainsPerUser[userId]

--- a/apps/platform/pkg/bot/systemdialect/systembot_after_userfile.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_after_userfile.go
@@ -38,7 +38,8 @@ func runUserFileAfterSaveBot(request *wire.SaveOp, connection wire.Connection, s
 		if err != nil {
 			return err
 		}
-		if relatedCollection == userCollectionId {
+		switch relatedCollection {
+		case userCollectionId:
 			relatedField, err := change.GetField("uesio/core.fieldid")
 			if err != nil {
 				return err
@@ -46,7 +47,7 @@ func runUserFileAfterSaveBot(request *wire.SaveOp, connection wire.Connection, s
 			if relatedField == "uesio/core.picture" {
 				userKeysToDelete = append(userKeysToDelete, auth.GetUserCacheKey(relatedRecordId, site))
 			}
-		} else if relatedCollection == studioFileCollectionId {
+		case studioFileCollectionId:
 			pathField, err := change.GetField("uesio/core.path")
 			if err != nil || pathField == "" {
 				return nil
@@ -59,7 +60,7 @@ func runUserFileAfterSaveBot(request *wire.SaveOp, connection wire.Connection, s
 			} else {
 				return nil
 			}
-		} else if relatedCollection == studioBotCollectionId {
+		case studioBotCollectionId:
 			// Increment the timestamp on the parent Bot,
 			// so that we are able to achieve cache invalidation
 			studioBotUpdates = append(studioBotUpdates, &wire.Item{

--- a/apps/platform/pkg/bot/systemdialect/systembot_after_workspace.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_after_workspace.go
@@ -4,6 +4,7 @@ import (
 	"archive/zip"
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
 
 	"gopkg.in/yaml.v3"
@@ -122,7 +123,7 @@ func runWorkspaceAfterSaveBot(request *wire.SaveOp, connection wire.Connection, 
 			return errors.New("unable to get workspace unique key, cannot truncate data")
 		}
 		if err = connection.TruncateTenantData(sess.MakeWorkspaceTenantID(workspaceUniqueKey)); err != nil {
-			return errors.New("unable to truncate workspace data: " + err.Error())
+			return fmt.Errorf("unable to truncate workspace data: %w", err)
 		}
 		return nil
 	})

--- a/apps/platform/pkg/bot/systemdialect/systembot_before_app.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_before_app.go
@@ -32,7 +32,7 @@ func runAppBeforeSaveBot(request *wire.SaveOp, connection wire.Connection, sessi
 		}
 		name, err := change.GetFieldAsString("uesio/studio.name")
 		if err != nil {
-			return errors.New("The name field is required to create an app")
+			return errors.New("the name field is required to create an app")
 		}
 		return change.SetField("uesio/studio.fullname", userKey+"/"+name)
 

--- a/apps/platform/pkg/bot/systemdialect/systembot_before_field.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_before_field.go
@@ -1,7 +1,7 @@
 package systemdialect
 
 import (
-	"errors"
+	"fmt"
 
 	"github.com/thecloudmasters/uesio/pkg/datasource"
 	"github.com/thecloudmasters/uesio/pkg/meta"
@@ -33,7 +33,7 @@ func runFieldBeforeSaveBot(request *wire.SaveOp, connection wire.Connection, ses
 
 		_, ok := meta.GetFieldTypes()[ftype]
 		if !ok {
-			return errors.New("Invalid Field Type for Field: " + ftype)
+			return fmt.Errorf("invalid field type for field: %s", ftype)
 		}
 
 		err = depMap.AddRequired(change, "collection", "uesio/studio.collection")

--- a/apps/platform/pkg/bot/systemdialect/systembot_before_user.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_before_user.go
@@ -25,7 +25,7 @@ func runUserBeforeSaveBot(request *wire.SaveOp, connection wire.Connection, sess
 			return err
 		}
 		if username == "" {
-			return errors.New("User must have a username")
+			return errors.New("user must have a username")
 		}
 		return change.SetField(commonfields.Owner, &meta.User{
 			BuiltIn: meta.BuiltIn{

--- a/apps/platform/pkg/bot/systemdialect/systembot_listener_addexternalbundle.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_listener_addexternalbundle.go
@@ -1,7 +1,7 @@
 package systemdialect
 
 import (
-	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -89,17 +89,17 @@ func getBundleFromVersion(namespace, version string) (*meta.Bundle, error) {
 
 	majorInt, err := strconv.Atoi(major)
 	if err != nil {
-		return nil, errors.New("Invalid major version string: " + major)
+		return nil, fmt.Errorf("invalid major version string: %s", major)
 	}
 
 	minorInt, err := strconv.Atoi(minor)
 	if err != nil {
-		return nil, errors.New("Invalid minor version string: " + minor)
+		return nil, fmt.Errorf("invalid minor version string: %s", minor)
 	}
 
 	patchInt, err := strconv.Atoi(patch)
 	if err != nil {
-		return nil, errors.New("Invalid patch version string: " + patch)
+		return nil, fmt.Errorf("invalid patch version string: %s", patch)
 	}
 
 	newBundle, err := meta.NewBundle(namespace, majorInt, minorInt, patchInt, "")

--- a/apps/platform/pkg/bot/systemdialect/systembot_listener_createapikey.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_listener_createapikey.go
@@ -40,7 +40,7 @@ func SecureRandomBytes(length int) []byte {
 	var randomBytes = make([]byte, length)
 	_, err := rand.Read(randomBytes)
 	if err != nil {
-		log.Fatal("Unable to generate random bytes")
+		log.Fatal("unable to generate random bytes")
 	}
 	return randomBytes
 }
@@ -49,12 +49,12 @@ func runCreateApiKeyListenerBot(params map[string]any, connection wire.Connectio
 
 	// Currently this only works in a siteadmin context
 	if session.GetSiteAdmin() == nil {
-		return nil, errors.New("Creating api keys currently only works in a site admin context")
+		return nil, errors.New("creating api keys currently only works in a site admin context")
 	}
 
 	keyParam, ok := params["name"]
 	if !ok {
-		return nil, errors.New("You must provide a key name")
+		return nil, errors.New("you must provide a key name")
 	}
 
 	keyName, ok := keyParam.(string)
@@ -64,7 +64,7 @@ func runCreateApiKeyListenerBot(params map[string]any, connection wire.Connectio
 
 	userIDParam, ok := params["userid"]
 	if !ok {
-		return nil, errors.New("You must provide a user id")
+		return nil, errors.New("you must provide a user id")
 	}
 
 	userID, ok := userIDParam.(string)

--- a/apps/platform/pkg/bot/systemdialect/systembot_listener_getstarterparams.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_listener_getstarterparams.go
@@ -2,6 +2,7 @@ package systemdialect
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/thecloudmasters/uesio/pkg/bot"
@@ -15,15 +16,15 @@ func runGetStarterParamsBot(params map[string]any, connection wire.Connection, s
 
 	starterTemplate, ok := params["template"]
 	if !ok {
-		return nil, errors.New("Invalid starter template")
+		return nil, errors.New("invalid starter template")
 	}
 	starterTemplateString, ok := starterTemplate.(string)
 	if !ok {
-		return nil, errors.New("Invalid starter template")
+		return nil, errors.New("invalid starter template")
 	}
 	starterTemplateParts := strings.Split(starterTemplateString, ":")
 	if len(starterTemplateParts) != 2 {
-		return nil, errors.New("Invalid starter template: " + starterTemplateString)
+		return nil, fmt.Errorf("invalid starter template: %s", starterTemplateString)
 	}
 	starterApp := starterTemplateParts[0]
 

--- a/apps/platform/pkg/bot/systemdialect/systembot_listener_runagent.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_listener_runagent.go
@@ -2,7 +2,7 @@ package systemdialect
 
 import (
 	"bytes"
-	"errors"
+	"fmt"
 
 	"github.com/thecloudmasters/uesio/pkg/bundle"
 	"github.com/thecloudmasters/uesio/pkg/datasource"
@@ -160,7 +160,7 @@ func threadItemToMessage(threadItem *wire.Item) (*bedrock.AnthropicMessage, erro
 		}, nil
 	}
 
-	return nil, errors.New("Thread item type not supported: " + itemType)
+	return nil, fmt.Errorf("thread item type not supported: %s", itemType)
 
 }
 

--- a/apps/platform/pkg/bot/systemdialect/systembot_load_configvalue.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_load_configvalue.go
@@ -2,6 +2,7 @@ package systemdialect
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/thecloudmasters/uesio/pkg/configstore"
 	"github.com/thecloudmasters/uesio/pkg/sess"
@@ -12,14 +13,14 @@ func runConfigValueLoadBot(op *wire.LoadOp, connection wire.Connection, session 
 
 	// Currently, this doesn't work for regular contexts
 	if session.GetWorkspace() == nil && session.GetSiteAdmin() == nil {
-		return errors.New("Must be in workspace or site admin context")
+		return errors.New("must be in workspace or site admin context")
 	}
 
 	configValues, err := configstore.GetConfigValues(session, &configstore.ConfigLoadOptions{
 		OnlyWriteable: true,
 	})
 	if err != nil {
-		return errors.New("Failed to get config values: " + err.Error())
+		return fmt.Errorf("failed to get config values: %w", err)
 	}
 
 	for _, configValue := range *configValues {

--- a/apps/platform/pkg/bot/systemdialect/systembot_load_external.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_load_external.go
@@ -59,7 +59,7 @@ func differentHostLoad(op *wire.LoadOp, session *sess.Session) error {
 	})
 
 	if response.Code != 200 {
-		return fmt.Errorf("External Load failed: %s, %v, %s", baseUrl, response.Code, response.Status)
+		return fmt.Errorf("external load failed: %s, %v, %s", baseUrl, response.Code, response.Status)
 	}
 
 	return addDataToCollection(op, collectionMetadata, &responseBody.Wires[0].Data)

--- a/apps/platform/pkg/bot/systemdialect/systembot_load_featureflag.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_load_featureflag.go
@@ -2,6 +2,7 @@ package systemdialect
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/thecloudmasters/uesio/pkg/featureflagstore"
 	"github.com/thecloudmasters/uesio/pkg/sess"
@@ -18,7 +19,7 @@ func runFeatureFlagLoadBot(op *wire.LoadOp, connection wire.Connection, session 
 	if session.GetSiteAdmin() != nil {
 		userCondition := extractConditionByField(op.Conditions, "userid")
 		if userCondition == nil {
-			return errors.New("You must provide a user condition in the site admin context.")
+			return errors.New("you must provide a user condition in the site admin context")
 		}
 		if userCondition.Value != nil {
 			var ok bool
@@ -40,12 +41,12 @@ func runFeatureFlagLoadBot(op *wire.LoadOp, connection wire.Connection, session 
 	}
 
 	if userID == "" {
-		return errors.New("No User Id provided to feature flag load.")
+		return errors.New("no user id provided to feature flag load")
 	}
 
 	featureFlags, err := featureflagstore.GetFeatureFlags(session, userID)
 	if err != nil {
-		return errors.New("Failed to get feature flags: " + err.Error())
+		return fmt.Errorf("failed to get feature flags: %w", err)
 	}
 
 	var orgOnly bool

--- a/apps/platform/pkg/bot/systemdialect/systembot_load_myintegrationcredentials.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_load_myintegrationcredentials.go
@@ -2,6 +2,7 @@ package systemdialect
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/thecloudmasters/uesio/pkg/bundle"
 	"github.com/thecloudmasters/uesio/pkg/bundlestore"
@@ -136,13 +137,13 @@ func getAllPerUserIntegrationsUserHasAccessTo(session *sess.Session, connection 
 		if err := bundle.LoadAllFromNamespaces(goutils.MapKeys(uniqueNamespaces), group, &bundlestore.GetAllItemsOptions{
 			Conditions: conditions,
 		}, session, connection); err != nil {
-			return nil, errors.New("unable to load integrations: " + err.Error())
+			return nil, fmt.Errorf("unable to load integrations: %w", err)
 		}
 	} else {
 		if err := bundle.LoadAllFromAny(group, &bundlestore.GetAllItemsOptions{
 			Conditions: conditions,
 		}, session, connection); err != nil {
-			return nil, errors.New("unable to load integrations: " + err.Error())
+			return nil, fmt.Errorf("unable to load integrations: %w", err)
 		}
 	}
 	return group, nil

--- a/apps/platform/pkg/bot/systemdialect/systembot_load_secret.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_load_secret.go
@@ -2,6 +2,7 @@ package systemdialect
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/thecloudmasters/uesio/pkg/secretstore"
 	"github.com/thecloudmasters/uesio/pkg/sess"
@@ -12,12 +13,12 @@ func runSecretLoadBot(op *wire.LoadOp, connection wire.Connection, session *sess
 
 	// Currently, this doesn't work for regular contexts
 	if session.GetWorkspace() == nil && session.GetSiteAdmin() == nil {
-		return errors.New("Must be in workspace or site admin context")
+		return errors.New("must be in workspace or site admin context")
 	}
 
 	secrets, err := secretstore.GetSecrets(session)
 	if err != nil {
-		return errors.New("Failed to get secrets: " + err.Error())
+		return fmt.Errorf("failed to get secrets: %w", err)
 	}
 
 	for _, secret := range *secrets {

--- a/apps/platform/pkg/bot/systemdialect/systembot_save_external.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_save_external.go
@@ -8,5 +8,5 @@ import (
 )
 
 func runUesioExternalSaveBot(op *wire.SaveOp, connection wire.Connection, session *sess.Session) error {
-	return errors.New("Uesio external save not yet supported")
+	return errors.New("uesio external save not yet supported")
 }

--- a/apps/platform/pkg/bot/systemdialect/systembot_save_featureflag.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_save_featureflag.go
@@ -33,7 +33,7 @@ func getKeyInfo(change *wire.ChangeItem, session *sess.Session) (string, string,
 		userID = keyParts[1]
 	}
 	if userID == "" {
-		return "", "", errors.New("No User Id provided to feature flag save.")
+		return "", "", errors.New("no user id provided to feature flag save")
 	}
 	return key, userID, nil
 }

--- a/apps/platform/pkg/bulk/batch.go
+++ b/apps/platform/pkg/bulk/batch.go
@@ -46,7 +46,7 @@ func NewBatch(body io.ReadCloser, jobID string, session *sess.Session) (*meta.Bu
 		return NewFileUploadBatch(body, job, session)
 	}
 
-	return nil, exceptions.NewBadRequestException(fmt.Sprintf("invalid JobType for creating batches: %s", job.Spec.JobType), nil)
+	return nil, exceptions.NewBadRequestException("invalid JobType for creating batches: "+job.Spec.JobType, nil)
 
 }
 

--- a/apps/platform/pkg/bulk/batch.go
+++ b/apps/platform/pkg/bulk/batch.go
@@ -1,7 +1,6 @@
 package bulk
 
 import (
-	"fmt"
 	"io"
 
 	"github.com/thecloudmasters/uesio/pkg/constant/commonfields"

--- a/apps/platform/pkg/bulk/csv.go
+++ b/apps/platform/pkg/bulk/csv.go
@@ -2,7 +2,7 @@ package bulk
 
 import (
 	"encoding/csv"
-	"errors"
+	"fmt"
 	"io"
 
 	"github.com/dimchansky/utfbom"
@@ -75,19 +75,20 @@ func processCSV(body io.ReadCloser, spec *meta.JobSpec, metadata *wire.MetadataC
 			return nil, err
 		}
 
-		if mapping.Type == "" || mapping.Type == "IMPORT" {
+		switch mapping.Type {
+		case "", "IMPORT":
 			if mapping.ColumnName == "" {
 				mapping.ColumnName = fieldName
 			}
 			colIndex, ok := columnIndexes[mapping.ColumnName]
 			if !ok {
-				return nil, errors.New("Invalid Column Name for Import: " + mapping.ColumnName)
+				return nil, fmt.Errorf("invalid column name for import: %s", mapping.ColumnName)
 			}
 			index = colIndex
 			valueGetter = getValue
-		} else if mapping.Type == "VALUE" {
+		case "VALUE":
 			if mapping.Value == "" {
-				return nil, errors.New("No Value Provided for mapping: " + fieldName)
+				return nil, fmt.Errorf("no value provided for mapping: %s", fieldName)
 			}
 			valueGetter = func(data any, mapping *meta.FieldMapping, index int) string {
 				return mapping.Value

--- a/apps/platform/pkg/bulk/exportcollection.go
+++ b/apps/platform/pkg/bulk/exportcollection.go
@@ -1,7 +1,6 @@
 package bulk
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
@@ -56,7 +55,7 @@ func exportCollection(create bundlestore.FileCreator, spec *meta.JobSpec, sessio
 	}
 
 	if collection == nil {
-		return errors.New("Cannot process that file type: " + spec.FileType)
+		return fmt.Errorf("cannot process that file type: %s", spec.FileType)
 	}
 
 	return datasource.LoadWithError(&wire.LoadOp{

--- a/apps/platform/pkg/bulk/exportcollection.go
+++ b/apps/platform/pkg/bulk/exportcollection.go
@@ -43,7 +43,7 @@ func exportCollection(create bundlestore.FileCreator, spec *meta.JobSpec, sessio
 		})
 	}
 
-	file, err := create(fmt.Sprintf("%s.csv", strings.ReplaceAll(spec.Collection, "/", "_")))
+	file, err := create(strings.ReplaceAll(spec.Collection, "/", "_") + ".csv")
 	if err != nil {
 		return err
 	}

--- a/apps/platform/pkg/bulk/exportfiles.go
+++ b/apps/platform/pkg/bulk/exportfiles.go
@@ -43,7 +43,7 @@ func exportFiles(create bundlestore.FileCreator, spec *meta.JobSpec, session *se
 		return err
 	}
 
-	file, err := create(fmt.Sprintf("%s.csv", strings.ReplaceAll(userFiles.GetName(), "/", "_")))
+	file, err := create(strings.ReplaceAll(userFiles.GetName(), "/", "_") + ".csv")
 	if err != nil {
 		return err
 	}

--- a/apps/platform/pkg/bulk/import.go
+++ b/apps/platform/pkg/bulk/import.go
@@ -1,7 +1,7 @@
 package bulk
 
 import (
-	"errors"
+	"fmt"
 	"io"
 
 	"github.com/thecloudmasters/uesio/pkg/datasource"
@@ -37,7 +37,7 @@ func NewImportBatch(body io.ReadCloser, job meta.BulkJob, session *sess.Session)
 	}
 
 	if saveRequest == nil {
-		return nil, errors.New("Cannot process that file type: " + fileFormat)
+		return nil, fmt.Errorf("cannot process that file type: %s", fileFormat)
 	}
 
 	err = datasource.Save(saveRequest, session)

--- a/apps/platform/pkg/bulk/loaders.go
+++ b/apps/platform/pkg/bulk/loaders.go
@@ -16,9 +16,9 @@ import (
 type valueFunc func(data any, mapping *meta.FieldMapping, index int) string
 type loaderFunc func(change wire.Item, data any) error
 
-const InvalidTimestampError = "Invalid format for TIMESTAMP field '%s': value '%v' is not valid ISO-8601 UTC datetime or Unix timestamp"
-const InvalidNumberError = "Invalid format for NUMBER field '%s': value '%v' is not a valid number"
-const InvalidCheckboxError = "Invalid format for CHECKBOX field '%s': value '%v' is not a valid boolean"
+const InvalidTimestampError = "invalid format for TIMESTAMP field '%s': value '%v' is not valid ISO-8601 UTC datetime or Unix timestamp"
+const InvalidNumberError = "invalid format for NUMBER field '%s': value '%v' is not a valid number"
+const InvalidCheckboxError = "invalid format for CHECKBOX field '%s': value '%v' is not a valid boolean"
 
 func getNumberLoader(index int, mapping *meta.FieldMapping, fieldMetadata *wire.FieldMetadata, getValue valueFunc) loaderFunc {
 	return func(change wire.Item, data any) error {
@@ -107,7 +107,7 @@ func getDateLoader(index int, mapping *meta.FieldMapping, fieldMetadata *wire.Fi
 		}
 		t, err := time.Parse(timeutils.ISO8601Date, stringValue)
 		if err != nil {
-			return errors.New("Invalid date format: " + fieldMetadata.GetFullName() + " : " + err.Error())
+			return fmt.Errorf("invalid date format: %s : %w", fieldMetadata.GetFullName(), err)
 		}
 
 		change[fieldMetadata.GetFullName()] = t.Format(timeutils.ISO8601Date)
@@ -123,7 +123,7 @@ func getStructLoader(index int, mapping *meta.FieldMapping, fieldMetadata *wire.
 		if rawVal != "" && rawVal != "{}" {
 			var jsonVal map[string]any
 			if err := json.Unmarshal([]byte(rawVal), &jsonVal); err != nil {
-				return errors.New("Invalid struct format: " + fieldMetadata.GetFullName() + " : " + err.Error())
+				return fmt.Errorf("invalid struct format: %s : %w", fieldMetadata.GetFullName(), err)
 			}
 			// Only allow valid subfields, ignore all other fields
 			for key := range fieldMetadata.SubFields {

--- a/apps/platform/pkg/bulk/loaders.go
+++ b/apps/platform/pkg/bulk/loaders.go
@@ -197,7 +197,7 @@ func getListLoader(index int, mapping *meta.FieldMapping, fieldMetadata *wire.Fi
 		if rawVal != "" && rawVal != "[]" {
 			err := json.Unmarshal([]byte(rawVal), &value)
 			if err != nil {
-				return fmt.Errorf("invalid LIST field value")
+				return errors.New("invalid LIST field value")
 			}
 		}
 		change[fieldMetadata.GetFullName()] = value

--- a/apps/platform/pkg/bulk/loaders_test.go
+++ b/apps/platform/pkg/bulk/loaders_test.go
@@ -54,7 +54,7 @@ func Test_TimestampLoader(t *testing.T) {
 			"return error if input is not an expected format",
 			"2022/12/13",
 			nil,
-			"Invalid format for TIMESTAMP field 'uesio/core.updatedat': value '2022/12/13' is not valid ISO-8601 UTC datetime or Unix timestamp",
+			"invalid format for TIMESTAMP field 'uesio/core.updatedat': value '2022/12/13' is not valid ISO-8601 UTC datetime or Unix timestamp",
 		},
 	}
 	for _, tt := range tests {
@@ -73,7 +73,7 @@ func Test_TimestampLoader(t *testing.T) {
 				val, err := changeItem.GetField(fieldMetadata.GetFullName())
 				if tt.want == nil {
 					assert.NotNil(t, err)
-					assert.Equal(t, err.Error(), "Field not found: "+fieldMetadata.GetFullName())
+					assert.Equal(t, err.Error(), "field not found: "+fieldMetadata.GetFullName())
 				} else {
 					assert.Nil(t, err)
 					assert.Equalf(t, tt.want, val, "TimestampLoader(%s)", tt.input)
@@ -135,7 +135,7 @@ func Test_NumberLoader(t *testing.T) {
 			"return error if input is not an expected format",
 			"2022/12/13",
 			nil,
-			"Invalid format for NUMBER field 'uesio/core.total_population': value '2022/12/13' is not a valid number",
+			"invalid format for NUMBER field 'uesio/core.total_population': value '2022/12/13' is not a valid number",
 		},
 	}
 	for _, tt := range tests {
@@ -205,7 +205,7 @@ func Test_BooleanLoader(t *testing.T) {
 			"return error if input can not be parsed as boolean",
 			"not a boolean",
 			nil,
-			"Invalid format for CHECKBOX field 'uesio/core.checkbox': value 'not a boolean' is not a valid boolean",
+			"invalid format for CHECKBOX field 'uesio/core.checkbox': value 'not a boolean' is not a valid boolean",
 		},
 	}
 	for _, tt := range tests {
@@ -549,7 +549,7 @@ func Test_StructLoader(t *testing.T) {
 			"return error if input is not an expected format",
 			"asjdfkasdjf",
 			nil,
-			"Invalid struct format: uesio/core.location : invalid character 'a' looking for beginning of value",
+			"invalid struct format: uesio/core.location : invalid character 'a' looking for beginning of value",
 		},
 	}
 	for _, tt := range tests {

--- a/apps/platform/pkg/bulk/stringers.go
+++ b/apps/platform/pkg/bulk/stringers.go
@@ -25,7 +25,7 @@ func getStringValue(fieldMetadata *wire.FieldMetadata, value any) (string, error
 	case "LIST", "STRUCT", "MAP":
 		byteValue, err := json.Marshal(value)
 		if err != nil {
-			return "", fmt.Errorf("Failed to serialize: %s: %w", fieldMetadata.GetFullName(), err)
+			return "", fmt.Errorf("failed to serialize: %s: %w", fieldMetadata.GetFullName(), err)
 		}
 		return string(byteValue), nil
 	case "MULTISELECT":
@@ -36,7 +36,7 @@ func getStringValue(fieldMetadata *wire.FieldMetadata, value any) (string, error
 		sort.Strings(values)
 		byteValue, err := json.Marshal(values)
 		if err != nil {
-			return "", fmt.Errorf("Failed to serialize: %s: %w", fieldMetadata.GetFullName(), err)
+			return "", fmt.Errorf("failed to serialize: %s: %w", fieldMetadata.GetFullName(), err)
 		}
 		return string(byteValue), nil
 	case "TIMESTAMP":
@@ -51,7 +51,7 @@ func getStringValue(fieldMetadata *wire.FieldMetadata, value any) (string, error
 			unixTimestamp = time.Unix(timestampInt, 0).UTC()
 		} else {
 			// It is neither -- this is not a supported format
-			return "", errors.New("Bad timestamp value")
+			return "", errors.New("bad timestamp value")
 		}
 		return unixTimestamp.Format(time.RFC3339), nil
 	case "NUMBER":
@@ -64,7 +64,7 @@ func getStringValue(fieldMetadata *wire.FieldMetadata, value any) (string, error
 	default:
 		stringVal, ok := value.(string)
 		if !ok {
-			fmt.Println("Failed to set: " + fieldMetadata.GetFullName() + ":" + fieldMetadata.Type)
+			fmt.Println("failed to set: " + fieldMetadata.GetFullName() + ":" + fieldMetadata.Type)
 			stringVal = ""
 		}
 		return stringVal, nil

--- a/apps/platform/pkg/bulk/stringers_test.go
+++ b/apps/platform/pkg/bulk/stringers_test.go
@@ -108,7 +108,7 @@ func Test_getStringValue(t *testing.T) {
 				"foo",
 			},
 			"",
-			"Bad timestamp value",
+			"bad timestamp value",
 		},
 		{
 			"stringify TIMESTAMP fields with float64 values into RFC-3339 UTC format",

--- a/apps/platform/pkg/bulk/uploadfiles.go
+++ b/apps/platform/pkg/bulk/uploadfiles.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"encoding/csv"
 	"errors"
+	"fmt"
 	"io"
 
 	"github.com/dimchansky/utfbom"
@@ -19,7 +20,7 @@ func NewFileUploadBatch(body io.ReadCloser, job meta.BulkJob, session *sess.Sess
 	spec := job.Spec
 
 	if spec.Collection == "" {
-		return nil, errors.New("Collection is required for an upload job")
+		return nil, errors.New("collection is required for an upload job")
 	}
 
 	// Unfortunately, we have to read the whole thing into memory
@@ -39,7 +40,7 @@ func NewFileUploadBatch(body io.ReadCloser, job meta.BulkJob, session *sess.Sess
 	// First open upload.csv
 	manifest, err := zipReader.Open("upload.csv")
 	if err != nil {
-		return nil, errors.New("No upload upload.csv manifiest file provided")
+		return nil, errors.New("no upload upload.csv manifiest file provided")
 	}
 
 	defer manifest.Close()
@@ -60,17 +61,17 @@ func NewFileUploadBatch(body io.ReadCloser, job meta.BulkJob, session *sess.Sess
 
 	recordIDIndex, ok := columnIndexes["uesio/core.recordid"]
 	if !ok {
-		return nil, errors.New("No record id column provided in upload.csv")
+		return nil, errors.New("no record id column provided in upload.csv")
 	}
 
 	fieldIDIndex, ok := columnIndexes["uesio/core.fieldid"]
 	if !ok {
-		return nil, errors.New("No field id column provided in upload.csv")
+		return nil, errors.New("no field id column provided in upload.csv")
 	}
 
 	pathIndex, ok := columnIndexes["uesio/core.path"]
 	if !ok {
-		return nil, errors.New("No path column provided in upload.csv")
+		return nil, errors.New("no path column provided in upload.csv")
 	}
 
 	sourcePathIndex, ok := columnIndexes["uesio/core.sourcepath"]
@@ -90,17 +91,17 @@ func NewFileUploadBatch(body io.ReadCloser, job meta.BulkJob, session *sess.Sess
 
 		recordid := record[recordIDIndex]
 		if recordid == "" {
-			return nil, errors.New("No record id provided for upload")
+			return nil, errors.New("no record id provided for upload")
 		}
 
 		path := record[pathIndex]
 		if path == "" {
-			return nil, errors.New("No path provided for upload")
+			return nil, errors.New("no path provided for upload")
 		}
 
 		sourcePath := record[sourcePathIndex]
 		if sourcePath == "" {
-			return nil, errors.New("No source path provided for upload")
+			return nil, errors.New("no source path provided for upload")
 		}
 
 		// It's ok for fieldid to be an empty string.
@@ -109,7 +110,7 @@ func NewFileUploadBatch(body io.ReadCloser, job meta.BulkJob, session *sess.Sess
 
 		f, err := zipReader.Open("files/" + sourcePath)
 		if err != nil {
-			return nil, errors.New("No file found at path: " + path)
+			return nil, fmt.Errorf("no file found at path: %s", path)
 		}
 		uploadOps = append(uploadOps, &filesource.FileUploadOp{
 			Data:            f,

--- a/apps/platform/pkg/bundle/bundles.go
+++ b/apps/platform/pkg/bundle/bundles.go
@@ -2,7 +2,6 @@ package bundle
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 
@@ -52,7 +51,7 @@ func GetVersion(namespace string, session *sess.Session) (string, error) {
 
 	_, _, err := meta.ParseNamespace(namespace)
 	if err != nil {
-		return "", errors.New("Bad namespace: " + namespace)
+		return "", fmt.Errorf("bad namespace: %s", namespace)
 	}
 
 	if appName == namespace {
@@ -63,7 +62,7 @@ func GetVersion(namespace string, session *sess.Session) (string, error) {
 	bundle := session.GetContextAppBundle()
 
 	if bundle == nil {
-		return "", fmt.Errorf("No Bundle info provided for: %s", appName)
+		return "", fmt.Errorf("no bundle info provided for: %s", appName)
 	}
 
 	depBundle, hasDep := bundle.Dependencies[namespace]
@@ -72,7 +71,7 @@ func GetVersion(namespace string, session *sess.Session) (string, error) {
 	}
 
 	if bundle.Licenses == nil {
-		return "", fmt.Errorf("No License info provided for: %s", appName)
+		return "", fmt.Errorf("no license info provided for: %s", appName)
 	}
 
 	license, hasLicense := bundle.Licenses[namespace]
@@ -137,7 +136,7 @@ func HasAny(group meta.BundleableGroup, namespace string, options *bundlestore.H
 func LoadAll(group meta.BundleableGroup, namespace string, options *bundlestore.GetAllItemsOptions, session *sess.Session, connection wire.Connection) error {
 	bs, err := GetBundleStoreConnection(namespace, session, connection)
 	if err != nil {
-		fmt.Println("Failed Load All: " + group.GetName())
+		fmt.Println("failed load all: " + group.GetName())
 		return err
 	}
 	return bs.GetAllItems(group, options)
@@ -150,7 +149,7 @@ func LoadMany(items []meta.BundleableItem, options *bundlestore.GetManyItemsOpti
 			if options.IgnoreUnlicensedItems {
 				continue
 			}
-			fmt.Println("Failed load many")
+			fmt.Println("failed load many")
 			for _, item := range nsItems {
 				fmt.Println(item.GetKey())
 			}

--- a/apps/platform/pkg/bundlestore/bundlestore.go
+++ b/apps/platform/pkg/bundlestore/bundlestore.go
@@ -3,6 +3,7 @@ package bundlestore
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 
 	"gopkg.in/yaml.v3"
@@ -38,7 +39,7 @@ func RegisterBundleStore(name string, store BundleStore) {
 func GetBundleStoreByType(bundleStoreType string) (BundleStore, error) {
 	adapter, ok := bundleStoreMap[bundleStoreType]
 	if !ok {
-		return nil, errors.New("No bundle store found of this type: " + bundleStoreType)
+		return nil, fmt.Errorf("no bundle store found of this type: %s", bundleStoreType)
 	}
 	return adapter, nil
 }
@@ -102,7 +103,7 @@ func getBundleStore(namespace string, workspace *meta.Workspace) (BundleStore, e
 	// If we're in a workspace context and the namespace we're looking for is that workspace,
 	// use the workspace bundlestore
 	if namespace == "" {
-		return nil, errors.New("Could not get bundlestore: No namespace provided")
+		return nil, errors.New("could not get bundlestore: no namespace provided")
 	}
 
 	_, _, err := meta.ParseNamespace(namespace)

--- a/apps/platform/pkg/bundlestore/filebundlestore/filebundlestore.go
+++ b/apps/platform/pkg/bundlestore/filebundlestore/filebundlestore.go
@@ -76,14 +76,14 @@ func (b *FileBundleStoreConnection) GetItem(item meta.BundleableItem, options *b
 	// to several different approaches that could be taken but need to be consistent for same/similar operations.
 	hasPermission := b.Permissions.HasPermission(item.GetPermChecker())
 	if !hasPermission {
-		message := fmt.Sprintf("No Permission to metadata item: %s : %s", item.GetCollectionName(), key)
+		message := fmt.Sprintf("no permission to metadata item: %s : %s", item.GetCollectionName(), key)
 		return exceptions.NewForbiddenException(message)
 	}
 
 	if b.Cache != nil {
 		if cachedItem, ok := b.Cache.GetItemFromCache(b.Namespace, b.Version, fullCollectionName, key); ok {
 			if !b.AllowPrivate && !cachedItem.IsPublic() {
-				message := fmt.Sprintf("Metadata item: %s is not public", key)
+				message := fmt.Sprintf("metadata item: %s is not public", key)
 				return exceptions.NewForbiddenException(message)
 			}
 			return meta.Copy(item, cachedItem)
@@ -112,11 +112,11 @@ func (b *FileBundleStoreConnection) GetItem(item meta.BundleableItem, options *b
 
 	err = bundlestore.DecodeYAML(item, buf)
 	if err != nil {
-		return fmt.Errorf("Error decoding metadata item: %s from file: %s : %w", key, fileMetadata.Path(), err)
+		return fmt.Errorf("error decoding metadata item: %s from file: %s : %w", key, fileMetadata.Path(), err)
 	}
 
 	if !b.AllowPrivate && !item.IsPublic() {
-		return exceptions.NewForbiddenException("Metadata item: " + key + " is not public")
+		return exceptions.NewForbiddenException("metadata item: " + key + " is not public")
 	}
 	if b.Cache == nil {
 		return nil
@@ -239,7 +239,7 @@ func (b *FileBundleStoreConnection) StoreItem(path string, reader io.Reader) err
 
 	_, err := b.FileConnection.Upload(reader, fullFilePath)
 	if err != nil {
-		return errors.New("Error Writing File: " + err.Error())
+		return fmt.Errorf("error writing file: %w", err)
 	}
 
 	return nil
@@ -255,7 +255,7 @@ func (b *FileBundleStoreConnection) DeleteBundle() error {
 
 	err := b.FileConnection.EmptyDir(fullFilePath)
 	if err != nil {
-		return errors.New("Error Deleting Bundle: " + err.Error())
+		return fmt.Errorf("error deleting bundle: %w", err)
 	}
 
 	return nil

--- a/apps/platform/pkg/bundlestore/workspacebundlestore/workspacebundlecacheutils.go
+++ b/apps/platform/pkg/bundlestore/workspacebundlestore/workspacebundlecacheutils.go
@@ -98,7 +98,7 @@ func handleWorkspaceMetadataChange(payload string) {
 	} else {
 		for _, itemKey := range wmc.ChangedItems {
 			if err := bundleStoreCache.InvalidateCacheItem(wmc.AppName, wmc.WorkspaceID, wmc.CollectionName, itemKey); err != nil {
-				slog.Error("Unable to purge workspace metadata cache key: " + err.Error())
+				slog.Error("unable to purge workspace metadata cache key: " + err.Error())
 			}
 		}
 	}

--- a/apps/platform/pkg/bundlestore/workspacebundlestore/workspacebundlestore.go
+++ b/apps/platform/pkg/bundlestore/workspacebundlestore/workspacebundlestore.go
@@ -39,7 +39,7 @@ func getFilteredFields(fieldNames []string) []wire.LoadRequestField {
 
 func (b *WorkspaceBundleStoreConnection) processItems(items []meta.BundleableItem, includeUserFields bool, looper func(meta.BundleableItem, []wire.ReferenceLocator, string) error) error {
 	if b.Workspace == nil {
-		return errors.New("Workspace bundle store, needs a workspace in context")
+		return errors.New("workspace bundle store, needs a workspace in context")
 	}
 	collectionLocatorMap := map[string]wire.LocatorMap{}
 	namespace := b.Workspace.GetAppFullName()
@@ -117,7 +117,7 @@ type WorkspaceBundleStore struct{}
 
 func (b *WorkspaceBundleStore) GetConnection(options bundlestore.ConnectionOptions) (bundlestore.BundleStoreConnection, error) {
 	if options.Workspace == nil {
-		return nil, errors.New("Workspace bundle store, needs a workspace in context")
+		return nil, errors.New("workspace bundle store, needs a workspace in context")
 	}
 	return &WorkspaceBundleStoreConnection{
 		ConnectionOptions: options,
@@ -205,13 +205,13 @@ func (b *WorkspaceBundleStoreConnection) GetManyItems(items []meta.BundleableIte
 	}
 	return b.processItems(items, options.IncludeUserFields, func(item meta.BundleableItem, locators []wire.ReferenceLocator, id string) error {
 		if locators == nil {
-			return errors.New("Found an item we weren't expecting")
+			return errors.New("found an item we weren't expecting")
 		}
 		if item == nil {
 			if options.AllowMissingItems {
 				return nil
 			}
-			return fmt.Errorf("Could not find workspace item: %s", id)
+			return fmt.Errorf("could not find workspace item: %s", id)
 		}
 		for _, locator := range locators {
 			err := meta.Copy(locator.Item, item)
@@ -287,7 +287,7 @@ func (b *WorkspaceBundleStoreConnection) GetItemRecordID(item meta.AttachableIte
 	}
 	recordIDString, ok := recordID.(string)
 	if !ok {
-		return "", errors.New("Invalid Record ID for attachment")
+		return "", errors.New("invalid record id for attachment")
 	}
 	return recordIDString, nil
 }
@@ -307,7 +307,7 @@ func (b *WorkspaceBundleStoreConnection) GetItemAttachment(w io.Writer, item met
 func (b *WorkspaceBundleStoreConnection) GetAttachmentData(item meta.AttachableItem) (*meta.UserFileMetadataCollection, error) {
 	recordIDString, err := b.GetItemRecordID(item)
 	if err != nil {
-		return nil, errors.New("Invalid Record ID for attachment: " + err.Error())
+		return nil, fmt.Errorf("invalid record id for attachment: %w", err)
 	}
 	userFiles := &meta.UserFileMetadataCollection{}
 	err = datasource.PlatformLoad(
@@ -413,7 +413,7 @@ func (b *WorkspaceBundleStoreConnection) GetBundleDef() (*meta.BundleDef, error)
 	}
 	for _, bd := range bdc {
 		if bd.Bundle == nil {
-			return nil, errors.New("Error getting bundle dependency: " + bd.UniqueKey)
+			return nil, fmt.Errorf("error getting bundle dependency: %s", bd.UniqueKey)
 		}
 		key := bd.Bundle.UniqueKey
 		bundleName, _, _ := strings.Cut(key, ":")
@@ -435,22 +435,22 @@ func (b *WorkspaceBundleStoreConnection) GetBundleDef() (*meta.BundleDef, error)
 func (b *WorkspaceBundleStoreConnection) HasAllItems(items []meta.BundleableItem) error {
 	return b.processItems(items, false, func(item meta.BundleableItem, locators []wire.ReferenceLocator, id string) error {
 		if locators == nil {
-			return errors.New("Found an item we weren't expecting")
+			return errors.New("found an item we weren't expecting")
 		}
 		if item == nil {
-			return fmt.Errorf("Could not find workspace item: %s", id)
+			return fmt.Errorf("could not find workspace item: %s", id)
 		}
 		return nil
 	})
 }
 
 func (b *WorkspaceBundleStoreConnection) SetBundleZip(reader io.ReaderAt, size int64) error {
-	return errors.New("tried to upload bundle zip in Workspace Bundle Store")
+	return errors.New("tried to upload bundle zip in workspace bundle store")
 }
 
 func (b *WorkspaceBundleStoreConnection) GetBundleZip(writer io.Writer, zipoptions *bundlestore.BundleZipOptions) error {
 	if b.Workspace == nil {
-		return errors.New("no Workspace provided for retrieve")
+		return errors.New("no workspace provided for retrieve")
 	}
 	// Create a new zip archive.
 	zipwriter := zip.NewWriter(writer)

--- a/apps/platform/pkg/cache/memory.go
+++ b/apps/platform/pkg/cache/memory.go
@@ -1,7 +1,7 @@
 package cache
 
 import (
-	"errors"
+	"fmt"
 	"time"
 
 	// Using go-cache package to get thread-safety, sharding, expiration, and cleanup,
@@ -26,7 +26,7 @@ func (mc *MemoryCache[T]) Get(key string) (T, error) {
 	if hasVal {
 		return val.(T), nil
 	}
-	return result, errors.New("key " + key + " not found")
+	return result, fmt.Errorf("key %s not found", key)
 }
 
 func (mc *MemoryCache[T]) Set(key string, value T) error {

--- a/apps/platform/pkg/cache/platform.go
+++ b/apps/platform/pkg/cache/platform.go
@@ -16,9 +16,10 @@ func NewPlatformCache[T any](namespace string, expiration time.Duration) Cache[T
 		expiration = getDefaultExpiration()
 	}
 	cacheType := os.Getenv("UESIO_PLATFORM_CACHE")
-	if cacheType == "redis" {
+	switch cacheType {
+	case "redis":
 		return NewRedisCache[T](namespace).WithExpiration(expiration)
-	} else if cacheType == "" || cacheType == "memory" {
+	case "", "memory":
 		return NewMemoryCache[T](expiration, expiration*2)
 	}
 	// TODO: The panic here is not ideal but we currently call NewPlatformCache from

--- a/apps/platform/pkg/cache/redis.go
+++ b/apps/platform/pkg/cache/redis.go
@@ -175,7 +175,7 @@ func deleteKeys(keys []string) error {
 	defer conn.Close()
 	_, err := conn.Do("DEL", redis.Args{}.AddFlat(keys)...)
 	if err != nil {
-		return fmt.Errorf("Error deleting cache keys from bot: %w", err)
+		return fmt.Errorf("error deleting cache keys from bot: %w", err)
 	}
 	return nil
 }
@@ -185,7 +185,7 @@ func flushAll() error {
 	defer conn.Close()
 	_, err := conn.Do("FLUSHALL")
 	if err != nil {
-		return fmt.Errorf("Error flushing cache from bot: %w", err)
+		return fmt.Errorf("error flushing cache from bot: %w", err)
 	}
 	return nil
 }

--- a/apps/platform/pkg/cmd/migrate.go
+++ b/apps/platform/pkg/cmd/migrate.go
@@ -62,7 +62,7 @@ func migrate(cmd *cobra.Command, args []string) error {
 		return conn.Migrate(opts)
 	})
 	if err != nil {
-		return fmt.Errorf("Migrations failed: %w", err)
+		return fmt.Errorf("migrations failed: %w", err)
 	}
 
 	slog.Info("Successfully ran migrations")

--- a/apps/platform/pkg/cmd/seed.go
+++ b/apps/platform/pkg/cmd/seed.go
@@ -163,7 +163,7 @@ func seed(cmd *cobra.Command, args []string) error {
 			slog.Info("Ignoring seed failures.")
 			return nil
 		}
-		return fmt.Errorf("Seeds failed: %w", err)
+		return fmt.Errorf("seeds failed: %w", err)
 	}
 
 	slog.Info("Successfully ran seeds")

--- a/apps/platform/pkg/cmd/serve.go
+++ b/apps/platform/pkg/cmd/serve.go
@@ -161,10 +161,10 @@ func serve(cmd *cobra.Command, args []string) error {
 
 	// OAuth routes
 	sr.HandleFunc("/oauth2/callback", oauth.Callback).Methods(http.MethodGet)
-	wr.HandleFunc(fmt.Sprintf("/oauth2/authorize/%s", itemParam), oauth.GetRedirectMetadata).Methods(http.MethodGet)
-	sr.HandleFunc(fmt.Sprintf("/oauth2/authorize/%s", itemParam), oauth.GetRedirectMetadata).Methods(http.MethodGet)
-	sa.HandleFunc(fmt.Sprintf("/oauth2/authorize/%s", itemParam), oauth.GetRedirectMetadata).Methods(http.MethodGet)
-	vr.HandleFunc(fmt.Sprintf("/oauth2/authorize/%s", itemParam), oauth.GetRedirectMetadata).Methods(http.MethodGet)
+	wr.HandleFunc("/oauth2/authorize/"+itemParam, oauth.GetRedirectMetadata).Methods(http.MethodGet)
+	sr.HandleFunc("/oauth2/authorize/"+itemParam, oauth.GetRedirectMetadata).Methods(http.MethodGet)
+	sa.HandleFunc("/oauth2/authorize/"+itemParam, oauth.GetRedirectMetadata).Methods(http.MethodGet)
+	vr.HandleFunc("/oauth2/authorize/"+itemParam, oauth.GetRedirectMetadata).Methods(http.MethodGet)
 	if env.InDevMode() {
 		// Add a mock oauth2 token server for testing. Someday this could be a real server
 		// but for now we just need it for integration tests
@@ -204,12 +204,12 @@ func serve(cmd *cobra.Command, args []string) error {
 	sa.HandleFunc(wireSavePath, controller.Save).Methods(http.MethodPost)
 
 	// Bot routes for site and workspace context
-	callBotPath := fmt.Sprintf("/bots/call/%s", itemParam)
+	callBotPath := "/bots/call/" + itemParam
 	sr.HandleFunc(callBotPath, controller.CallListenerBot).Methods(http.MethodPost)
 	wr.HandleFunc(callBotPath, controller.CallListenerBot).Methods(http.MethodPost)
 	sa.HandleFunc(callBotPath, controller.CallListenerBot).Methods(http.MethodPost)
 
-	botParamPath := fmt.Sprintf("/bots/params/{type}/%s", itemParam)
+	botParamPath := "/bots/params/{type}/" + itemParam
 	sr.HandleFunc(botParamPath, controller.GetBotParams).Methods(http.MethodGet)
 	wr.HandleFunc(botParamPath, controller.GetBotParams).Methods(http.MethodGet)
 
@@ -217,27 +217,27 @@ func serve(cmd *cobra.Command, args []string) error {
 	wr.HandleFunc("/retrieve/types", controller.RetrieveAppTypes).Methods(http.MethodGet)
 
 	// Run Integration Action routes for site and workspace context
-	runIntegrationActionPath := fmt.Sprintf("/integrationactions/run/%s", itemParam)
-	describeActionsPath := fmt.Sprintf("/integrationactions/describe/%s", itemParam)
+	runIntegrationActionPath := "/integrationactions/run/" + itemParam
+	describeActionsPath := "/integrationactions/describe/" + itemParam
 	sr.HandleFunc(runIntegrationActionPath, controller.RunIntegrationAction).Methods(http.MethodPost)
 	wr.HandleFunc(runIntegrationActionPath, controller.RunIntegrationAction).Methods(http.MethodPost)
 	wr.HandleFunc(describeActionsPath, controller.DescribeIntegrationAction).Methods(http.MethodGet)
 
-	viewParamPath := fmt.Sprintf("/views/params/%s", itemParam)
+	viewParamPath := "/views/params/" + itemParam
 	wr.HandleFunc(viewParamPath, controller.GetViewParams).Methods(http.MethodGet)
-	routeParamPath := fmt.Sprintf("/routes/params/%s", itemParam)
+	routeParamPath := "/routes/params/" + itemParam
 	wr.HandleFunc(routeParamPath, controller.GetRouteParams).Methods(http.MethodGet)
 
 	//
 	// File (actual metadata, not userfiles) routes for site and workspace context
 
 	// Versioned file serving routes
-	versionedFilesPath := fmt.Sprintf("/files/%s", versionedItemParam)
+	versionedFilesPath := "/files/" + versionedItemParam
 	sr.HandleFunc(versionedFilesPath, file.ServeFile).Methods(http.MethodGet)
 	wr.HandleFunc(versionedFilesPath, file.ServeFile).Methods(http.MethodGet)
 
 	// Un-versioned file serving routes - for backwards compatibility, and for local development
-	filesPath := fmt.Sprintf("/files/%s", itemParam)
+	filesPath := "/files/" + itemParam
 	sr.HandleFunc(filesPath, file.ServeFile).Methods(http.MethodGet)
 	wr.HandleFunc(filesPath, file.ServeFile).Methods(http.MethodGet)
 
@@ -253,12 +253,12 @@ func serve(cmd *cobra.Command, args []string) error {
 	serveRoutePath := fmt.Sprintf("/app/%s/{route:.*}", nsParam)
 	sr.HandleFunc(serveRoutePath, controller.ServeRoute)
 	wr.HandleFunc(serveRoutePath, controller.ServeRoute)
-	serveRouteByKey := fmt.Sprintf("/r/%s", itemParam)
+	serveRouteByKey := "/r/" + itemParam
 	sr.HandleFunc(serveRouteByKey, controller.ServeRouteByKey)
 	wr.HandleFunc(serveRouteByKey, controller.ServeRouteByKey)
 
 	// Route navigation apis for site and workspace context for collection based route assignments
-	collectionRouteAssignmentPath := fmt.Sprintf("/routes/assignment/{viewtype}/collection/%s", itemParam)
+	collectionRouteAssignmentPath := "/routes/assignment/{viewtype}/collection/" + itemParam
 	sr.HandleFunc(collectionRouteAssignmentPath, controller.RouteAssignment).Methods(http.MethodGet)
 	wr.HandleFunc(collectionRouteAssignmentPath, controller.RouteAssignment).Methods(http.MethodGet)
 	sr.HandleFunc(collectionRouteAssignmentPath+"/{id}", controller.RouteAssignment).Methods(http.MethodGet)
@@ -276,7 +276,7 @@ func serve(cmd *cobra.Command, args []string) error {
 	sr.HandleFunc(pathRoutePath, controller.RouteByPath).Methods(http.MethodGet)
 	wr.HandleFunc(pathRoutePath, controller.RouteByPath).Methods(http.MethodGet)
 
-	routeByKey := fmt.Sprintf("/routes/key/%s", itemParam)
+	routeByKey := "/routes/key/" + itemParam
 	sr.HandleFunc(routeByKey, controller.RouteByKey).Methods(http.MethodGet)
 	wr.HandleFunc(routeByKey, controller.RouteByKey).Methods(http.MethodGet)
 
@@ -284,7 +284,7 @@ func serve(cmd *cobra.Command, args []string) error {
 	componentPackFileSuffix := "/{filename:[a-zA-Z0-9\\-_]+\\.(?:json|js|xml|txt|css){1}(?:\\.map)?}"
 
 	// Versioned component pack file routes
-	versionedComponentPackPath := fmt.Sprintf("/componentpacks/%s", versionedItemParam)
+	versionedComponentPackPath := "/componentpacks/" + versionedItemParam
 
 	versionedComponentPackFinal := versionedComponentPackPath + componentPackFileSuffix
 
@@ -293,7 +293,7 @@ func serve(cmd *cobra.Command, args []string) error {
 
 	fontFileSuffix := "/{filename:.*}"
 
-	fontPath := fmt.Sprintf("/fonts/%s", versionedItemParam)
+	fontPath := "/fonts/" + versionedItemParam
 
 	fontFinal := fontPath + fontFileSuffix
 
@@ -314,7 +314,7 @@ func serve(cmd *cobra.Command, args []string) error {
 	vr.HandleFunc(metadataRetrievePath, controller.Retrieve).Methods(http.MethodGet, http.MethodPost)
 
 	// Get Collection Metadata (We may be able to get rid of this someday...)
-	collectionMetadataPath := fmt.Sprintf("/collections/meta/%s", collectionParam)
+	collectionMetadataPath := "/collections/meta/" + collectionParam
 	wr.HandleFunc(collectionMetadataPath, controller.GetCollectionMetadata).Methods(http.MethodGet)
 	sa.HandleFunc(collectionMetadataPath, controller.GetCollectionMetadata).Methods(http.MethodGet)
 
@@ -334,7 +334,7 @@ func serve(cmd *cobra.Command, args []string) error {
 	sa.HandleFunc(itemListPath, controller.MetadataList).Methods(http.MethodGet)
 	vr.HandleFunc(itemListPath, controller.MetadataList).Methods(http.MethodGet)
 
-	itemListPathWithGrouping := fmt.Sprintf("/metadata/types/{type}/list/%s", groupingParam)
+	itemListPathWithGrouping := "/metadata/types/{type}/list/" + groupingParam
 	sr.HandleFunc(itemListPathWithGrouping, controller.MetadataList).Methods(http.MethodGet)
 	wr.HandleFunc(itemListPathWithGrouping, controller.MetadataList).Methods(http.MethodGet)
 	sa.HandleFunc(itemListPathWithGrouping, controller.MetadataList).Methods(http.MethodGet)
@@ -361,7 +361,7 @@ func serve(cmd *cobra.Command, args []string) error {
 	sa.HandleFunc(bulkBatchPath, controller.BulkBatch).Methods(http.MethodPost)
 
 	// View Preview Routes
-	viewPath := fmt.Sprintf("/views/%s", itemParam)
+	viewPath := "/views/" + itemParam
 	wr.HandleFunc(viewPath+"/preview", controller.ViewPreview(false)).Methods(http.MethodGet)
 	wr.HandleFunc(viewPath+"/edit", controller.ViewPreview(true)).Methods(http.MethodGet)
 

--- a/apps/platform/pkg/cmd/serve.go
+++ b/apps/platform/pkg/cmd/serve.go
@@ -82,7 +82,7 @@ func serve(cmd *cobra.Command, args []string) error {
 
 	cwd, err := os.Getwd()
 	if err != nil {
-		return fmt.Errorf("Failed to obtain working directory: %w", err)
+		return fmt.Errorf("failed to obtain working directory: %w", err)
 	}
 
 	// If we have UESIO_BUILD_VERSION, append that to the prefixes to enable us to have versioned assets
@@ -465,7 +465,7 @@ func serve(cmd *cobra.Command, args []string) error {
 			)(r))
 		*/
 		if serveErr != nil && serveErr.Error() != "http: Server closed" {
-			slog.Error("Failed to start server: " + serveErr.Error())
+			slog.Error("failed to start server: " + serveErr.Error())
 			// this will terminate the server without waiting for graceful shutdown
 			server.StartupError()
 		}

--- a/apps/platform/pkg/configstore/configstore.go
+++ b/apps/platform/pkg/configstore/configstore.go
@@ -1,7 +1,7 @@
 package configstore
 
 import (
-	"errors"
+	"fmt"
 
 	"github.com/thecloudmasters/uesio/pkg/bundle"
 	"github.com/thecloudmasters/uesio/pkg/meta"
@@ -93,7 +93,7 @@ func GetConfigValues(session *sess.Session, options *ConfigLoadOptions) (*meta.C
 func GetConfigStore(configStoreType string) (ConfigStore, error) {
 	configStore, ok := configStoreMap[configStoreType]
 	if !ok {
-		return nil, errors.New("Invalid config store type: " + configStoreType)
+		return nil, fmt.Errorf("invalid config store type: %s", configStoreType)
 	}
 	return configStore, nil
 }

--- a/apps/platform/pkg/configstore/environment/environment.go
+++ b/apps/platform/pkg/configstore/environment/environment.go
@@ -2,6 +2,7 @@ package environment
 
 import (
 	"errors"
+	"fmt"
 	"log"
 	"log/slog"
 	"os"
@@ -17,7 +18,7 @@ type ConfigStore struct {
 func GetRequiredEnv(key string) string {
 	value, ok := os.LookupEnv(key)
 	if !ok || value == "" {
-		log.Fatal(errors.New("Missing environment variable: " + key))
+		log.Fatal(fmt.Errorf("missing environment variable: %s", key))
 	}
 	return value
 }

--- a/apps/platform/pkg/controller/buildermetadata.go
+++ b/apps/platform/pkg/controller/buildermetadata.go
@@ -27,7 +27,7 @@ func BuilderMetadata(w http.ResponseWriter, r *http.Request) {
 	deps.Collection = nil
 
 	if err := routing.GetBuilderDependencies(namespace, name, deps, session); err != nil {
-		ctlutil.HandleError(w, exceptions.NewBadRequestException("Failed Getting Builder Metadata", err))
+		ctlutil.HandleError(w, exceptions.NewBadRequestException("failed getting builder metadata", err))
 		return
 	}
 

--- a/apps/platform/pkg/controller/bulkjob.go
+++ b/apps/platform/pkg/controller/bulkjob.go
@@ -27,7 +27,7 @@ func BulkJob(w http.ResponseWriter, r *http.Request) {
 	spec := meta.JobSpec(specRequest)
 	jobID, err := bulk.NewJob(&spec, session)
 	if err != nil {
-		ctlutil.HandleError(w, exceptions.NewBadRequestException("Failed Creating New Job", err))
+		ctlutil.HandleError(w, exceptions.NewBadRequestException("failed creating new job", err))
 		return
 	}
 

--- a/apps/platform/pkg/controller/bundleslist.go
+++ b/apps/platform/pkg/controller/bundleslist.go
@@ -70,7 +70,7 @@ func BundlesList(w http.ResponseWriter, r *http.Request) {
 		},
 	}, adminSession, nil)
 	if err != nil {
-		ctlutil.HandleError(w, exceptions.NewBadRequestException("Failed Getting Bundle List", err))
+		ctlutil.HandleError(w, exceptions.NewBadRequestException("failed getting bundle list", err))
 		return
 	}
 
@@ -100,7 +100,7 @@ func BundlesList(w http.ResponseWriter, r *http.Request) {
 		})
 		return nil
 	}); err != nil {
-		ctlutil.HandleError(w, exceptions.NewBadRequestException("Failed Getting Bundle List", err))
+		ctlutil.HandleError(w, exceptions.NewBadRequestException("failed getting bundle list", err))
 		return
 	}
 	sort.Slice(responses, func(i, j int) bool {

--- a/apps/platform/pkg/controller/bundlesretrieve.go
+++ b/apps/platform/pkg/controller/bundlesretrieve.go
@@ -19,13 +19,13 @@ func BundlesRetrieve(w http.ResponseWriter, r *http.Request) {
 
 	appID, ok := vars["app"]
 	if !ok {
-		ctlutil.HandleError(w, exceptions.NewBadRequestException("Failed Getting Bundle missing required parameter app", nil))
+		ctlutil.HandleError(w, exceptions.NewBadRequestException("failed getting bundle missing required parameter app", nil))
 		return
 	}
 
 	version, ok := vars["version"]
 	if !ok {
-		ctlutil.HandleError(w, exceptions.NewBadRequestException("Failed Getting Bundle missing required parameter version", nil))
+		ctlutil.HandleError(w, exceptions.NewBadRequestException("failed getting bundle missing required parameter version", nil))
 		return
 	}
 
@@ -37,7 +37,7 @@ func BundlesRetrieve(w http.ResponseWriter, r *http.Request) {
 		Context:    session.Context(),
 	})
 	if err != nil {
-		ctlutil.HandleError(w, exceptions.NewBadRequestException("Failed Getting Bundle", err))
+		ctlutil.HandleError(w, exceptions.NewBadRequestException("failed getting bundle", err))
 		return
 	}
 
@@ -49,7 +49,7 @@ func BundlesRetrieve(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		// Note - We are streaming result so Http StatusCode will have been set to 200 after
 		// the first Write so we implement custom approach to detecting failure on client
-		ctlutil.HandleTrailingError(w, exceptions.NewBadRequestException("Failed Getting Bundle", err))
+		ctlutil.HandleTrailingError(w, exceptions.NewBadRequestException("failed getting bundle", err))
 		return
 	}
 }

--- a/apps/platform/pkg/controller/bundleversionslist.go
+++ b/apps/platform/pkg/controller/bundleversionslist.go
@@ -1,7 +1,6 @@
 package controller
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/gorilla/mux"

--- a/apps/platform/pkg/controller/bundleversionslist.go
+++ b/apps/platform/pkg/controller/bundleversionslist.go
@@ -101,7 +101,7 @@ func BundleVersionsList(w http.ResponseWriter, r *http.Request) {
 		}
 		responses = append(responses, BundleVersionsListResponse{
 			Description: goutils.StringValue(description),
-			Version:     fmt.Sprintf("v%s", goutils.StringValue(version)),
+			Version:     "v" + goutils.StringValue(version),
 		})
 		return nil
 	}); err != nil {

--- a/apps/platform/pkg/controller/bundleversionslist.go
+++ b/apps/platform/pkg/controller/bundleversionslist.go
@@ -85,7 +85,7 @@ func BundleVersionsList(w http.ResponseWriter, r *http.Request) {
 		},
 		adminSession,
 	); err != nil {
-		ctlutil.HandleError(w, exceptions.NewBadRequestException("Failed Getting Bundle Versions List", err))
+		ctlutil.HandleError(w, exceptions.NewBadRequestException("failed getting bundle versions list", err))
 		return
 	}
 
@@ -105,7 +105,7 @@ func BundleVersionsList(w http.ResponseWriter, r *http.Request) {
 		})
 		return nil
 	}); err != nil {
-		ctlutil.HandleError(w, exceptions.NewBadRequestException("Failed Getting Bundle Versions List", err))
+		ctlutil.HandleError(w, exceptions.NewBadRequestException("failed getting bundle versions list", err))
 		return
 	}
 	filejson.RespondJSON(w, r, responses)

--- a/apps/platform/pkg/controller/collectiondeleteapi.go
+++ b/apps/platform/pkg/controller/collectiondeleteapi.go
@@ -116,7 +116,7 @@ func DeleteRecordApi(w http.ResponseWriter, r *http.Request) {
 	err := datasource.LoadWithError(op, session, nil)
 
 	if err != nil {
-		ctlutil.HandleError(w, exceptions.NewBadRequestException("Error querying collection records to delete", err))
+		ctlutil.HandleError(w, exceptions.NewBadRequestException("error querying collection records to delete", err))
 		return
 	}
 
@@ -129,7 +129,7 @@ func DeleteRecordApi(w http.ResponseWriter, r *http.Request) {
 			Params:     params,
 		}}
 		if err = datasource.HandleSaveRequestErrors(saveRequests, datasource.Save(saveRequests, session)); err != nil {
-			ctlutil.HandleError(w, exceptions.NewBadRequestException("Delete failed", err))
+			ctlutil.HandleError(w, exceptions.NewBadRequestException("delete failed", err))
 			return
 		}
 		w.WriteHeader(http.StatusNoContent)

--- a/apps/platform/pkg/controller/deleteauthcredentials.go
+++ b/apps/platform/pkg/controller/deleteauthcredentials.go
@@ -1,7 +1,6 @@
 package controller
 
 import (
-	"errors"
 	"fmt"
 	"net/http"
 
@@ -26,19 +25,19 @@ func DeleteAuthCredentials(w http.ResponseWriter, r *http.Request) {
 
 	conn, err := datasource.GetPlatformConnection(session, nil)
 	if err != nil {
-		ctlutil.HandleError(w, errors.New("unable to obtain platform connection: "+err.Error()))
+		ctlutil.HandleError(w, fmt.Errorf("unable to obtain platform connection: %w", err))
 		return
 	}
 	coreSession, err := datasource.EnterVersionContext("uesio/core", session, conn)
 	if err != nil {
-		ctlutil.HandleError(w, errors.New("unable to obtain core session: "+err.Error()))
+		ctlutil.HandleError(w, fmt.Errorf("unable to obtain core session: %w", err))
 		return
 	}
 
 	credential, err := oauth2.GetIntegrationCredential(user.ID, integrationName, coreSession, conn)
 
 	if err != nil {
-		ctlutil.HandleError(w, errors.New("unable to retrieve integration credential for user: "+err.Error()))
+		ctlutil.HandleError(w, fmt.Errorf("unable to retrieve integration credential for user: %w", err))
 		return
 	}
 
@@ -49,7 +48,7 @@ func DeleteAuthCredentials(w http.ResponseWriter, r *http.Request) {
 
 	// If we have a credential, delete it, otherwise, there's nothing to do
 	if err = oauth2.DeleteIntegrationCredential(credential, coreSession, conn); err != nil {
-		ctlutil.HandleError(w, errors.New("unable to delete integration credential: "+err.Error()))
+		ctlutil.HandleError(w, fmt.Errorf("unable to delete integration credential: %w", err))
 		return
 	}
 

--- a/apps/platform/pkg/controller/file/userfile.go
+++ b/apps/platform/pkg/controller/file/userfile.go
@@ -43,13 +43,13 @@ func processUploadRequest(r *http.Request) (*meta.UserFileMetadata, error) {
 		}
 		if part.FormName() == "file" {
 			if op.Path == "" {
-				return nil, errors.New("No name specified")
+				return nil, errors.New("no name specified")
 			}
 			if op.CollectionID == "" {
-				return nil, errors.New("No collectionid specified")
+				return nil, errors.New("no collectionid specified")
 			}
 			if op.RecordID == "" {
-				return nil, errors.New("No recordid specified")
+				return nil, errors.New("no recordid specified")
 			}
 			op.Data = part
 			results, err := filesource.Upload([]*filesource.FileUploadOp{op}, nil, session, op.Params)
@@ -57,7 +57,7 @@ func processUploadRequest(r *http.Request) (*meta.UserFileMetadata, error) {
 				return nil, err
 			}
 			if len(results) != 1 {
-				return nil, errors.New("Upload Failed: Invalid Response")
+				return nil, errors.New("upload failed: invalid response")
 			}
 			result = results[0]
 		}

--- a/apps/platform/pkg/controller/file/vendor.go
+++ b/apps/platform/pkg/controller/file/vendor.go
@@ -42,7 +42,7 @@ func init() {
 	vendorScriptsManifestFile, err := os.ReadFile(manifestFilePath)
 
 	if err != nil {
-		fmt.Println("Unable to read vendor scripts manifest file")
+		fmt.Println("unable to read vendor scripts manifest file")
 		panic(err)
 	}
 
@@ -51,7 +51,7 @@ func init() {
 	err = json.Unmarshal(vendorScriptsManifestFile, &vendorManifest)
 
 	if err != nil {
-		fmt.Println("Unable to parse vendor scripts manifest")
+		fmt.Println("unable to parse vendor scripts manifest")
 		panic(err)
 	}
 

--- a/apps/platform/pkg/controller/integrationaction.go
+++ b/apps/platform/pkg/controller/integrationaction.go
@@ -47,7 +47,7 @@ func RunIntegrationAction(w http.ResponseWriter, r *http.Request) {
 	session := middleware.GetSession(r)
 	connection, err := datasource.GetPlatformConnection(session, nil)
 	if err != nil {
-		ctlutil.HandleError(w, fmt.Errorf("Unable to obtain platform connection: %w", err))
+		ctlutil.HandleError(w, fmt.Errorf("unable to obtain platform connection: %w", err))
 		return
 	}
 
@@ -151,7 +151,7 @@ func DescribeIntegrationAction(w http.ResponseWriter, r *http.Request) {
 	session := middleware.GetSession(r)
 	connection, err := datasource.GetPlatformConnection(session, nil)
 	if err != nil {
-		ctlutil.HandleError(w, errors.New("Unable to obtain platform connection: "+err.Error()))
+		ctlutil.HandleError(w, fmt.Errorf("unable to obtain platform connection: %w", err))
 		return
 	}
 

--- a/apps/platform/pkg/controller/logout.go
+++ b/apps/platform/pkg/controller/logout.go
@@ -33,7 +33,7 @@ func Logout(w http.ResponseWriter, r *http.Request) {
 	}
 	redirectNamespace, redirectRoute, err := meta.ParseKey(loginRoute)
 	if err != nil {
-		ctlutil.HandleError(w, exceptions.NewBadRequestException(fmt.Sprintf("invalid login route: %s", loginRoute), nil))
+		ctlutil.HandleError(w, exceptions.NewBadRequestException("invalid login route: "+loginRoute, nil))
 		return
 	}
 

--- a/apps/platform/pkg/controller/logout.go
+++ b/apps/platform/pkg/controller/logout.go
@@ -1,7 +1,6 @@
 package controller
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/thecloudmasters/uesio/pkg/controller/ctlutil"

--- a/apps/platform/pkg/controller/mergedata.go
+++ b/apps/platform/pkg/controller/mergedata.go
@@ -1,7 +1,6 @@
 package controller
 
 import (
-	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -283,7 +282,7 @@ func ExecuteIndexTemplate(w http.ResponseWriter, route *meta.Route, preloadmeta 
 
 	routingMergeData, err := GetRoutingMergeData(route, preloadmeta, session)
 	if err != nil {
-		ctlutil.HandleError(w, errors.New("Error getting route merge data: "+err.Error()))
+		ctlutil.HandleError(w, fmt.Errorf("error getting route merge data: %w", err))
 		return
 	}
 
@@ -307,7 +306,7 @@ func ExecuteIndexTemplate(w http.ResponseWriter, route *meta.Route, preloadmeta 
 	// }
 
 	if err = indexTemplate.Execute(w, mergeData); err != nil {
-		ctlutil.HandleError(w, errors.New("Error merging template: "+err.Error()))
+		ctlutil.HandleError(w, fmt.Errorf("error merging template: %w", err))
 		return
 	}
 }

--- a/apps/platform/pkg/controller/mergedata.go
+++ b/apps/platform/pkg/controller/mergedata.go
@@ -113,7 +113,7 @@ func getSiteBundleVersion(namespace string, modstamp int64, site *preload.SiteMe
 		// NON-system bundles
 		if namespace == site.App {
 			// If requested namespace is the app's name, use the site version
-			siteBundleVersion = fmt.Sprintf("/%s", site.Version)
+			siteBundleVersion = "/" + site.Version
 		} else if site.Dependencies != nil {
 			// For all other deps, use the site's declared bundle dependency version,
 			// which SHOULD be present (otherwise how are they using it...)
@@ -130,7 +130,7 @@ func getSiteBundleVersion(namespace string, modstamp int64, site *preload.SiteMe
 			siteBundleVersion = fmt.Sprintf("/%d", modstamp)
 		} else if site.Version != "" {
 			// Final fallback --- use site version
-			siteBundleVersion = fmt.Sprintf("/%s", site.Version)
+			siteBundleVersion = "/" + site.Version
 		}
 	}
 

--- a/apps/platform/pkg/controller/oauth/authorize_metadata.go
+++ b/apps/platform/pkg/controller/oauth/authorize_metadata.go
@@ -27,8 +27,7 @@ func GetRedirectMetadata(w http.ResponseWriter, r *http.Request) {
 	}
 	conf, err := oauth.GetConfig(integrationConnection.GetCredentials(), fmt.Sprintf("%s://%s", tls.ServeAppDefaultScheme(), r.Host))
 	if err != nil {
-		ctlutil.HandleError(w, exceptions.NewForbiddenException(fmt.Sprintf(
-			"invalid integration configuration: %s", err.Error())))
+		ctlutil.HandleError(w, exceptions.NewForbiddenException("invalid integration configuration: "+err.Error()))
 		return
 	}
 	redirectMetadata, err := oauth.GetRedirectMetadata(conf, integrationName, session)

--- a/apps/platform/pkg/controller/oauth/callback.go
+++ b/apps/platform/pkg/controller/oauth/callback.go
@@ -46,12 +46,12 @@ func Callback(w http.ResponseWriter, r *http.Request) {
 
 	connection, err := datasource.GetPlatformConnection(s, nil)
 	if err != nil {
-		ctlutil.HandleError(w, errors.New("failed to obtain platform connection: "+err.Error()))
+		ctlutil.HandleError(w, fmt.Errorf("failed to obtain platform connection: %w", err))
 		return
 	}
 	versionSession, err := datasource.EnterVersionContext("uesio/core", s, connection)
 	if err != nil {
-		ctlutil.HandleError(w, errors.New("failed to enter version context: "+err.Error()))
+		ctlutil.HandleError(w, fmt.Errorf("failed to enter version context: %w", err))
 		return
 	}
 	route, err := loadCallbackRoute(r, versionSession, connection)
@@ -78,7 +78,7 @@ func Callback(w http.ResponseWriter, r *http.Request) {
 	// Now that we have an access token (and maybe refresh token),
 	// store this into an Integration Credential record in the DB.
 	if err = oauth.UpsertIntegrationCredential(oauth.BuildIntegrationCredential(integrationName, userId, tok), versionSession, connection); err != nil {
-		controller.HandleErrorRoute(w, r, s, r.URL.Path, "", errors.New("failed to obtain access token from authorization code: "+err.Error()), false)
+		controller.HandleErrorRoute(w, r, s, r.URL.Path, "", fmt.Errorf("failed to obtain access token from authorization code: %w", err), false)
 		return
 	}
 

--- a/apps/platform/pkg/controller/requestparams.go
+++ b/apps/platform/pkg/controller/requestparams.go
@@ -20,7 +20,7 @@ func getParamsFromRequestBody(r *http.Request) (map[string]any, error) {
 	if strings.Contains(contentType, "application/x-www-form-urlencoded") {
 		// ParseForm must be called in order for r.Form to contain any parsed form data variables
 		if err := r.ParseForm(); err != nil {
-			return nil, exceptions.NewBadRequestException("Unable to parse form data", err)
+			return nil, exceptions.NewBadRequestException("unable to parse form data", err)
 		}
 		params = map[string]any{}
 		for param, values := range r.Form {
@@ -29,7 +29,7 @@ func getParamsFromRequestBody(r *http.Request) (map[string]any, error) {
 	} else {
 		err := json.NewDecoder(r.Body).Decode(&params)
 		if err != nil {
-			return nil, exceptions.NewBadRequestException("Invalid request format", err)
+			return nil, exceptions.NewBadRequestException("invalid request format", err)
 		}
 	}
 	return params, nil

--- a/apps/platform/pkg/controller/robots.go
+++ b/apps/platform/pkg/controller/robots.go
@@ -120,7 +120,7 @@ func writeAllowedRoutePaths(w io.Writer, publicRoutes map[string]bool, homeRoute
 
 func normalizePath(path string) string {
 	if !strings.HasPrefix(path, "/") {
-		return fmt.Sprintf("/%s", path)
+		return "/" + path
 	}
 	return path
 }

--- a/apps/platform/pkg/controller/route.go
+++ b/apps/platform/pkg/controller/route.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/gorilla/mux"

--- a/apps/platform/pkg/controller/route.go
+++ b/apps/platform/pkg/controller/route.go
@@ -136,7 +136,7 @@ func handleApiErrorRoute(w http.ResponseWriter, r *http.Request, path, namespace
 
 func handleApiNotFoundRoute(w http.ResponseWriter, r *http.Request, path, namespace string, session *sess.Session) {
 	if routingMergeData, err := getRouteAPIResult(
-		getNotFoundRoute(path, namespace, "You may need to log in again.", "true"),
+		getNotFoundRoute(path, namespace, "you may need to log in again.", "true"),
 		sess.GetAnonSessionFrom(session),
 	); err != nil {
 		ctlutil.HandleError(w, err)
@@ -216,7 +216,7 @@ type errorResponse struct {
 }
 
 func HandleErrorRoute(w http.ResponseWriter, r *http.Request, session *sess.Session, path string, namespace string, incomingErr error, redirect bool) {
-	slog.Debug("Error Getting Route: " + incomingErr.Error())
+	slog.Debug("error getting route: " + incomingErr.Error())
 
 	// If this is an invalid param exception
 
@@ -247,7 +247,7 @@ func HandleErrorRoute(w http.ResponseWriter, r *http.Request, session *sess.Sess
 		// Otherwise, Enter into a version context to display the error page
 		versionSession, err := datasource.EnterVersionContext("uesio/core", session, nil)
 		if err != nil {
-			ctlutil.HandleError(w, fmt.Errorf("Error Getting Version Session: %w", err))
+			ctlutil.HandleError(w, fmt.Errorf("error getting version session: %w", err))
 			return
 		}
 		errorSession = versionSession
@@ -255,7 +255,7 @@ func HandleErrorRoute(w http.ResponseWriter, r *http.Request, session *sess.Sess
 
 	depsCache, err := routing.GetMetadataDeps(route, errorSession)
 	if err != nil {
-		ctlutil.HandleError(w, fmt.Errorf("Error Getting Error Route Metadata: %w", err))
+		ctlutil.HandleError(w, fmt.Errorf("error getting error route metadata: %w", err))
 		return
 	}
 

--- a/apps/platform/pkg/controller/route.go
+++ b/apps/platform/pkg/controller/route.go
@@ -282,7 +282,7 @@ func HandleErrorRoute(w http.ResponseWriter, r *http.Request, session *sess.Sess
 func getErrorResponse(err error, statusCode int) *errorResponse {
 	resp := &errorResponse{
 		Code:   statusCode,
-		Status: strings.Replace(http.StatusText(statusCode), fmt.Sprintf("%d", statusCode), "", 1),
+		Status: strings.Replace(http.StatusText(statusCode), strconv.Itoa(statusCode), "", 1),
 		Error:  err.Error(),
 	}
 	var paramException *exceptions.InvalidParamException

--- a/apps/platform/pkg/controller/runusageworker.go
+++ b/apps/platform/pkg/controller/runusageworker.go
@@ -1,7 +1,6 @@
 package controller
 
 import (
-	"errors"
 	"fmt"
 	"net/http"
 
@@ -11,7 +10,7 @@ import (
 
 func RunUsageWorker(w http.ResponseWriter, r *http.Request) {
 	if err := usage_worker.UsageWorker(r.Context()); err != nil {
-		ctlutil.HandleError(w, errors.New("Usage Worker Failed: "+err.Error()))
+		ctlutil.HandleError(w, fmt.Errorf("usage worker failed: %w", err))
 		return
 	}
 	fmt.Fprintf(w, "Usage Worker Success")

--- a/apps/platform/pkg/controller/server.go
+++ b/apps/platform/pkg/controller/server.go
@@ -92,7 +92,7 @@ func (s *ServerWithShutdown) WaitShutdown() {
 	// Completely shutdown the server
 	err := s.Shutdown(ctx)
 	if err != nil {
-		slog.Error(fmt.Sprintf("Error terminating server: %s", err.Error()))
+		slog.Error(fmt.Sprintf("error terminating server: %s", err.Error()))
 	}
 	if !startupError {
 		slog.Info("Graceful shutdown is complete.")

--- a/apps/platform/pkg/controller/server.go
+++ b/apps/platform/pkg/controller/server.go
@@ -92,7 +92,7 @@ func (s *ServerWithShutdown) WaitShutdown() {
 	// Completely shutdown the server
 	err := s.Shutdown(ctx)
 	if err != nil {
-		slog.Error(fmt.Sprintf("error terminating server: %s", err.Error()))
+		slog.Error("error terminating server: " + err.Error())
 	}
 	if !startupError {
 		slog.Info("Graceful shutdown is complete.")

--- a/apps/platform/pkg/controller/viewmetadata.go
+++ b/apps/platform/pkg/controller/viewmetadata.go
@@ -27,7 +27,7 @@ func ViewMetadata(w http.ResponseWriter, r *http.Request) {
 	deps.Collection = nil
 
 	if err := routing.GetViewDependencies(namespace, name, deps, session); err != nil {
-		ctlutil.HandleError(w, exceptions.NewBadRequestException("Failed Getting Builder Metadata", err))
+		ctlutil.HandleError(w, exceptions.NewBadRequestException("failed getting builder metadata", err))
 		return
 	}
 

--- a/apps/platform/pkg/creds/aws.go
+++ b/apps/platform/pkg/creds/aws.go
@@ -46,7 +46,7 @@ func GetAWSConfig(ctx context.Context, dbcreds *wire.Credentials) (aws.Config, e
 
 	region, ok := (*dbcreds)["region"]
 	if !ok {
-		return aws.Config{}, errors.New("No region provided in credentials")
+		return aws.Config{}, errors.New("no region provided in credentials")
 	}
 
 	endpoint := (*dbcreds)["endpoint"]

--- a/apps/platform/pkg/datasource/cascade.go
+++ b/apps/platform/pkg/datasource/cascade.go
@@ -1,7 +1,6 @@
 package datasource
 
 import (
-	"errors"
 	"fmt"
 	"maps"
 	"slices"
@@ -111,7 +110,7 @@ func getCascadeDeletes(
 
 		err = connection.Load(idLoadOp, versionSession)
 		if err != nil {
-			return nil, errors.New("Cascade delete error: " + err.Error())
+			return nil, fmt.Errorf("cascade delete error: %w", err)
 		}
 
 		if len(idLoadCollection) == 0 {

--- a/apps/platform/pkg/datasource/cascade.go
+++ b/apps/platform/pkg/datasource/cascade.go
@@ -78,7 +78,7 @@ func getCascadeDeletes(
 
 		idLoadOp := &wire.LoadOp{
 			CollectionName: referencedCollection,
-			WireName:       fmt.Sprintf("CascadeDeleteIdLoad_%s", referencedCollection),
+			WireName:       "CascadeDeleteIdLoad_" + referencedCollection,
 			Fields:         []wire.LoadRequestField{{ID: commonfields.Id}},
 			Collection:     &idLoadCollection,
 			Conditions: []wire.LoadRequestCondition{

--- a/apps/platform/pkg/datasource/connection.go
+++ b/apps/platform/pkg/datasource/connection.go
@@ -1,7 +1,7 @@
 package datasource
 
 import (
-	"errors"
+	"fmt"
 
 	"github.com/thecloudmasters/uesio/pkg/adapt"
 	"github.com/thecloudmasters/uesio/pkg/meta"
@@ -38,7 +38,7 @@ func GetConnection(dataSourceKey string, session *sess.Session, connection wire.
 
 	mergedType, hasType := dataSourceTypesByName[dataSourceKey]
 	if !hasType {
-		return nil, errors.New("unknown datasource type: " + dataSourceKey)
+		return nil, fmt.Errorf("unknown datasource type: %s", dataSourceKey)
 	}
 
 	adapter, err := adapt.GetAdapter(mergedType)

--- a/apps/platform/pkg/datasource/fetchreferences.go
+++ b/apps/platform/pkg/datasource/fetchreferences.go
@@ -148,7 +148,7 @@ func FetchReferences(
 					})
 				}
 
-				return fmt.Errorf("There was a problem getting reference info on field: %s in collection: %s", field.GetFullName(), op.CollectionName)
+				return fmt.Errorf("there was a problem getting reference info on field: %s in collection: %s", field.GetFullName(), op.CollectionName)
 
 			})
 			if err != nil {

--- a/apps/platform/pkg/datasource/fieldvalidations/emailfield.go
+++ b/apps/platform/pkg/datasource/fieldvalidations/emailfield.go
@@ -22,7 +22,7 @@ func ValidateEmailField(field *wire.FieldMetadata) ValidationFunc {
 		val, err := change.FieldChanges.GetField(field.GetFullName())
 		if err == nil && val != "" {
 			if !isEmailValid(fmt.Sprintf("%v", val)) {
-				return exceptions.NewSaveException(change.RecordKey, field.GetFullName(), fmt.Sprintf("%s is not a valid email address", field.Label), nil)
+				return exceptions.NewSaveException(change.RecordKey, field.GetFullName(), field.Label+" is not a valid email address", nil)
 			}
 		}
 		return nil

--- a/apps/platform/pkg/datasource/fieldvalidations/metadataname.go
+++ b/apps/platform/pkg/datasource/fieldvalidations/metadataname.go
@@ -12,7 +12,7 @@ func validateMetadataName(field *wire.FieldMetadata) ValidationFunc {
 	return func(change *wire.ChangeItem) *exceptions.SaveException {
 		val, err := change.FieldChanges.GetField(field.GetFullName())
 		if err == nil && !meta.IsValidMetadataName(fmt.Sprintf("%v", val)) {
-			return exceptions.NewSaveException(change.RecordKey, field.GetFullName(), fmt.Sprintf("Field: %s failed metadata validation, can only contain lowercase characters a-z, the underscore character and the numerals 0-9", field.Label), nil)
+			return exceptions.NewSaveException(change.RecordKey, field.GetFullName(), fmt.Sprintf("field: %s failed metadata validation, can only contain lowercase characters a-z, the underscore character and the numerals 0-9", field.Label), nil)
 		}
 		return nil
 	}

--- a/apps/platform/pkg/datasource/fieldvalidations/numberfield.go
+++ b/apps/platform/pkg/datasource/fieldvalidations/numberfield.go
@@ -18,7 +18,7 @@ func ValidateNumberField(field *wire.FieldMetadata) ValidationFunc {
 		_, isInt := val.(int)
 		if err == nil && !isFloat && !isInt64 && !isInt {
 			return exceptions.NewSaveException(
-				change.RecordKey, field.GetFullName(), fmt.Sprintf("Field: %s is not a valid number", field.Label), nil)
+				change.RecordKey, field.GetFullName(), fmt.Sprintf("field: %s is not a valid number", field.Label), nil)
 		}
 		return nil
 	}

--- a/apps/platform/pkg/datasource/fieldvalidations/regex.go
+++ b/apps/platform/pkg/datasource/fieldvalidations/regex.go
@@ -18,7 +18,7 @@ func ValidateRegex(field *wire.FieldMetadata) ValidationFunc {
 	return func(change *wire.ChangeItem) *exceptions.SaveException {
 		val, err2 := change.FieldChanges.GetField(field.GetFullName())
 		if err2 == nil && !regex.MatchString(fmt.Sprintf("%v", val)) {
-			return exceptions.NewSaveException(change.RecordKey, field.GetFullName(), fmt.Sprintf("Field: %s does not follow the expected format pattern", field.Label), nil)
+			return exceptions.NewSaveException(change.RecordKey, field.GetFullName(), fmt.Sprintf("field: %s does not follow the expected format pattern", field.Label), nil)
 		}
 		return nil
 	}

--- a/apps/platform/pkg/datasource/fieldvalidations/required.go
+++ b/apps/platform/pkg/datasource/fieldvalidations/required.go
@@ -15,7 +15,7 @@ func ValidateRequiredField(field *wire.FieldMetadata) ValidationFunc {
 		isMissingInsert := change.IsNew && (valueIsUndefined || valueIsEmpty)
 		isMissingUpdate := !change.IsNew && !valueIsUndefined && valueIsEmpty
 		if isMissingInsert || isMissingUpdate {
-			return exceptions.NewSaveException(change.RecordKey, field.GetFullName(), fmt.Sprintf("Field: %s is required", field.Label), nil)
+			return exceptions.NewSaveException(change.RecordKey, field.GetFullName(), fmt.Sprintf("field: %s is required", field.Label), nil)
 		}
 		return nil
 	}

--- a/apps/platform/pkg/datasource/load_conditions.go
+++ b/apps/platform/pkg/datasource/load_conditions.go
@@ -165,14 +165,14 @@ func processConditions(
 			}
 
 			if lookupOp == nil {
-				return nil, exceptions.NewBadRequestException(fmt.Sprintf("Could not find lookup wire: %s", condition.LookupWire), nil)
+				return nil, exceptions.NewBadRequestException("Could not find lookup wire: "+condition.LookupWire, nil)
 			}
 
 			values := make([]any, 0, lookupOp.Collection.Len())
 			err := lookupOp.Collection.Loop(func(item meta.Item, index string) error {
 				value, err := item.GetField(condition.LookupField)
 				if err != nil {
-					return exceptions.NewBadRequestException(fmt.Sprintf("could not get value of specific Lookup field from record: %s", condition.LookupField), nil)
+					return exceptions.NewBadRequestException("could not get value of specific Lookup field from record: "+condition.LookupField, nil)
 				}
 				values = append(values, value)
 				return nil
@@ -188,7 +188,7 @@ func processConditions(
 				condition.Operator = "IN"
 			}
 			if condition.Operator != "IN" && condition.Operator != "NOT_IN" {
-				return nil, exceptions.NewBadRequestException(fmt.Sprintf("invalid operator for lookup condition, must be one of [IN, NOT_IN]: %s", condition.Operator), nil)
+				return nil, exceptions.NewBadRequestException("invalid operator for lookup condition, must be one of [IN, NOT_IN]: "+condition.Operator, nil)
 			}
 		}
 		useConditions = append(useConditions, condition)
@@ -382,10 +382,10 @@ func getMetadataForConditionLoad(
 	if condition.ValueSource == "LOOKUP" {
 
 		if condition.LookupWire == "" {
-			return fmt.Errorf("invalid condition with valueSource 'LOOKUP': lookupWire is required")
+			return errors.New("invalid condition with valueSource 'LOOKUP': lookupWire is required")
 		}
 		if condition.LookupField == "" {
-			return fmt.Errorf("invalid condition with valueSource 'LOOKUP': lookupField is required")
+			return errors.New("invalid condition with valueSource 'LOOKUP': lookupField is required")
 		}
 
 		// Look through the previous wires to find the one to look up on.

--- a/apps/platform/pkg/datasource/load_conditions.go
+++ b/apps/platform/pkg/datasource/load_conditions.go
@@ -1,6 +1,7 @@
 package datasource
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 

--- a/apps/platform/pkg/datasource/load_metadata.go
+++ b/apps/platform/pkg/datasource/load_metadata.go
@@ -103,7 +103,7 @@ func GetMetadataForLoad(
 
 	collectionMetadata, err := metadataResponse.GetCollection(collectionKey)
 	if err != nil {
-		return exceptions.NewForbiddenException("Your profile has no access to the " + collectionKey + " collection")
+		return exceptions.NewForbiddenException("your profile has no access to the " + collectionKey + " collection")
 	}
 
 	// Now loop over fields and do some additional processing for reference & formula fields

--- a/apps/platform/pkg/datasource/oldvaluelookups.go
+++ b/apps/platform/pkg/datasource/oldvaluelookups.go
@@ -1,7 +1,7 @@
 package datasource
 
 import (
-	"errors"
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -163,11 +163,11 @@ func HandleOldValuesLookup(
 			if op.Options != nil && op.Options.IgnoreMissingRecords {
 				return nil
 			}
-			return errors.New("Could not find record to update or delete: " + ID)
+			return fmt.Errorf("could not find record to update or delete: %s", ID)
 		}
 
 		if len(matchIndexes) == 0 {
-			return errors.New("Bad OldValue Lookup Here: " + strconv.Itoa(len(matchIndexes)))
+			return fmt.Errorf("bad oldvalue lookup: %d", len(matchIndexes))
 		}
 
 		for _, matchIndex := range matchIndexes {

--- a/apps/platform/pkg/datasource/platformload.go
+++ b/apps/platform/pkg/datasource/platformload.go
@@ -93,10 +93,10 @@ func PlatformLoadOne(item meta.CollectionableItem, options *PlatformLoadOptions,
 	collectionName := collection.GetName()
 
 	if length == 0 {
-		return exceptions.NewNotFoundException(fmt.Sprintf("Couldn't find item from platform load: Collection=%s, Conditions=%v", collectionName, options.GetConditionsDebug()))
+		return exceptions.NewNotFoundException(fmt.Sprintf("couldn't find item from platform load: Collection=%s, Conditions=%v", collectionName, options.GetConditionsDebug()))
 	}
 	if length > 1 {
-		return exceptions.NewDuplicateException(fmt.Sprintf("Duplicate item found from platform load: %s (%v)", collectionName+" : "+options.GetConditionsDebug(), length))
+		return exceptions.NewDuplicateException(fmt.Sprintf("duplicate item found from platform load: %s (%v)", collectionName+" : "+options.GetConditionsDebug(), length))
 	}
 
 	return nil

--- a/apps/platform/pkg/datasource/recordpermissions.go
+++ b/apps/platform/pkg/datasource/recordpermissions.go
@@ -167,7 +167,7 @@ func handleStandardChange(change *wire.ChangeItem, tokenFuncs []tokenFunc, sessi
 	}
 
 	if !hasToken && !userCanModifyAllRecords {
-		return exceptions.NewForbiddenException("User does not have access to write to this record: " + change.UniqueKey + " of collection: " + change.Metadata.GetFullName())
+		return exceptions.NewForbiddenException("user does not have access to write to this record: " + change.UniqueKey + " of collection: " + change.Metadata.GetFullName())
 	}
 
 	return nil
@@ -190,7 +190,7 @@ func handleAccessFieldChange(change *wire.ChangeItem, tokenFuncs []tokenFunc, me
 
 		accessItem, err = wire.GetLoadable(accessInterface)
 		if err != nil {
-			return fmt.Errorf("Couldn't convert item: %T", accessInterface)
+			return fmt.Errorf("couldn't convert item: %T", accessInterface)
 		}
 
 		fieldMetadata, err := challengeMetadata.GetField(challengeMetadata.AccessField)
@@ -242,7 +242,7 @@ func handleAccessFieldChange(change *wire.ChangeItem, tokenFuncs []tokenFunc, me
 	}
 
 	if !hasToken {
-		return exceptions.NewForbiddenException("User does not have parent access to write to this record: " + change.UniqueKey + " of collection: " + change.Metadata.GetFullName())
+		return exceptions.NewForbiddenException("user does not have parent access to write to this record: " + change.UniqueKey + " of collection: " + change.Metadata.GetFullName())
 	}
 
 	return nil

--- a/apps/platform/pkg/datasource/references.go
+++ b/apps/platform/pkg/datasource/references.go
@@ -24,7 +24,7 @@ func LoadLooper(
 	ids := idMap.GetIDs()
 	idLength := len(ids)
 	if idLength == 0 {
-		return errors.New("No ids provided for load looper")
+		return errors.New("no ids provided for load looper")
 	}
 	var condition wire.LoadRequestCondition
 	if idLength == 1 {
@@ -166,7 +166,7 @@ func HandleReferences(
 				if options.AllowMissingItems {
 					return nil
 				}
-				return fmt.Errorf("Missing Reference Item For Key: %s on %s -> %s", ID, collectionName, ref.GetMatchField())
+				return fmt.Errorf("missing reference item for key: %s on %s -> %s", ID, collectionName, ref.GetMatchField())
 			}
 
 			// Loop over all matchIndexes and copy the data from the refItem

--- a/apps/platform/pkg/datasource/referencesgroup.go
+++ b/apps/platform/pkg/datasource/referencesgroup.go
@@ -13,7 +13,7 @@ import (
 func loadData(op *wire.LoadOp, connection wire.Connection, session *sess.Session, index int) error {
 
 	if index == adapt.MAX_ITER_REF_GROUP {
-		return errors.New("You have reached the maximum limit of Reference Group")
+		return errors.New("you have reached the maximum limit of reference group")
 	}
 
 	err := connection.Load(op, session)

--- a/apps/platform/pkg/datasource/upsertlookups.go
+++ b/apps/platform/pkg/datasource/upsertlookups.go
@@ -1,8 +1,7 @@
 package datasource
 
 import (
-	"errors"
-	"strconv"
+	"fmt"
 
 	"github.com/thecloudmasters/uesio/pkg/constant/commonfields"
 	"github.com/thecloudmasters/uesio/pkg/meta"
@@ -78,7 +77,7 @@ func HandleUpsertLookup(
 		}
 
 		if len(matchIndexes) != 1 {
-			return errors.New("Bad Lookup Here: " + strconv.Itoa(len(matchIndexes)))
+			return fmt.Errorf("bad lookup: %d", len(matchIndexes))
 		}
 
 		match := matchIndexes[0].Item

--- a/apps/platform/pkg/datasource/usertokens.go
+++ b/apps/platform/pkg/datasource/usertokens.go
@@ -31,7 +31,7 @@ func getTokensForRequest(metadata *wire.MetadataCache, session *sess.Session, to
 				return nil, err
 			}
 			if fieldMetadata.ReferenceMetadata == nil {
-				return nil, errors.New("Access field is not a reference field")
+				return nil, errors.New("access field is not a reference field")
 			}
 			challengeMetadata, err = metadata.GetCollection(fieldMetadata.ReferenceMetadata.GetCollection())
 			if err != nil {

--- a/apps/platform/pkg/datasource/workspacecontext.go
+++ b/apps/platform/pkg/datasource/workspacecontext.go
@@ -112,7 +112,7 @@ func RequestWorkspaceWriteAccess(params map[string]any, connection wire.Connecti
 func addWorkspaceImpersonationContext(workspace *meta.Workspace, session *sess.Session, connection wire.Connection) error {
 
 	if session.GetWorkspace() == nil {
-		return errors.New("Must already have a workspace context to add impersonation.")
+		return errors.New("must already have a workspace context to add impersonation")
 	}
 
 	results := &wire.Collection{}
@@ -153,7 +153,7 @@ func addWorkspaceImpersonationContext(workspace *meta.Workspace, session *sess.S
 		if profileKey != "" {
 			profile, err := LoadAndHydrateProfile(profileKey, session)
 			if err != nil {
-				return errors.New("Error Loading Profile: " + profileKey + " : " + err.Error())
+				return fmt.Errorf("error loading profile: %s : %w", profileKey, err)
 			}
 
 			session.SetWorkspaceSession(sess.NewWorkspaceSession(
@@ -213,7 +213,7 @@ func AddWorkspaceImpersonationContext(workspaceKey string, session *sess.Session
 	sessClone := session.RemoveWorkspaceContext()
 	workspace, err := QueryWorkspaceForWrite(workspaceKey, commonfields.UniqueKey, sessClone, connection)
 	if err != nil {
-		return nil, fmt.Errorf("could not get workspace context: workspace %s does not exist or you don't have access to modify it.", workspaceKey)
+		return nil, fmt.Errorf("could not get workspace context: workspace %s does not exist or you don't have access to modify it", workspaceKey)
 	}
 	err = addWorkspaceContext(workspace, sessClone, connection)
 	if err != nil {
@@ -235,7 +235,7 @@ func AddWorkspaceContextByKey(workspaceKey string, session *sess.Session, connec
 	sessClone := session.RemoveWorkspaceContext()
 	workspace, err := QueryWorkspaceForWrite(workspaceKey, commonfields.UniqueKey, sessClone, connection)
 	if err != nil {
-		return nil, fmt.Errorf("could not get workspace context: workspace %s does not exist or you don't have access to modify it.", workspaceKey)
+		return nil, fmt.Errorf("could not get workspace context: workspace %s does not exist or you don't have access to modify it", workspaceKey)
 	}
 	return sessClone, addWorkspaceContext(workspace, sessClone, connection)
 }
@@ -249,7 +249,7 @@ func AddWorkspaceContextByID(workspaceID string, session *sess.Session, connecti
 	sessClone := session.RemoveWorkspaceContext()
 	workspace, err := QueryWorkspaceForWrite(workspaceID, commonfields.Id, sessClone, connection)
 	if err != nil {
-		return nil, fmt.Errorf("could not get workspace context: workspace does not exist or you don't have access to modify it.")
+		return nil, fmt.Errorf("could not get workspace context: workspace does not exist or you don't have access to modify it")
 	}
 	return sessClone, addWorkspaceContext(workspace, sessClone, connection)
 }

--- a/apps/platform/pkg/datasource/workspacecontext.go
+++ b/apps/platform/pkg/datasource/workspacecontext.go
@@ -249,7 +249,7 @@ func AddWorkspaceContextByID(workspaceID string, session *sess.Session, connecti
 	sessClone := session.RemoveWorkspaceContext()
 	workspace, err := QueryWorkspaceForWrite(workspaceID, commonfields.Id, sessClone, connection)
 	if err != nil {
-		return nil, fmt.Errorf("could not get workspace context: workspace does not exist or you don't have access to modify it")
+		return nil, errors.New("could not get workspace context: workspace does not exist or you don't have access to modify it")
 	}
 	return sessClone, addWorkspaceContext(workspace, sessClone, connection)
 }

--- a/apps/platform/pkg/deploy/createbundle.go
+++ b/apps/platform/pkg/deploy/createbundle.go
@@ -89,12 +89,12 @@ func CreateBundle(options *CreateBundleOptions, connection wire.Connection, sess
 
 	app, err := datasource.QueryAppForWrite(appName, commonfields.UniqueKey, session, connection)
 	if err != nil {
-		return nil, exceptions.NewForbiddenException(fmt.Sprintf("you do not have permission to create bundles for app %s", appName))
+		return nil, exceptions.NewForbiddenException("you do not have permission to create bundles for app " + appName)
 	}
 
 	workspace, err := datasource.QueryWorkspaceForWrite(appName+":"+workspaceName, commonfields.UniqueKey, session, connection)
 	if err != nil {
-		return nil, exceptions.NewForbiddenException(fmt.Sprintf("you do not have permission to create bundles for workspace %s", workspaceName))
+		return nil, exceptions.NewForbiddenException("you do not have permission to create bundles for workspace " + workspaceName)
 	}
 
 	var bundles meta.BundleCollection

--- a/apps/platform/pkg/deploy/createbundle.go
+++ b/apps/platform/pkg/deploy/createbundle.go
@@ -73,7 +73,7 @@ func NewCreateBundleOptions(params map[string]any) (*CreateBundleOptions, error)
 func CreateBundle(options *CreateBundleOptions, connection wire.Connection, session *sess.Session) (*meta.Bundle, error) {
 
 	if options == nil {
-		return nil, errors.New("Invalid Create options")
+		return nil, errors.New("invalid create options")
 	}
 
 	appName := options.AppName

--- a/apps/platform/pkg/deploy/createbundle.go
+++ b/apps/platform/pkg/deploy/createbundle.go
@@ -3,7 +3,6 @@ package deploy
 import (
 	"bytes"
 	"errors"
-	"fmt"
 
 	"github.com/thecloudmasters/uesio/pkg/bundlestore"
 	"github.com/thecloudmasters/uesio/pkg/constant"

--- a/apps/platform/pkg/deploy/createsite.go
+++ b/apps/platform/pkg/deploy/createsite.go
@@ -2,7 +2,6 @@ package deploy
 
 import (
 	"errors"
-	"fmt"
 	"strings"
 
 	"github.com/thecloudmasters/uesio/pkg/constant/commonfields"

--- a/apps/platform/pkg/deploy/createsite.go
+++ b/apps/platform/pkg/deploy/createsite.go
@@ -54,7 +54,7 @@ func NewCreateSiteOptions(params map[string]any) (*CreateSiteOptions, error) {
 func CreateSite(options *CreateSiteOptions, connection wire.Connection, session *sess.Session) (*meta.Site, error) {
 
 	if options == nil {
-		return nil, errors.New("Invalid Create options")
+		return nil, errors.New("invalid create options")
 	}
 
 	appName := options.AppName

--- a/apps/platform/pkg/deploy/createsite.go
+++ b/apps/platform/pkg/deploy/createsite.go
@@ -64,7 +64,7 @@ func CreateSite(options *CreateSiteOptions, connection wire.Connection, session 
 
 	app, err := datasource.QueryAppForWrite(appName, commonfields.UniqueKey, session, connection)
 	if err != nil {
-		return nil, exceptions.NewForbiddenException(fmt.Sprintf("you do not have permission to create bundles for app %s", appName))
+		return nil, exceptions.NewForbiddenException("you do not have permission to create bundles for app " + appName)
 	}
 
 	major, minor, patch, err := meta.ParseVersionString(version)

--- a/apps/platform/pkg/deploy/createuser.go
+++ b/apps/platform/pkg/deploy/createuser.go
@@ -73,7 +73,7 @@ func NewCreateUserOptions(siteID string, params map[string]any) (*CreateUserOpti
 
 func CreateUser(options *CreateUserOptions, connection wire.Connection, session *sess.Session) (*meta.User, error) {
 	if options == nil {
-		return nil, errors.New("Invalid Create options")
+		return nil, errors.New("invalid create options")
 	}
 
 	user := &meta.User{

--- a/apps/platform/pkg/deploy/deploy.go
+++ b/apps/platform/pkg/deploy/deploy.go
@@ -110,7 +110,7 @@ func DeployWithOptions(body io.ReadCloser, session *sess.Session, options *Deplo
 
 	workspace := session.GetWorkspace()
 	if workspace == nil {
-		return errors.New("No Workspace provided for deployment")
+		return errors.New("no workspace provided for deployment")
 	}
 
 	// Unfortunately, we have to read the whole thing into memory
@@ -228,7 +228,7 @@ func DeployWithOptions(body io.ReadCloser, session *sess.Session, options *Deplo
 				if exceptions.GetStatusCodeForError(err) < 500 {
 					return err
 				}
-				return exceptions.NewBadRequestException(fmt.Sprintf("Unable to read file '%s'", collectionItem.GetKey()), err)
+				return exceptions.NewBadRequestException(fmt.Sprintf("unable to read file '%s'", collectionItem.GetKey()), err)
 			}
 			continue
 		}

--- a/apps/platform/pkg/featureflagstore/featureflagstore.go
+++ b/apps/platform/pkg/featureflagstore/featureflagstore.go
@@ -1,7 +1,6 @@
 package featureflagstore
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/thecloudmasters/uesio/pkg/bundle"
@@ -85,7 +84,7 @@ func GetFeatureFlags(session *sess.Session, user string) (*meta.FeatureFlagColle
 func getFeatureFlagStore(configStoreType string) (FeatureFlagStore, error) {
 	featureFlagAssignment, ok := featureFlagStoreMap[configStoreType]
 	if !ok {
-		return nil, errors.New("Invalid config store type: " + configStoreType)
+		return nil, fmt.Errorf("invalid config store type: %s", configStoreType)
 	}
 	return featureFlagAssignment, nil
 }

--- a/apps/platform/pkg/featureflagstore/platform/platform.go
+++ b/apps/platform/pkg/featureflagstore/platform/platform.go
@@ -83,7 +83,7 @@ func (ffs *FeatureFlagStore) Get(key, user string, session *sess.Session) (*meta
 	}
 	length := len(assignments)
 	if length > 1 {
-		return nil, errors.New("Too many Assignments")
+		return nil, errors.New("too many assignments")
 	}
 	if length == 1 {
 		return assignments[0], nil

--- a/apps/platform/pkg/fileadapt/fileadapter.go
+++ b/apps/platform/pkg/fileadapt/fileadapter.go
@@ -2,7 +2,7 @@ package fileadapt
 
 import (
 	"context"
-	"errors"
+	"fmt"
 
 	"github.com/thecloudmasters/uesio/pkg/bundle"
 	"github.com/thecloudmasters/uesio/pkg/configstore"
@@ -26,7 +26,7 @@ func GetFileAdapter(adapterType string, session *sess.Session) (FileAdapter, err
 	}
 	adapter, ok := adapterMap[mergedType]
 	if !ok {
-		return nil, errors.New("No adapter found of this type: " + adapterType)
+		return nil, fmt.Errorf("no adapter found of this type: %s", adapterType)
 	}
 	return adapter, nil
 }

--- a/apps/platform/pkg/fileadapt/localfiles/localfiles.go
+++ b/apps/platform/pkg/fileadapt/localfiles/localfiles.go
@@ -98,12 +98,12 @@ func (c *Connection) Upload(fileData io.Reader, path string) (int64, error) {
 
 	outFile, err := os.Create(fullPath)
 	if err != nil {
-		return 0, errors.New("Error Creating File: " + err.Error())
+		return 0, fmt.Errorf("error creating file: %w", err)
 	}
 	defer outFile.Close()
 	size, err := io.Copy(outFile, fileData)
 	if err != nil {
-		return 0, errors.New("Error Writing File: " + err.Error())
+		return 0, fmt.Errorf("error writing file: %w", err)
 	}
 
 	return size, nil
@@ -134,7 +134,7 @@ func (c *Connection) Delete(path string) error {
 	fullPath := filepath.Join(c.bucket, filepath.FromSlash(path))
 	err := os.Remove(fullPath)
 	if err != nil {
-		return errors.New("Error Reading File: " + err.Error())
+		return fmt.Errorf("error reading file: %w", err)
 	}
 	// Now remove subfolders if they're empty
 	removeEmptyDir(filepath.Dir(fullPath))
@@ -145,7 +145,7 @@ func (c *Connection) EmptyDir(path string) error {
 	fullPath := filepath.Join(c.bucket, filepath.FromSlash(path))
 	err := os.RemoveAll(fullPath)
 	if err != nil {
-		return errors.New("Error Reading File: " + err.Error())
+		return fmt.Errorf("error reading file: %w", err)
 	}
 	return nil
 }

--- a/apps/platform/pkg/fileadapt/s3/delete.go
+++ b/apps/platform/pkg/fileadapt/s3/delete.go
@@ -26,7 +26,7 @@ func (c *Connection) EmptyDir(path string) error {
 
 	objKeys, err := c.List(path)
 	if err != nil {
-		return errors.New("failed to EmptyDir")
+		return errors.New("failed to empty directory")
 	}
 
 	if len(objKeys) == 0 {
@@ -46,7 +46,7 @@ func (c *Connection) EmptyDir(path string) error {
 	})
 
 	if err != nil {
-		return errors.New("failed to EmptyDir")
+		return errors.New("failed to empty directory")
 	}
 
 	return nil

--- a/apps/platform/pkg/fileadapt/s3/s3.go
+++ b/apps/platform/pkg/fileadapt/s3/s3.go
@@ -2,7 +2,7 @@ package s3
 
 import (
 	"context"
-	"errors"
+	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 
@@ -17,7 +17,7 @@ type FileAdapter struct {
 func (a *FileAdapter) GetFileConnection(ctx context.Context, credentials *wire.Credentials, bucket string) (file.Connection, error) {
 	client, err := getS3Client(ctx, credentials)
 	if err != nil {
-		return nil, errors.New("invalid FileAdapterCredentials specified: " + err.Error())
+		return nil, fmt.Errorf("invalid file adapter credentials specified: %w", err)
 	}
 	return &Connection{
 		credentials: credentials,

--- a/apps/platform/pkg/filesource/delete.go
+++ b/apps/platform/pkg/filesource/delete.go
@@ -51,7 +51,7 @@ func Delete(userFileID string, session *sess.Session) error {
 	if fieldMetadata != nil {
 
 		if fieldMetadata.Type != "FILE" {
-			return errors.New("Can only delete files attached to FILE fields")
+			return errors.New("can only delete files attached to FILE fields")
 		}
 
 		err = datasource.Save([]datasource.SaveRequest{

--- a/apps/platform/pkg/filesource/upload.go
+++ b/apps/platform/pkg/filesource/upload.go
@@ -2,6 +2,7 @@ package filesource
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"mime"
 	"path"
@@ -71,7 +72,7 @@ func Upload(ops []*FileUploadOp, connection wire.Connection, session *sess.Sessi
 
 		if op.RecordID == "" {
 			if op.RecordUniqueKey == "" {
-				return nil, errors.New("You must provide either a RecordID, or a RecordUniqueKey for a file upload")
+				return nil, errors.New("you must provide either a RecordID, or a RecordUniqueKey for a file upload")
 			}
 			idMap, ok := idMaps[op.CollectionID]
 			if !ok {
@@ -104,7 +105,7 @@ func Upload(ops []*FileUploadOp, connection wire.Connection, session *sess.Sessi
 		}, commonfields.UniqueKey, metadataResponse, session, func(item meta.Item, matchIndexes []wire.ReferenceLocator, ID string) error {
 
 			if item == nil {
-				return errors.New("Could not match upload on unique key: " + ID)
+				return fmt.Errorf("could not match upload on unique key: %s", ID)
 			}
 			//One collection with more than 1 fields of type File
 			for i := range matchIndexes {
@@ -204,7 +205,7 @@ func Upload(ops []*FileUploadOp, connection wire.Connection, session *sess.Sessi
 
 	err = datasource.SaveWithOptions(fieldUpdates, session, datasource.NewSaveOptions(connection, metadataResponse))
 	if err != nil {
-		return nil, errors.New("Failed to update field for the given file: " + err.Error())
+		return nil, fmt.Errorf("failed to update field for the given file: %w", err)
 	}
 
 	return userFileCollection, nil

--- a/apps/platform/pkg/formula/formulafield_test.go
+++ b/apps/platform/pkg/formula/formulafield_test.go
@@ -56,7 +56,7 @@ func TestIdentifierValidation(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			fields, err := GetFormulaFields(context.Background(), tt.expression)
 			if err != nil {
-				t.Errorf("Error Getting Fields for Expression: %s", err.Error())
+				t.Errorf("error getting fields for expression: %s", err.Error())
 			}
 
 			assert.Equal(t, tt.fields, fields)
@@ -140,14 +140,14 @@ func TestFormulas(t *testing.T) {
 
 			exec, err := UesioLanguage.NewEvaluable(tt.expression)
 			if err != nil {
-				t.Errorf("Error Creating Expression: %s", err.Error())
+				t.Errorf("error creating expression: %s", err.Error())
 			}
 
 			evaluator := &RuntimeEvaluator{item: tt.item, collectionMetadata: tt.metadata}
 
 			value, err := exec(context.Background(), evaluator)
 			if err != nil {
-				t.Errorf("Error Evaluating Expression: %s", err.Error())
+				t.Errorf("error evaluating expression: %s", err.Error())
 			}
 
 			assert.Equal(t, tt.expectedResult, value)

--- a/apps/platform/pkg/integ/bedrock/claude.go
+++ b/apps/platform/pkg/integ/bedrock/claude.go
@@ -227,11 +227,11 @@ func (cmh *ClaudeModelHandler) GetInvokeResult(body []byte) (result any, inputTo
 	usage := modelOutput.Usage
 
 	if len(content) < 1 {
-		return "", 0, 0, errors.New("Invalid Response from Bedrock")
+		return "", 0, 0, errors.New("invalid response from bedrock")
 	}
 
 	if usage == nil {
-		return "", 0, 0, errors.New("No usage information provided")
+		return "", 0, 0, errors.New("no usage information provided")
 	}
 
 	return content, usage.InputTokens, usage.OutputTokens, nil
@@ -247,7 +247,7 @@ func (cmh *ClaudeModelHandler) HandleStreamChunk(chunk []byte) (result []byte, i
 
 	if modelOutput.Type == "message_start" {
 		if modelOutput.Message == nil || modelOutput.Message.Usage == nil {
-			return nil, 0, 0, false, errors.New("Could not get input token usage")
+			return nil, 0, 0, false, errors.New("could not get input token usage")
 		}
 		inputTokens += modelOutput.Message.Usage.InputTokens
 	}
@@ -256,7 +256,7 @@ func (cmh *ClaudeModelHandler) HandleStreamChunk(chunk []byte) (result []byte, i
 	if modelOutput.Type == "message_stop" && modelOutput.AmazonBedrockInvocationMetrics != nil {
 
 		if modelOutput.AmazonBedrockInvocationMetrics == nil {
-			return nil, 0, 0, false, errors.New("Could not get output token usage")
+			return nil, 0, 0, false, errors.New("could not get output token usage")
 		}
 
 		outputTokens += int64(modelOutput.AmazonBedrockInvocationMetrics.OutputTokenCount)

--- a/apps/platform/pkg/integ/bedrock/invoke.go
+++ b/apps/platform/pkg/integ/bedrock/invoke.go
@@ -1,7 +1,7 @@
 package bedrock
 
 import (
-	"errors"
+	"fmt"
 
 	"github.com/thecloudmasters/uesio/pkg/usage"
 )
@@ -15,7 +15,7 @@ func (c *Connection) invokeModel(requestOptions map[string]any) (any, error) {
 
 	handler, ok := modelHandlers[options.Model]
 	if !ok {
-		return nil, errors.New("Model Not Supported: " + options.Model)
+		return nil, fmt.Errorf("model not supported: %s", options.Model)
 	}
 
 	result, inputTokens, outputTokens, err := handler.Invoke(c, options)

--- a/apps/platform/pkg/integ/bedrock/stream.go
+++ b/apps/platform/pkg/integ/bedrock/stream.go
@@ -1,8 +1,6 @@
 package bedrock
 
-import (
-	"errors"
-)
+import "fmt"
 
 type MessagesModelStreamOutput struct {
 	Type  string `json:"type"`
@@ -35,7 +33,7 @@ func (c *Connection) streamModel(requestOptions map[string]any) (any, error) {
 
 	handler, ok := modelHandlers[options.Model]
 	if !ok {
-		return nil, errors.New("Model Not Supported: " + options.Model)
+		return nil, fmt.Errorf("model not supported: %s", options.Model)
 	}
 
 	return handler.Stream(c, options)

--- a/apps/platform/pkg/integ/openai/openai.go
+++ b/apps/platform/pkg/integ/openai/openai.go
@@ -29,7 +29,7 @@ type connection struct {
 func newOpenAiConnection(ic *wire.IntegrationConnection) (*connection, error) {
 	apikey, err := ic.GetCredentials().GetRequiredEntry("apikey")
 	if err != nil || apikey == "" {
-		return nil, errors.New("OpenAI API Key not provided")
+		return nil, errors.New("openai api key not provided")
 	}
 	return &connection{
 		client:      oai.NewClient(apikey),
@@ -50,7 +50,7 @@ func RunAction(bot *meta.Bot, ic *wire.IntegrationConnection, actionName string,
 		return c.autoComplete(params)
 	}
 
-	return nil, errors.New("invalid action name for Open AI integration")
+	return nil, errors.New("invalid action name for openai integration")
 
 }
 

--- a/apps/platform/pkg/invoices/invoices.go
+++ b/apps/platform/pkg/invoices/invoices.go
@@ -2,7 +2,7 @@ package invoices
 
 import (
 	"context"
-	"errors"
+	"fmt"
 	"log/slog"
 	"strings"
 	"time"
@@ -51,7 +51,7 @@ func InvoicingJob(ctx context.Context) error {
 func parseLicenseKey(key string) (string, string, error) {
 	keyArray := strings.Split(key, ":")
 	if len(keyArray) != 2 {
-		return "", "", errors.New("Invalid Key: " + key)
+		return "", "", fmt.Errorf("invalid key: %s", key)
 	}
 	return keyArray[0], keyArray[1], nil
 }
@@ -59,7 +59,7 @@ func parseLicenseKey(key string) (string, string, error) {
 func parseLipsKey(key string) (string, string, string, error) {
 	keyArray := strings.Split(key, ":")
 	if len(keyArray) != 5 {
-		return "", "", "", errors.New("Invalid Key: " + key)
+		return "", "", "", fmt.Errorf("invalid key: %s", key)
 	}
 	return keyArray[2], keyArray[3], keyArray[4], nil
 }

--- a/apps/platform/pkg/limits/limits.go
+++ b/apps/platform/pkg/limits/limits.go
@@ -1,7 +1,7 @@
 package limits
 
 import (
-	"errors"
+	"fmt"
 
 	"github.com/thecloudmasters/uesio/pkg/featureflagstore"
 	"github.com/thecloudmasters/uesio/pkg/sess"
@@ -26,5 +26,5 @@ func GetNumericLimit(numericLimitName, user string, session *sess.Session) (int,
 			return intVal, nil
 		}
 	}
-	return 0, errors.New("No value found for feature flag: " + numericLimitName)
+	return 0, fmt.Errorf("no value found for feature flag: %s", numericLimitName)
 }

--- a/apps/platform/pkg/merge/merge.go
+++ b/apps/platform/pkg/merge/merge.go
@@ -92,7 +92,7 @@ var RecordMergeFunc = func(m ServerMergeData, key string) (any, error) {
 
 	wireData, hasWireData := m.WireData[wireName]
 	if !hasWireData {
-		return nil, errors.New("$Record{} merge referenced wire " + wireName + ", which was not loaded")
+		return nil, fmt.Errorf("$Record{} merge referenced wire %s, which was not loaded", wireName)
 	}
 
 	if wireData.Len() < 1 {

--- a/apps/platform/pkg/meta/agent.go
+++ b/apps/platform/pkg/meta/agent.go
@@ -1,7 +1,7 @@
 package meta
 
 import (
-	"errors"
+	"fmt"
 	"path"
 
 	"gopkg.in/yaml.v3"
@@ -10,7 +10,7 @@ import (
 func NewAgent(key string) (*Agent, error) {
 	namespace, name, err := ParseKey(key)
 	if err != nil {
-		return nil, errors.New("Bad Key for Agent: " + key)
+		return nil, fmt.Errorf("bad key for agent: %s", key)
 	}
 	return NewBaseAgent(namespace, name), nil
 }

--- a/apps/platform/pkg/meta/authsource.go
+++ b/apps/platform/pkg/meta/authsource.go
@@ -1,7 +1,7 @@
 package meta
 
 import (
-	"errors"
+	"fmt"
 
 	"gopkg.in/yaml.v3"
 )
@@ -9,7 +9,7 @@ import (
 func NewAuthSource(key string) (*AuthSource, error) {
 	namespace, name, err := ParseKey(key)
 	if err != nil {
-		return nil, errors.New("Bad Key for AuthSource: " + key)
+		return nil, fmt.Errorf("bad key for auth source: %s", key)
 	}
 	return NewBaseAuthSource(namespace, name), nil
 }

--- a/apps/platform/pkg/meta/bot.go
+++ b/apps/platform/pkg/meta/bot.go
@@ -534,7 +534,7 @@ func getParamDef(p *BotParam) (typeOutput, importOutput string, err error) {
 	}
 	typeOutput, importOutput, err = getTSTypeNameForParam(p)
 	if err != nil {
-		return "", "", exceptions.NewBadRequestException(fmt.Sprintf("Could not generate type for parameter: %s", p.Name), err)
+		return "", "", exceptions.NewBadRequestException("Could not generate type for parameter: "+p.Name, err)
 	}
 	// example: "foo: string", "bar?: number", "baz: CustomType"
 	typeOutput = p.Name + joiner + typeOutput

--- a/apps/platform/pkg/meta/bot.go
+++ b/apps/platform/pkg/meta/bot.go
@@ -1,7 +1,6 @@
 package meta
 
 import (
-	"errors"
 	"fmt"
 	"path"
 	"strconv"
@@ -18,13 +17,13 @@ func NewBot(key string) (*Bot, error) {
 	keyArray := strings.Split(key, ":")
 	keyArraySize := len(keyArray)
 	if (keyArraySize) < 2 {
-		return nil, errors.New("Invalid Bot Key")
+		return nil, fmt.Errorf("invalid bot key: %s", key)
 	}
 	botType := keyArray[0]
 	var collectionKey, botKey string
 	if IsBotTypeWithCollection(botType) {
 		if (keyArraySize) != 3 {
-			return nil, errors.New("Invalid Bot Key")
+			return nil, fmt.Errorf("invalid bot key: %s", key)
 		}
 		collectionKey = keyArray[1]
 		botKey = keyArray[2]
@@ -32,7 +31,7 @@ func NewBot(key string) (*Bot, error) {
 		collectionKey = ""
 		botKey = keyArray[1]
 		if (keyArraySize) > 3 {
-			return nil, errors.New("Invalid Bot Key")
+			return nil, fmt.Errorf("invalid bot key: %s", key)
 		}
 		if (keyArraySize) == 3 {
 			collectionKey = keyArray[1]

--- a/apps/platform/pkg/meta/bundle.go
+++ b/apps/platform/pkg/meta/bundle.go
@@ -1,7 +1,6 @@
 package meta
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 )
@@ -24,11 +23,11 @@ func NewBundle(namespace string, major, minor, patch int, description string) (*
 func ParseVersionString(version string) (string, string, string, error) {
 	//Remove the 'v' and split on dots
 	if !strings.HasPrefix(version, "v") {
-		return "", "", "", errors.New("Invalid version string")
+		return "", "", "", fmt.Errorf("invalid version string: %s", version)
 	}
 	parts := strings.Split(strings.Split(version, "v")[1], ".")
 	if len(parts) != 3 {
-		return "", "", "", errors.New("Invalid version string")
+		return "", "", "", fmt.Errorf("invalid version string: %s", version)
 	}
 	return parts[0], parts[1], parts[2], nil
 }

--- a/apps/platform/pkg/meta/collection.go
+++ b/apps/platform/pkg/meta/collection.go
@@ -1,7 +1,7 @@
 package meta
 
 import (
-	"errors"
+	"fmt"
 
 	"github.com/thecloudmasters/uesio/pkg/constant/commonfields"
 	"gopkg.in/yaml.v3"
@@ -10,7 +10,7 @@ import (
 func NewCollection(key string) (*Collection, error) {
 	namespace, name, err := ParseKey(key)
 	if err != nil {
-		return nil, errors.New("Bad Key for Collection: " + key)
+		return nil, fmt.Errorf("bad key for collection: %s", key)
 	}
 	return NewBaseCollection(namespace, name), nil
 }

--- a/apps/platform/pkg/meta/collection_test.go
+++ b/apps/platform/pkg/meta/collection_test.go
@@ -137,7 +137,7 @@ func TestCollectionUnmarshal(t *testing.T) {
 			"somecollection_badname.yaml",
 			"my/namespace",
 			nil,
-			exceptions.NewBadRequestException("Metadata name does not match filename: somecollection, somecollection_badname", nil),
+			exceptions.NewBadRequestException("metadata name does not match filename: somecollection, somecollection_badname", nil),
 		},
 	}
 

--- a/apps/platform/pkg/meta/component.go
+++ b/apps/platform/pkg/meta/component.go
@@ -2,7 +2,6 @@ package meta
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 
 	"github.com/francoispqt/gojay"
@@ -17,7 +16,7 @@ const (
 func NewComponent(key string) (*Component, error) {
 	namespace, name, err := ParseKey(key)
 	if err != nil {
-		return nil, errors.New("Bad Key for Component: " + key)
+		return nil, fmt.Errorf("bad key for component: %s", key)
 	}
 	return NewBaseComponent(namespace, name), nil
 }

--- a/apps/platform/pkg/meta/componentpack.go
+++ b/apps/platform/pkg/meta/componentpack.go
@@ -1,7 +1,7 @@
 package meta
 
 import (
-	"errors"
+	"fmt"
 	"path"
 
 	"github.com/francoispqt/gojay"
@@ -11,7 +11,7 @@ import (
 func NewComponentPack(key string) (*ComponentPack, error) {
 	namespace, name, err := ParseKey(key)
 	if err != nil {
-		return nil, errors.New("Bad Key for Component Pack: " + key)
+		return nil, fmt.Errorf("bad key for component pack: %s", key)
 	}
 	return NewBaseComponentPack(namespace, name), nil
 }

--- a/apps/platform/pkg/meta/componentvariant.go
+++ b/apps/platform/pkg/meta/componentvariant.go
@@ -1,7 +1,6 @@
 package meta
 
 import (
-	"errors"
 	"fmt"
 	"path"
 	"strings"
@@ -13,11 +12,11 @@ import (
 func NewComponentVariant(key string) (*ComponentVariant, error) {
 	keyArray := strings.Split(key, ":")
 	if len(keyArray) != 2 {
-		return nil, errors.New("Invalid Variant Key: " + key)
+		return nil, fmt.Errorf("invalid variant key: %s", key)
 	}
 	namespace, name, err := ParseKey(keyArray[1])
 	if err != nil {
-		return nil, errors.New("Invalid Variant Key: " + key)
+		return nil, fmt.Errorf("invalid variant key: %s", key)
 	}
 	return NewBaseComponentVariant(keyArray[0], namespace, name), nil
 }

--- a/apps/platform/pkg/meta/configvalue.go
+++ b/apps/platform/pkg/meta/configvalue.go
@@ -1,7 +1,6 @@
 package meta
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/francoispqt/gojay"
@@ -41,7 +40,7 @@ func (cv *ConfigValue) IsNil() bool {
 func NewConfigValue(key string) (*ConfigValue, error) {
 	namespace, name, err := ParseKey(key)
 	if err != nil {
-		return nil, errors.New("Bad Key for ConfigValue: " + key)
+		return nil, fmt.Errorf("bad key for config value: %s", key)
 	}
 	return NewBaseConfigValue(namespace, name), nil
 }

--- a/apps/platform/pkg/meta/credential.go
+++ b/apps/platform/pkg/meta/credential.go
@@ -1,7 +1,7 @@
 package meta
 
 import (
-	"errors"
+	"fmt"
 
 	"gopkg.in/yaml.v3"
 
@@ -11,7 +11,7 @@ import (
 func NewCredential(key string) (*Credential, error) {
 	namespace, name, err := ParseKey(key)
 	if err != nil {
-		return nil, errors.New("Bad Key for Credential: " + key)
+		return nil, fmt.Errorf("bad key for credential: %s", key)
 	}
 	return NewBaseCredential(namespace, name), nil
 }

--- a/apps/platform/pkg/meta/credential_test.go
+++ b/apps/platform/pkg/meta/credential_test.go
@@ -168,7 +168,7 @@ func TestCredentialUnmarshal(t *testing.T) {
 			"somecredential_badname.yaml",
 			"my/namespace",
 			nil,
-			exceptions.NewBadRequestException("Metadata name does not match filename: somecredential, somecredential_badname", nil),
+			exceptions.NewBadRequestException("metadata name does not match filename: somecredential, somecredential_badname", nil),
 		},
 	}
 

--- a/apps/platform/pkg/meta/featureflag.go
+++ b/apps/platform/pkg/meta/featureflag.go
@@ -1,7 +1,7 @@
 package meta
 
 import (
-	"errors"
+	"fmt"
 
 	"github.com/francoispqt/gojay"
 	"gopkg.in/yaml.v3"
@@ -42,7 +42,7 @@ func (ff *FeatureFlag) IsNil() bool {
 func NewFeatureFlag(key string) (*FeatureFlag, error) {
 	namespace, name, err := ParseKey(key)
 	if err != nil {
-		return nil, errors.New("Bad Key for FeatureFlag: " + key)
+		return nil, fmt.Errorf("bad key for feature flag: %s", key)
 	}
 	return NewBaseFeatureFlag(namespace, name), nil
 }

--- a/apps/platform/pkg/meta/field.go
+++ b/apps/platform/pkg/meta/field.go
@@ -11,7 +11,7 @@ import (
 func NewField(collectionKey, fieldKey string) (*Field, error) {
 	namespace, name, err := ParseKey(fieldKey)
 	if err != nil {
-		return nil, errors.New("Bad Key for Field: " + collectionKey + " : " + fieldKey)
+		return nil, fmt.Errorf("bad key for field: %s : %s", collectionKey, fieldKey)
 	}
 	return NewBaseField(collectionKey, namespace, name), nil
 }
@@ -127,10 +127,10 @@ func (f *Field) UnmarshalYAML(node *yaml.Node) error {
 
 	_, ok := GetFieldTypes()[fieldType]
 	if !ok {
-		return errors.New("Invalid Field Type for Field: " + f.GetKey() + " : " + fieldType)
+		return fmt.Errorf("invalid field type for field: %s : %s", f.GetKey(), fieldType)
 	}
 	if f.CollectionRef == "" {
-		return errors.New("Invalid Collection Value for Field: " + f.GetKey())
+		return fmt.Errorf("invalid collection value for field: %s", f.GetKey())
 	}
 
 	if fieldType == "REFERENCE" {
@@ -174,7 +174,7 @@ func (f *Field) UnmarshalYAML(node *yaml.Node) error {
 	if fieldType == "SELECT" || fieldType == "MULTISELECT" {
 		f.SelectList, err = pickRequiredMetadataItem(node, "selectList", f.Namespace)
 		if err != nil {
-			return fmt.Errorf("Invalid selectlist metadata provided for field: %s : Missing select list name", f.GetKey())
+			return fmt.Errorf("invalid selectlist metadata provided for field: %s : missing select list name", f.GetKey())
 		}
 	}
 

--- a/apps/platform/pkg/meta/field_test.go
+++ b/apps/platform/pkg/meta/field_test.go
@@ -243,7 +243,7 @@ func TestFieldUnmarshal(t *testing.T) {
 			"my/namespace/mycollection/myfield.yaml",
 			"my/namespace",
 			nil,
-			errors.New("Invalid Field Type for Field: my/namespace.mycollection:my/namespace.myfield : TACO"),
+			errors.New("invalid field type for field: my/namespace.mycollection:my/namespace.myfield : TACO"),
 		},
 		{
 			"reference",
@@ -357,7 +357,7 @@ func TestFieldUnmarshal(t *testing.T) {
 			"my/namespace/mycollection/myfield.yaml",
 			"my/namespace",
 			nil,
-			errors.New("Invalid selectlist metadata provided for field: my/namespace.mycollection:my/namespace.myfield : Missing select list name"),
+			errors.New("invalid selectlist metadata provided for field: my/namespace.mycollection:my/namespace.myfield : missing select list name"),
 		},
 		{
 			"number",

--- a/apps/platform/pkg/meta/fieldcollection.go
+++ b/apps/platform/pkg/meta/fieldcollection.go
@@ -1,7 +1,6 @@
 package meta
 
 import (
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -48,7 +47,7 @@ func (fc *FieldCollection) GetItemFromPath(path, namespace string) BundleableIte
 func (fc *FieldCollection) GetItemFromKey(key string) (BundleableItem, error) {
 	keyArray := strings.Split(key, ":")
 	if (len(keyArray)) != 2 {
-		return nil, errors.New("Invalid Field Key")
+		return nil, fmt.Errorf("invalid field key: %s", key)
 	}
 	return NewField(keyArray[0], keyArray[1])
 }

--- a/apps/platform/pkg/meta/file.go
+++ b/apps/platform/pkg/meta/file.go
@@ -1,7 +1,6 @@
 package meta
 
 import (
-	"errors"
 	"fmt"
 	"path"
 
@@ -13,7 +12,7 @@ import (
 func NewFile(key string) (*File, error) {
 	namespace, name, err := ParseKey(key)
 	if err != nil {
-		return nil, errors.New("Bad Key for File: " + key)
+		return nil, fmt.Errorf("bad key for file: %s", key)
 	}
 	return NewBaseFile(namespace, name), nil
 }

--- a/apps/platform/pkg/meta/file.go
+++ b/apps/platform/pkg/meta/file.go
@@ -98,7 +98,7 @@ func (f *File) UnmarshalYAML(node *yaml.Node) error {
 	// Backwards compatibility
 	oldFileNameProperty := GetNodeValueAsString(node, "fileName")
 	if oldFileNameProperty != "" {
-		f.Path = fmt.Sprintf("file/%s", oldFileNameProperty)
+		f.Path = "file/" + oldFileNameProperty
 	}
 	return node.Decode((*FileWrapper)(f))
 }

--- a/apps/platform/pkg/meta/filesource.go
+++ b/apps/platform/pkg/meta/filesource.go
@@ -1,7 +1,7 @@
 package meta
 
 import (
-	"errors"
+	"fmt"
 
 	"gopkg.in/yaml.v3"
 )
@@ -9,7 +9,7 @@ import (
 func NewFileSource(key string) (*FileSource, error) {
 	namespace, name, err := ParseKey(key)
 	if err != nil {
-		return nil, errors.New("Bad Key for FileSource: " + key)
+		return nil, fmt.Errorf("bad key for file source: %s", key)
 	}
 	return NewBaseFileSource(namespace, name), nil
 }

--- a/apps/platform/pkg/meta/font.go
+++ b/apps/platform/pkg/meta/font.go
@@ -1,7 +1,7 @@
 package meta
 
 import (
-	"errors"
+	"fmt"
 	"path"
 
 	"gopkg.in/yaml.v3"
@@ -10,7 +10,7 @@ import (
 func NewFont(key string) (*Font, error) {
 	namespace, name, err := ParseKey(key)
 	if err != nil {
-		return nil, errors.New("Bad Key for Font: " + key)
+		return nil, fmt.Errorf("bad key for font: %s", key)
 	}
 	return NewBaseFont(namespace, name), nil
 }

--- a/apps/platform/pkg/meta/integration.go
+++ b/apps/platform/pkg/meta/integration.go
@@ -11,7 +11,7 @@ import (
 func NewIntegration(key string) (*Integration, error) {
 	namespace, name, err := ParseKey(key)
 	if err != nil {
-		return nil, exceptions.NewBadRequestException(fmt.Sprintf("Bad Key for Integration: %s", key), nil)
+		return nil, exceptions.NewBadRequestException(fmt.Sprintf("bad key for integration: %s", key), nil)
 	}
 	return NewBaseIntegration(namespace, name), nil
 }

--- a/apps/platform/pkg/meta/integration.go
+++ b/apps/platform/pkg/meta/integration.go
@@ -11,7 +11,7 @@ import (
 func NewIntegration(key string) (*Integration, error) {
 	namespace, name, err := ParseKey(key)
 	if err != nil {
-		return nil, exceptions.NewBadRequestException(fmt.Sprintf("bad key for integration: %s", key), nil)
+		return nil, exceptions.NewBadRequestException("bad key for integration: "+key, nil)
 	}
 	return NewBaseIntegration(namespace, name), nil
 }

--- a/apps/platform/pkg/meta/integration.go
+++ b/apps/platform/pkg/meta/integration.go
@@ -1,8 +1,6 @@
 package meta
 
 import (
-	"fmt"
-
 	"gopkg.in/yaml.v3"
 
 	"github.com/thecloudmasters/uesio/pkg/types/exceptions"

--- a/apps/platform/pkg/meta/integrationaction.go
+++ b/apps/platform/pkg/meta/integrationaction.go
@@ -1,7 +1,6 @@
 package meta
 
 import (
-	"errors"
 	"fmt"
 	"path"
 
@@ -14,7 +13,7 @@ func NewIntegrationAction(integrationTypeName, actionName string) (*IntegrationA
 		// Action Name probably is local, so use the integration type's namespace
 		integrationTypeName, _, err := ParseKey(integrationTypeName)
 		if err != nil {
-			return nil, errors.New("bad key for Integration Action: " + actionName)
+			return nil, fmt.Errorf("bad key for integration action: %s", actionName)
 		}
 		namespace = integrationTypeName
 		name = actionName

--- a/apps/platform/pkg/meta/integrationactioncollection.go
+++ b/apps/platform/pkg/meta/integrationactioncollection.go
@@ -1,7 +1,6 @@
 package meta
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -49,7 +48,7 @@ func (iac *IntegrationActionCollection) GetItemFromPath(path, namespace string) 
 func (iac *IntegrationActionCollection) GetItemFromKey(key string) (BundleableItem, error) {
 	keyArray := strings.Split(key, ":")
 	if (len(keyArray)) != 2 {
-		return nil, errors.New("invalid Integration Action Key")
+		return nil, fmt.Errorf("invalid integration action key: %s", key)
 	}
 	return NewIntegrationAction(keyArray[0], keyArray[1])
 }

--- a/apps/platform/pkg/meta/integrationtype.go
+++ b/apps/platform/pkg/meta/integrationtype.go
@@ -1,7 +1,7 @@
 package meta
 
 import (
-	"errors"
+	"fmt"
 
 	"gopkg.in/yaml.v3"
 )
@@ -9,7 +9,7 @@ import (
 func NewIntegrationType(key string) (*IntegrationType, error) {
 	namespace, name, err := ParseKey(key)
 	if err != nil {
-		return nil, errors.New("Bad Key for Integration Type: " + key)
+		return nil, fmt.Errorf("bad key for integration type: %s", key)
 	}
 	return NewBaseIntegrationType(namespace, name), nil
 }

--- a/apps/platform/pkg/meta/label.go
+++ b/apps/platform/pkg/meta/label.go
@@ -1,7 +1,7 @@
 package meta
 
 import (
-	"errors"
+	"fmt"
 
 	"github.com/francoispqt/gojay"
 	"gopkg.in/yaml.v3"
@@ -32,7 +32,7 @@ func (l *Label) IsNil() bool {
 func NewLabel(key string) (*Label, error) {
 	namespace, name, err := ParseKey(key)
 	if err != nil {
-		return nil, errors.New("Bad Key for Label: " + key)
+		return nil, fmt.Errorf("bad key for label: %s", key)
 	}
 	return NewBaseLabel(namespace, name), nil
 }

--- a/apps/platform/pkg/meta/metadata.go
+++ b/apps/platform/pkg/meta/metadata.go
@@ -128,7 +128,7 @@ type BundleableItem interface {
 func ParseKey(key string) (namespace string, name string, err error) {
 	keyArray := strings.Split(key, ".")
 	if len(keyArray) != 2 {
-		return "", "", errors.New("Invalid Key: " + key)
+		return "", "", fmt.Errorf("invalid key: %s", key)
 	}
 	return keyArray[0], keyArray[1], nil
 }
@@ -141,13 +141,13 @@ func ParseKeyWithDefault(key, defaultNamespace string) (string, string, error) {
 	if len(keyArray) == 1 {
 		return defaultNamespace, key, nil
 	}
-	return "", "", errors.New("Invalid Key With Default: " + key)
+	return "", "", fmt.Errorf("invalid key with default: %s", key)
 }
 
 func ParseNamespace(namespace string) (string, string, error) {
 	keyArray := strings.Split(namespace, "/")
 	if len(keyArray) != 2 {
-		return "", "", errors.New("Invalid Namespace: " + namespace)
+		return "", "", fmt.Errorf("invalid namespace: %s", namespace)
 	}
 	return keyArray[0], keyArray[1], nil
 }
@@ -233,7 +233,7 @@ func StandardGetFields(item CollectionableItem) []string {
 func StandardFieldGet(item CollectionableItem, fieldName string) (any, error) {
 	itemMeta := item.GetItemMeta()
 	if itemMeta != nil && !itemMeta.IsValidField(fieldName) {
-		return nil, errors.New("Field Not Found: " + item.GetCollectionName() + " : " + fieldName)
+		return nil, fmt.Errorf("field not found: %s : %s", item.GetCollectionName(), fieldName)
 	}
 	return reflecttool.GetField(item, fieldName)
 }
@@ -241,7 +241,7 @@ func StandardFieldGet(item CollectionableItem, fieldName string) (any, error) {
 func StandardFieldSet(item CollectionableItem, fieldName string, value any) error {
 	err := reflecttool.SetField(item, fieldName, value)
 	if err != nil {
-		return fmt.Errorf("Failed to set field: %s on item: %s: %w", fieldName, item.GetCollectionName(), err)
+		return fmt.Errorf("failed to set field: %s on item: %s: %w", fieldName, item.GetCollectionName(), err)
 	}
 	return nil
 }
@@ -397,7 +397,7 @@ func GetGroupingConditions(metadataType, grouping any) (BundleConditions, error)
 func GetBundleableGroupFromType(metadataType string) (BundleableGroup, error) {
 	group, ok := bundleableGroupMap[metadataType]
 	if !ok {
-		return nil, errors.New("Bad metadata type: " + metadataType)
+		return nil, fmt.Errorf("bad metadata type: %s", metadataType)
 	}
 	return group(), nil
 }

--- a/apps/platform/pkg/meta/permissionset.go
+++ b/apps/platform/pkg/meta/permissionset.go
@@ -1,7 +1,7 @@
 package meta
 
 import (
-	"errors"
+	"fmt"
 
 	"gopkg.in/yaml.v3"
 
@@ -11,7 +11,7 @@ import (
 func NewPermissionSet(key string) (*PermissionSet, error) {
 	namespace, name, err := ParseKey(key)
 	if err != nil {
-		return nil, errors.New("Bad Key for PermissionSet: " + key)
+		return nil, fmt.Errorf("bad key for permission set: %s", key)
 	}
 	return NewBasePermissionSet(namespace, name), nil
 }

--- a/apps/platform/pkg/meta/profile.go
+++ b/apps/platform/pkg/meta/profile.go
@@ -1,7 +1,7 @@
 package meta
 
 import (
-	"errors"
+	"fmt"
 
 	"gopkg.in/yaml.v3"
 )
@@ -9,7 +9,7 @@ import (
 func NewProfile(key string) (*Profile, error) {
 	namespace, name, err := ParseKey(key)
 	if err != nil {
-		return nil, errors.New("Bad Key for Profile: " + key)
+		return nil, fmt.Errorf("bad key for profile: %s", key)
 	}
 	return NewBaseProfile(namespace, name), nil
 }

--- a/apps/platform/pkg/meta/recordchallengetoken.go
+++ b/apps/platform/pkg/meta/recordchallengetoken.go
@@ -1,14 +1,14 @@
 package meta
 
 import (
-	"errors"
+	"fmt"
 	"path"
 )
 
 func NewRecordChallengeToken(collectionKey, key string) (*RecordChallengeToken, error) {
 	namespace, name, err := ParseKey(key)
 	if err != nil {
-		return nil, errors.New("Bad Key for Record Challeng Token: " + collectionKey + " : " + key)
+		return nil, fmt.Errorf("bad key for record challenge token: %s : %s", collectionKey, key)
 	}
 	return NewBaseRecordChallengeToken(collectionKey, namespace, name), nil
 }

--- a/apps/platform/pkg/meta/recordchallengetokencollection.go
+++ b/apps/platform/pkg/meta/recordchallengetokencollection.go
@@ -48,7 +48,7 @@ func (rctc *RecordChallengeTokenCollection) GetItemFromPath(path, namespace stri
 func (rctc *RecordChallengeTokenCollection) GetItemFromKey(key string) (BundleableItem, error) {
 	keyArray := strings.Split(key, ":")
 	if (len(keyArray)) != 2 {
-		return nil, errors.New("Invalid Record Challenge Token Key")
+		return nil, errors.New("invalid record challenge token key")
 	}
 	return NewRecordChallengeToken(keyArray[0], keyArray[1])
 }

--- a/apps/platform/pkg/meta/route.go
+++ b/apps/platform/pkg/meta/route.go
@@ -13,7 +13,7 @@ import (
 func NewRoute(key string) (*Route, error) {
 	namespace, name, err := ParseKey(key)
 	if err != nil {
-		return nil, errors.New("Invalid Route Key: " + key)
+		return nil, fmt.Errorf("invalid route key: %s", key)
 	}
 	return NewBaseRoute(namespace, name), nil
 }
@@ -91,16 +91,17 @@ func (r *Route) UnmarshalYAML(node *yaml.Node) error {
 		return err
 	}
 	routeType := GetNodeValueAsString(node, "type")
-	if routeType == "redirect" {
+	switch routeType {
+	case "redirect":
 		if redirectTo := GetNodeValueAsString(node, "redirect"); redirectTo == "" {
 			return errors.New("redirect property is required for routes of type 'redirect'")
 		}
-	} else if routeType == "bot" {
+	case "bot":
 		r.BotRef, err = pickRequiredMetadataItem(node, "bot", r.Namespace)
 		if err != nil || r.BotRef == "" {
-			return errors.New("bot property is required for Run Bot routes")
+			return errors.New("bot property is required for run bot routes")
 		}
-	} else {
+	default:
 		r.ViewRef, err = pickRequiredMetadataItem(node, "view", r.Namespace)
 		if err != nil {
 			return fmt.Errorf("invalid route %s: %s", r.GetKey(), err.Error())

--- a/apps/platform/pkg/meta/route_test.go
+++ b/apps/platform/pkg/meta/route_test.go
@@ -159,7 +159,7 @@ func TestRouteUnmarshal(t *testing.T) {
 			"myroute_badname.yaml",
 			"my/namespace",
 			nil,
-			exceptions.NewBadRequestException("Metadata name does not match filename: myroute, myroute_badname", nil),
+			exceptions.NewBadRequestException("metadata name does not match filename: myroute, myroute_badname", nil),
 		},
 	}
 

--- a/apps/platform/pkg/meta/routeassignmentcollection.go
+++ b/apps/platform/pkg/meta/routeassignmentcollection.go
@@ -1,7 +1,6 @@
 package meta
 
 import (
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -61,11 +60,11 @@ func (rc *RouteAssignmentCollection) GetItemFromPath(path, namespace string) Bun
 func (rc *RouteAssignmentCollection) GetItemFromKey(key string) (BundleableItem, error) {
 	keyArray := strings.Split(key, ":")
 	if (len(keyArray)) != 2 {
-		return nil, errors.New("Invalid Route Assignment Key")
+		return nil, fmt.Errorf("invalid route assignment key: %s", key)
 	}
 	namespace, viewType, err := ParseKey(keyArray[1])
 	if err != nil {
-		return nil, errors.New("Bad Key for RouteAssignment: " + key)
+		return nil, fmt.Errorf("bad key for route assignment: %s", key)
 	}
 	return NewRouteAssignment(keyArray[0], namespace, viewType)
 }

--- a/apps/platform/pkg/meta/secret.go
+++ b/apps/platform/pkg/meta/secret.go
@@ -1,7 +1,7 @@
 package meta
 
 import (
-	"errors"
+	"fmt"
 
 	"gopkg.in/yaml.v3"
 )
@@ -18,7 +18,7 @@ type SecretWrapper Secret
 func NewSecret(key string) (*Secret, error) {
 	namespace, name, err := ParseKey(key)
 	if err != nil {
-		return nil, errors.New("Bad Key for Secret: " + key)
+		return nil, fmt.Errorf("bad key for secret: %s", key)
 	}
 	return NewBaseSecret(namespace, name), nil
 }

--- a/apps/platform/pkg/meta/selectlist.go
+++ b/apps/platform/pkg/meta/selectlist.go
@@ -1,7 +1,7 @@
 package meta
 
 import (
-	"errors"
+	"fmt"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -29,7 +29,7 @@ type SelectListWrapper SelectList
 func NewSelectList(key string) (*SelectList, error) {
 	namespace, name, err := ParseKey(key)
 	if err != nil {
-		return nil, errors.New("Bad Key for SelectList: " + key)
+		return nil, fmt.Errorf("bad key for select list: %s", key)
 	}
 	return NewBaseSelectList(namespace, name), nil
 }

--- a/apps/platform/pkg/meta/signupmethod.go
+++ b/apps/platform/pkg/meta/signupmethod.go
@@ -1,7 +1,7 @@
 package meta
 
 import (
-	"errors"
+	"fmt"
 
 	"gopkg.in/yaml.v3"
 )
@@ -9,7 +9,7 @@ import (
 func NewSignupMethod(key string) (*SignupMethod, error) {
 	namespace, name, err := ParseKey(key)
 	if err != nil {
-		return nil, errors.New("Bad Key for SignupMethod: " + key)
+		return nil, fmt.Errorf("bad key for signup method: %s", key)
 	}
 	return NewBaseSignupMethod(namespace, name), nil
 }

--- a/apps/platform/pkg/meta/theme.go
+++ b/apps/platform/pkg/meta/theme.go
@@ -1,7 +1,7 @@
 package meta
 
 import (
-	"errors"
+	"fmt"
 
 	"github.com/francoispqt/gojay"
 	"gopkg.in/yaml.v3"
@@ -32,7 +32,7 @@ func (t *Theme) IsNil() bool {
 func NewTheme(key string) (*Theme, error) {
 	namespace, name, err := ParseKey(key)
 	if err != nil {
-		return nil, errors.New("Bad Key for Theme: " + key)
+		return nil, fmt.Errorf("bad key for theme: %s", key)
 	}
 	return NewBaseTheme(namespace, name), nil
 }

--- a/apps/platform/pkg/meta/useraccesstoken.go
+++ b/apps/platform/pkg/meta/useraccesstoken.go
@@ -1,13 +1,11 @@
 package meta
 
-import (
-	"errors"
-)
+import "fmt"
 
 func NewUserAccessToken(key string) (*UserAccessToken, error) {
 	namespace, name, err := ParseKey(key)
 	if err != nil {
-		return nil, errors.New("Bad Key for User Access Token: " + key)
+		return nil, fmt.Errorf("bad key for user access token: %s", key)
 	}
 	return NewBaseUserAccessToken(namespace, name), nil
 }

--- a/apps/platform/pkg/meta/utility.go
+++ b/apps/platform/pkg/meta/utility.go
@@ -1,7 +1,7 @@
 package meta
 
 import (
-	"errors"
+	"fmt"
 
 	"gopkg.in/yaml.v3"
 )
@@ -9,7 +9,7 @@ import (
 func NewUtility(key string) (*Utility, error) {
 	namespace, name, err := ParseKey(key)
 	if err != nil {
-		return nil, errors.New("Bad Key for Utility: " + key)
+		return nil, fmt.Errorf("bad key for utility: %s", key)
 	}
 	return NewBaseUtility(namespace, name), nil
 }

--- a/apps/platform/pkg/meta/view.go
+++ b/apps/platform/pkg/meta/view.go
@@ -1,7 +1,7 @@
 package meta
 
 import (
-	"errors"
+	"fmt"
 
 	"github.com/francoispqt/gojay"
 	"gopkg.in/yaml.v3"
@@ -32,7 +32,7 @@ func (v *View) IsNil() bool {
 func NewView(key string) (*View, error) {
 	namespace, name, err := ParseKey(key)
 	if err != nil {
-		return nil, errors.New("Bad Key for View: " + key)
+		return nil, fmt.Errorf("bad key for view: %s", key)
 	}
 	return NewBaseView(namespace, name), nil
 }

--- a/apps/platform/pkg/meta/yamlnodeutils.go
+++ b/apps/platform/pkg/meta/yamlnodeutils.go
@@ -78,7 +78,7 @@ func GetMapNodes(node *yaml.Node) ([]NodePair, error) {
 
 	node = UnwrapDocumentNode(node)
 	if node.Kind != yaml.MappingNode {
-		return nil, fmt.Errorf("definition is not a mapping node")
+		return nil, errors.New("definition is not a mapping node")
 	}
 
 	contentSize := len(node.Content) / 2
@@ -106,7 +106,7 @@ func GetMapNode(node *yaml.Node, key string) (*yaml.Node, error) {
 func GetMapNodeWithIndex(node *yaml.Node, key string) (*yaml.Node, int, error) {
 	node = UnwrapDocumentNode(node)
 	if node.Kind != yaml.MappingNode {
-		return nil, 0, fmt.Errorf("definition is not a mapping node")
+		return nil, 0, errors.New("definition is not a mapping node")
 	}
 
 	for i := range node.Content {
@@ -186,7 +186,7 @@ func validateMetadataName(name string, expectedName string) error {
 		return exceptions.NewBadRequestException(fmt.Sprintf("metadata name does not match filename: %s, %s", name, expectedName), nil)
 	}
 	if !IsValidMetadataName(name) {
-		return exceptions.NewBadRequestException(fmt.Sprintf("failed metadata validation, can only contain lowercase characters a-z, the underscore character and the numerals 0-9: %s", name), nil)
+		return exceptions.NewBadRequestException("failed metadata validation, can only contain lowercase characters a-z, the underscore character and the numerals 0-9: "+name, nil)
 	}
 	return nil
 }

--- a/apps/platform/pkg/meta/yamlnodeutils.go
+++ b/apps/platform/pkg/meta/yamlnodeutils.go
@@ -78,7 +78,7 @@ func GetMapNodes(node *yaml.Node) ([]NodePair, error) {
 
 	node = UnwrapDocumentNode(node)
 	if node.Kind != yaml.MappingNode {
-		return nil, fmt.Errorf("Definition is not a mapping node.")
+		return nil, fmt.Errorf("definition is not a mapping node")
 	}
 
 	contentSize := len(node.Content) / 2
@@ -106,7 +106,7 @@ func GetMapNode(node *yaml.Node, key string) (*yaml.Node, error) {
 func GetMapNodeWithIndex(node *yaml.Node, key string) (*yaml.Node, int, error) {
 	node = UnwrapDocumentNode(node)
 	if node.Kind != yaml.MappingNode {
-		return nil, 0, fmt.Errorf("Definition is not a mapping node.")
+		return nil, 0, fmt.Errorf("definition is not a mapping node")
 	}
 
 	for i := range node.Content {
@@ -116,7 +116,7 @@ func GetMapNodeWithIndex(node *yaml.Node, key string) (*yaml.Node, int, error) {
 		}
 	}
 
-	return nil, 0, fmt.Errorf("Node not found of key: %s", key)
+	return nil, 0, fmt.Errorf("node not found of key: %s", key)
 }
 
 // Removes an entry from a map node and returns it.
@@ -183,10 +183,10 @@ func validateMetadataNameNode(node *yaml.Node, expectedName, nameKey string) err
 
 func validateMetadataName(name string, expectedName string) error {
 	if expectedName != "" && name != expectedName {
-		return exceptions.NewBadRequestException(fmt.Sprintf("Metadata name does not match filename: %s, %s", name, expectedName), nil)
+		return exceptions.NewBadRequestException(fmt.Sprintf("metadata name does not match filename: %s, %s", name, expectedName), nil)
 	}
 	if !IsValidMetadataName(name) {
-		return exceptions.NewBadRequestException(fmt.Sprintf("Failed metadata validation, can only contain lowercase characters a-z, the underscore character and the numerals 0-9: %s", name), nil)
+		return exceptions.NewBadRequestException(fmt.Sprintf("failed metadata validation, can only contain lowercase characters a-z, the underscore character and the numerals 0-9: %s", name), nil)
 	}
 	return nil
 }

--- a/apps/platform/pkg/meta/yamlnodeutils.go
+++ b/apps/platform/pkg/meta/yamlnodeutils.go
@@ -1,6 +1,7 @@
 package meta
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"

--- a/apps/platform/pkg/middleware/dev_logger.go
+++ b/apps/platform/pkg/middleware/dev_logger.go
@@ -74,7 +74,7 @@ func (h *DevLogHandler) Handle(ctx context.Context, r slog.Record) error {
 		duration := statsObject["duration"].(time.Duration).Round(time.Millisecond)
 		path := colorFunc(requestObject["path"].(string))
 		method := colorFunc(requestObject["method"].(string))
-		code := colorFunc(fmt.Sprintf("%d", int(statsObject["code"].(int64))))
+		code := colorFunc(strconv.Itoa(int(statsObject["code"].(int64))))
 		h.l.Printf("%v %-4s %-32s %s %5s %16s %s %s\n", timeStr, method, path, code, duration, size, siteKey, user)
 	} else {
 		var fieldsString string

--- a/apps/platform/pkg/middleware/dev_logger.go
+++ b/apps/platform/pkg/middleware/dev_logger.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log"
 	"log/slog"
+	"strconv"
 	"time"
 
 	"github.com/fatih/color"

--- a/apps/platform/pkg/oauth2/integrationcredential.go
+++ b/apps/platform/pkg/oauth2/integrationcredential.go
@@ -1,7 +1,7 @@
 package oauth2
 
 import (
-	"errors"
+	"fmt"
 	"strings"
 	"time"
 
@@ -166,7 +166,7 @@ func GetIntegrationCredential(
 			Connection: connection,
 		},
 	); err != nil {
-		return nil, errors.New("unable to load existing integration credentials: " + err.Error())
+		return nil, fmt.Errorf("unable to load existing integration credentials: %w", err)
 	}
 	// Return the record we found, if any
 	if integrationCredentials.Len() == 0 {

--- a/apps/platform/pkg/oauth2/transport.go
+++ b/apps/platform/pkg/oauth2/transport.go
@@ -44,7 +44,7 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 
 	if t.Source == nil {
-		return nil, errors.New("oauth2: Transport's Source is nil")
+		return nil, errors.New("oauth2: transport's source is nil")
 	}
 	token, err := t.Source.Token()
 	if err != nil {

--- a/apps/platform/pkg/reflecttool/get.go
+++ b/apps/platform/pkg/reflecttool/get.go
@@ -42,7 +42,7 @@ func GetField(obj any, name string) (any, error) {
 			continue
 		}
 		if objKind != reflect.Struct && objKind != reflect.Ptr {
-			return nil, errors.New("Cannot use GetField on a non-struct interface")
+			return nil, errors.New("cannot use GetField on a non-struct interface")
 		}
 
 		fieldName, err := getFieldName(objType, name)
@@ -71,7 +71,7 @@ func getPointer(from reflect.Value) (any, error) {
 func getFieldReflect(value reflect.Value) (any, error) {
 
 	if !value.IsValid() {
-		return nil, fmt.Errorf("No such field")
+		return nil, fmt.Errorf("no such field")
 	}
 
 	switch value.Kind() {

--- a/apps/platform/pkg/reflecttool/get.go
+++ b/apps/platform/pkg/reflecttool/get.go
@@ -71,7 +71,7 @@ func getPointer(from reflect.Value) (any, error) {
 func getFieldReflect(value reflect.Value) (any, error) {
 
 	if !value.IsValid() {
-		return nil, fmt.Errorf("no such field")
+		return nil, errors.New("no such field")
 	}
 
 	switch value.Kind() {

--- a/apps/platform/pkg/reflecttool/set.go
+++ b/apps/platform/pkg/reflecttool/set.go
@@ -18,7 +18,7 @@ func SetField(obj any, name string, value any) error {
 	structKind := structValue.Kind()
 	structType := structValue.Type()
 	if structKind != reflect.Struct {
-		return errors.New("Cannot use SetField on a non-struct interface")
+		return errors.New("cannot use SetField on a non-struct interface")
 	}
 	fieldName, err := getFieldName(structType, name)
 	if err != nil {
@@ -38,7 +38,7 @@ func setSlice(to reflect.Value, from reflect.Value) error {
 	// Verify that from's type is a slice so we don't have a panic
 	fromKind := from.Kind()
 	if fromKind != reflect.Slice {
-		return fmt.Errorf("Cannot set kind: %s to slice", fromKind)
+		return fmt.Errorf("cannot set kind: %s to slice", fromKind)
 	}
 	for i := range from.Len() {
 		newItem := reflect.Indirect(reflect.New(itemType))
@@ -57,7 +57,7 @@ func setMap(to reflect.Value, from reflect.Value) error {
 	// Verify that from's type is a map so we don't have a panic
 	fromKind := from.Kind()
 	if fromKind != reflect.Map {
-		return fmt.Errorf("Cannot set kind: %s to map", fromKind)
+		return fmt.Errorf("cannot set kind: %s to map", fromKind)
 	}
 	for _, key := range from.MapKeys() {
 		newItem := reflect.Indirect(reflect.New(itemType))
@@ -86,7 +86,7 @@ func setStruct(to reflect.Value, from reflect.Value) error {
 		return nil
 	}
 	if fromKind != reflect.Map {
-		return fmt.Errorf("Cannot set kind: %s to a %s struct", fromKind, structType)
+		return fmt.Errorf("cannot set kind: %s to a %s struct", fromKind, structType)
 	}
 	for _, key := range from.MapKeys() {
 		fieldName, err := getFieldName(structType, key.String())
@@ -139,7 +139,7 @@ func setPrimative(to reflect.Value, from reflect.Value) error {
 			fmt.Println("WARNING: converted string to int: " + stringVal)
 			return nil
 		}
-		return errors.New("Provided value type didn't match obj field type: " + to.Type().String() + " : " + from.Type().String())
+		return fmt.Errorf("provided value type didn't match obj field type: %s : %s", to.Type().String(), from.Type().String())
 	}
 
 	to.Set(from)
@@ -153,11 +153,11 @@ func setFieldReflect(to reflect.Value, from reflect.Value) error {
 	}
 
 	if !to.IsValid() {
-		return fmt.Errorf("No such field")
+		return fmt.Errorf("no such field")
 	}
 
 	if !to.CanSet() {
-		return fmt.Errorf("Cannot set")
+		return fmt.Errorf("cannot set")
 	}
 
 	switch to.Kind() {

--- a/apps/platform/pkg/reflecttool/set.go
+++ b/apps/platform/pkg/reflecttool/set.go
@@ -153,11 +153,11 @@ func setFieldReflect(to reflect.Value, from reflect.Value) error {
 	}
 
 	if !to.IsValid() {
-		return fmt.Errorf("no such field")
+		return errors.New("no such field")
 	}
 
 	if !to.CanSet() {
-		return fmt.Errorf("cannot set")
+		return errors.New("cannot set")
 	}
 
 	switch to.Kind() {

--- a/apps/platform/pkg/reflecttool/tags.go
+++ b/apps/platform/pkg/reflecttool/tags.go
@@ -2,6 +2,7 @@ package reflecttool
 
 import (
 	"errors"
+	"fmt"
 	"reflect"
 	"strings"
 	"sync"
@@ -14,7 +15,7 @@ func getFieldName(objType reflect.Type, uesioName string) (string, error) {
 	}
 	name, ok := tags[uesioName]
 	if !ok {
-		return "", errors.New("Could not find field: " + uesioName + " : " + objType.String())
+		return "", fmt.Errorf("could not find field: %s : %s", uesioName, objType.String())
 	}
 	return name, nil
 }
@@ -24,7 +25,7 @@ func GetFieldNames(obj any) ([]string, error) {
 	structKind := structValue.Kind()
 	structType := structValue.Type()
 	if structKind != reflect.Struct {
-		return nil, errors.New("Cannot use GetFieldNames on a non-struct interface")
+		return nil, errors.New("cannot use GetFieldNames on a non-struct interface")
 	}
 	tags, err := getTags(structType)
 	if err != nil {

--- a/apps/platform/pkg/retrieve/retrieve.go
+++ b/apps/platform/pkg/retrieve/retrieve.go
@@ -1,7 +1,6 @@
 package retrieve
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -52,7 +51,7 @@ func GenerateAppTypeScriptTypes(out io.Writer, bs bundlestore.BundleStoreConnect
 			Conditions: genOptions.GetTypescriptableItemConditions(),
 		})
 		if err != nil {
-			return errors.New("failed to retrieve items of type: " + metadataType + ": " + err.Error())
+			return fmt.Errorf("failed to retrieve items of type: %s : %w", metadataType, err)
 		}
 		var typeDefsByNamespace map[string]*strings.Builder
 		// If needed, generate a wrapper module around all types for this group
@@ -148,7 +147,7 @@ func RetrieveBundle(targetDirectory string, create bundlestore.FileCreator, bs b
 		}
 		err = bs.GetAllItems(group, nil)
 		if err != nil {
-			return errors.New("failed to retrieve items of type: " + metadataType + ": " + err.Error())
+			return fmt.Errorf("failed to retrieve items of type: %s : %w", metadataType, err)
 		}
 
 		err = group.Loop(func(item meta.Item, _ string) error {
@@ -157,7 +156,7 @@ func RetrieveBundle(targetDirectory string, create bundlestore.FileCreator, bs b
 
 			f, err := create(path.Join(targetDirectory, metadataType, itempath))
 			if err != nil {
-				return errors.New("failed to create " + metadataType + " file: " + itempath + ": " + err.Error())
+				return fmt.Errorf("failed to create %s file: %s : %w", metadataType, itempath, err)
 			}
 			defer f.Close()
 
@@ -165,7 +164,7 @@ func RetrieveBundle(targetDirectory string, create bundlestore.FileCreator, bs b
 			encoder.SetIndent(2)
 			err = encoder.Encode(item)
 			if err != nil {
-				return errors.New("failed to encode metadata item of type " + metadataType + " into YAML: " + itempath + ": " + err.Error())
+				return fmt.Errorf("failed to encode metadata item of type %s into YAML: %s : %w", metadataType, itempath, err)
 			}
 
 			attachableItem, isAttachable := item.(meta.AttachableItem)
@@ -195,7 +194,7 @@ func RetrieveBundle(targetDirectory string, create bundlestore.FileCreator, bs b
 
 	f, err := create(path.Join(targetDirectory, "bundle.yaml"))
 	if err != nil {
-		return errors.New("failed to create bundle.yaml file: " + err.Error())
+		return fmt.Errorf("failed to create bundle.yaml file: %w", err)
 	}
 	defer f.Close()
 
@@ -203,7 +202,7 @@ func RetrieveBundle(targetDirectory string, create bundlestore.FileCreator, bs b
 	encoder.SetIndent(2)
 	err = encoder.Encode(bundleDef)
 	if err != nil {
-		return errors.New("failed to encode bundle.yaml file into YAML: " + err.Error())
+		return fmt.Errorf("failed to encode bundle.yaml file into YAML: %w", err)
 	}
 
 	return nil

--- a/apps/platform/pkg/routing/deps.go
+++ b/apps/platform/pkg/routing/deps.go
@@ -441,7 +441,7 @@ func GetWorkspaceModeDeps(deps *preload.PreloadMetadata, session *sess.Session, 
 		return err
 	}
 
-	deps.Component.AddItem(preload.NewComponentMergeData(fmt.Sprintf("%s:namespaces", builderComponentID), appData))
+	deps.Component.AddItem(preload.NewComponentMergeData(builderComponentID+":namespaces", appData))
 
 	return nil
 }
@@ -512,11 +512,11 @@ func GetBuilderDependencies(viewNamespace, viewName string, deps *preload.Preloa
 }
 
 func GetBuildModeKey(builderComponentID string) string {
-	return fmt.Sprintf("%s:buildmode", builderComponentID)
+	return builderComponentID + ":buildmode"
 }
 
 func GetIndexPanelKey(builderComponentID string) string {
-	return fmt.Sprintf("%s:indexpanel", builderComponentID)
+	return builderComponentID + ":indexpanel"
 }
 
 func GetMetadataDeps(route *meta.Route, session *sess.Session) (*preload.PreloadMetadata, error) {

--- a/apps/platform/pkg/routing/deps.go
+++ b/apps/platform/pkg/routing/deps.go
@@ -72,7 +72,7 @@ func getFullyQualifiedVariantKey(fullName string, componentKey string) (string, 
 	if len(keyArray) == 1 && componentKey != "" {
 		return fmt.Sprintf("%s:%s", componentKey, fullName), nil
 	}
-	return "", errors.New("Invalid Variant Key: " + fullName)
+	return "", fmt.Errorf("invalid variant key: %s", fullName)
 }
 
 func addComponentPackToDeps(deps *preload.PreloadMetadata, packNamespace, packName string, session *sess.Session) error {
@@ -483,13 +483,13 @@ func GetBuilderDependencies(viewNamespace, viewName string, deps *preload.Preloa
 	var variants meta.ComponentVariantCollection
 	err = bundle.LoadAllFromAny(&variants, nil, session, nil)
 	if err != nil {
-		return errors.New("Failed to load variants: " + err.Error())
+		return fmt.Errorf("failed to load variants: %w", err)
 	}
 
 	var components meta.ComponentCollection
 	err = bundle.LoadAllFromAny(&components, nil, session, nil)
 	if err != nil {
-		return errors.New("Failed to load components: " + err.Error())
+		return fmt.Errorf("failed to load components: %w", err)
 	}
 
 	for _, component := range components {
@@ -546,24 +546,24 @@ func GetMetadataDeps(route *meta.Route, session *sess.Session) (*preload.Preload
 
 	labels, err := translate.GetTranslatedLabels(session)
 	if err != nil {
-		return nil, errors.New("Failed to get translated labels: " + err.Error())
+		return nil, fmt.Errorf("failed to get translated labels: %w", err)
 	}
 
 	featureFlags, err := featureflagstore.GetFeatureFlags(session, session.GetContextUser().ID)
 	if err != nil {
-		return nil, errors.New("Failed to get feature flags: " + err.Error())
+		return nil, fmt.Errorf("failed to get feature flags: %w", err)
 	}
 
 	configValues, err := configstore.GetConfigValues(session, nil)
 	if err != nil {
-		return nil, errors.New("Failed to get config values: " + err.Error())
+		return nil, fmt.Errorf("failed to get config values: %w", err)
 	}
 
 	// Add in fonts
 	var fonts meta.FontCollection
 	err = bundle.LoadAllFromAny(&fonts, nil, session, nil)
 	if err != nil {
-		return nil, errors.New("Failed to load fonts: " + err.Error())
+		return nil, fmt.Errorf("failed to load fonts: %w", err)
 	}
 
 	for _, font := range fonts {
@@ -574,7 +574,7 @@ func GetMetadataDeps(route *meta.Route, session *sess.Session) (*preload.Preload
 	var routeAssignments meta.RouteAssignmentCollection
 	err = bundle.LoadAllFromAny(&routeAssignments, nil, session, nil)
 	if err != nil {
-		return nil, errors.New("Failed to load route assignments: " + err.Error())
+		return nil, fmt.Errorf("failed to load route assignments: %w", err)
 	}
 
 	routes := []meta.BundleableItem{}
@@ -602,14 +602,14 @@ func GetMetadataDeps(route *meta.Route, session *sess.Session) (*preload.Preload
 		AllowMissingItems: true,
 	}, session, nil)
 	if err != nil {
-		return nil, errors.New("Failed to load routes for route assignments: " + err.Error())
+		return nil, fmt.Errorf("failed to load routes for route assignments: %w", err)
 	}
 
 	err = bundle.LoadMany(collections, &bundlestore.GetManyItemsOptions{
 		AllowMissingItems: true,
 	}, session, nil)
 	if err != nil {
-		return nil, errors.New("Failed to load collections for route assignments: " + err.Error())
+		return nil, fmt.Errorf("failed to load collections for route assignments: %w", err)
 	}
 
 	for _, assignment := range routeAssignments {
@@ -707,12 +707,12 @@ func addStaticFileModstampsForWorkspaceToDeps(deps *preload.PreloadMetadata, wor
 	var files meta.FileCollection
 	err := bundle.LoadAllFromNamespaces([]string{workspace.GetAppFullName()}, &files, nil, session, nil)
 	if err != nil {
-		return errors.New("failed to load static files: " + err.Error())
+		return fmt.Errorf("failed to load static files: %w", err)
 	}
 	err = files.Loop(func(item meta.Item, index string) error {
 		file, ok := item.(*meta.File)
 		if !ok {
-			return errors.New("item is not a valid File")
+			return errors.New("item is not a valid file")
 		}
 		deps.StaticFile.AddItem(file)
 		return nil
@@ -949,7 +949,7 @@ func addComponentType(key string, deps *preload.PreloadMetadata, subViews map[st
 		case *meta.RuntimeComponentMetadata:
 			return (*meta.Component)(c), nil
 		default:
-			return nil, errors.New("Bad type for component metadata")
+			return nil, errors.New("bad type for component metadata")
 		}
 	}
 	// Load the Component meta info from bundle store

--- a/apps/platform/pkg/routing/routing.go
+++ b/apps/platform/pkg/routing/routing.go
@@ -78,12 +78,12 @@ func GetRouteFromPath(r *http.Request, namespace, path, prefix string, session *
 	routeMatch := &mux.RouteMatch{}
 
 	if matched := router.Match(r, routeMatch); !matched {
-		return nil, errors.New("No Route Match Found: " + path)
+		return nil, fmt.Errorf("no route match found: %s", path)
 	}
 
 	pathTemplate, err := routeMatch.Route.GetPathTemplate()
 	if err != nil {
-		return nil, errors.New("no Path Template found for route")
+		return nil, errors.New("no path template found for route")
 	}
 
 	pathTemplate = strings.Replace(pathTemplate, prefix, "", 1)
@@ -97,7 +97,7 @@ func GetRouteFromPath(r *http.Request, namespace, path, prefix string, session *
 		}
 	}
 	if route == nil {
-		return nil, errors.New("Error matching route")
+		return nil, errors.New("error matching route")
 	}
 	route.Path = path
 	// Inject all routeMatch vars, which are fully-resolved and can safely override anything in route params
@@ -109,7 +109,7 @@ func GetRouteFromPath(r *http.Request, namespace, path, prefix string, session *
 
 	params, err := ResolveRouteParams(route.Params, session, r.URL.Query())
 	if err != nil {
-		return nil, errors.New("unable to resolve route parameters: " + err.Error())
+		return nil, fmt.Errorf("unable to resolve route parameters: %w", err)
 	}
 	route.Params = params
 
@@ -136,7 +136,7 @@ func GetRouteFromAssignment(r *http.Request, namespace, collection string, viewt
 	}
 
 	if routeAssignment == nil {
-		return nil, errors.New("No route found with this collection and view type: " + namespace + "." + collection + " : " + viewtype)
+		return nil, fmt.Errorf("no route found with this collection and view type: %s.%s : %s", namespace, collection, viewtype)
 	}
 
 	route, err := meta.NewRoute(routeAssignment.RouteRef)

--- a/apps/platform/pkg/secretstore/environment/environment.go
+++ b/apps/platform/pkg/secretstore/environment/environment.go
@@ -27,7 +27,7 @@ var secretValues = map[string]string{
 func (ss *SecretStore) Get(key string, session *sess.Session) (*meta.SecretStoreValue, error) {
 	value, ok := secretValues[key]
 	if !ok {
-		return nil, exceptions.NewNotFoundException("Secret Value not found: " + key)
+		return nil, exceptions.NewNotFoundException("secret value not found: " + key)
 	}
 	return &meta.SecretStoreValue{
 		Value: value,
@@ -36,9 +36,9 @@ func (ss *SecretStore) Get(key string, session *sess.Session) (*meta.SecretStore
 }
 
 func (ss *SecretStore) Set(key, value string, session *sess.Session) error {
-	return errors.New("You cannot set secret values in the environment store")
+	return errors.New("you cannot set secret values in the environment store")
 }
 
 func (ss *SecretStore) Remove(key string, session *sess.Session) error {
-	return errors.New("You cannot remove secret values in the environment store")
+	return errors.New("you cannot remove secret values in the environment store")
 }

--- a/apps/platform/pkg/secretstore/secretstore.go
+++ b/apps/platform/pkg/secretstore/secretstore.go
@@ -1,7 +1,6 @@
 package secretstore
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -23,7 +22,7 @@ var secretStoreMap = map[string]SecretStore{}
 func GetSecretStore(secretStoreType string) (SecretStore, error) {
 	secretStore, ok := secretStoreMap[secretStoreType]
 	if !ok {
-		return nil, errors.New("Invalid secret store type: " + secretStoreType)
+		return nil, fmt.Errorf("invalid secret store type: %s", secretStoreType)
 	}
 	return secretStore, nil
 }

--- a/apps/platform/pkg/sess/session.go
+++ b/apps/platform/pkg/sess/session.go
@@ -287,11 +287,11 @@ func (s *Session) SetVersionSession(version *VersionSession) *Session {
 }
 
 func MakeSiteTenantID(ID string) string {
-	return fmt.Sprintf("site:%s", ID)
+	return "site:" + ID
 }
 
 func MakeWorkspaceTenantID(ID string) string {
-	return fmt.Sprintf("workspace:%s", ID)
+	return "workspace:" + ID
 }
 
 func (s *Session) GetTenantIDForCollection(collectionKey string) string {

--- a/apps/platform/pkg/sess/session.go
+++ b/apps/platform/pkg/sess/session.go
@@ -2,7 +2,6 @@ package sess
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"sort"
 	"time"

--- a/apps/platform/pkg/templating/templating.go
+++ b/apps/platform/pkg/templating/templating.go
@@ -2,7 +2,7 @@ package templating
 
 import (
 	"bytes"
-	"errors"
+	"fmt"
 	"regexp"
 	"strings"
 	"text/template"
@@ -13,13 +13,13 @@ const defaultTemplateKey = "__default__"
 func ValidKeyFunc(m map[string]any, key string) (any, error) {
 	val, ok := m[key]
 	if !ok {
-		return nil, errors.New("missing key " + key)
+		return nil, fmt.Errorf("missing key: %s", key)
 	}
 	return val, nil
 }
 
 func ForceErrorFunc(m any, key string) (any, error) {
-	return nil, errors.New("This template function is not allowed: " + key)
+	return nil, fmt.Errorf("this template function is not allowed: %s", key)
 }
 
 func NewTemplateWithValidKeysOnly(templateString string) (*template.Template, error) {

--- a/apps/platform/pkg/templating/templating_test.go
+++ b/apps/platform/pkg/templating/templating_test.go
@@ -8,7 +8,7 @@ func TestNew(t *testing.T) {
 	t.Run("Sanity check template creation", func(t *testing.T) {
 		_, err := NewTemplateWithValidKeysOnly("example")
 		if err != nil {
-			t.Errorf("Failed to parse simple template")
+			t.Errorf("failed to parse simple template")
 		}
 	})
 }

--- a/apps/platform/pkg/translate/translate.go
+++ b/apps/platform/pkg/translate/translate.go
@@ -1,7 +1,7 @@
 package translate
 
 import (
-	"errors"
+	"fmt"
 
 	"github.com/thecloudmasters/uesio/pkg/bundle"
 	"github.com/thecloudmasters/uesio/pkg/bundlestore"
@@ -19,7 +19,7 @@ func GetTranslatedLabels(session *sess.Session) (map[string]string, error) {
 	var labels meta.LabelCollection
 	err := bundle.LoadAllFromAny(&labels, nil, session, nil)
 	if err != nil {
-		return nil, errors.New("Failed to load labels: " + err.Error())
+		return nil, fmt.Errorf("failed to load labels: %w", err)
 	}
 
 	var translations meta.TranslationCollection
@@ -31,7 +31,7 @@ func GetTranslatedLabels(session *sess.Session) (map[string]string, error) {
 		}, session, nil)
 
 		if err != nil {
-			return nil, errors.New("Failed to load translations: " + err.Error())
+			return nil, fmt.Errorf("failed to load translations: %w", err)
 		}
 	}
 

--- a/apps/platform/pkg/truncate/truncate.go
+++ b/apps/platform/pkg/truncate/truncate.go
@@ -1,7 +1,7 @@
 package truncate
 
 import (
-	"errors"
+	"fmt"
 
 	"github.com/thecloudmasters/uesio/pkg/constant"
 	"github.com/thecloudmasters/uesio/pkg/datasource"
@@ -17,18 +17,18 @@ func TruncateWorkspaceData(tenantID string, session *sess.Session) error {
 	}
 
 	if tenantID == "site:uesio/studio:prod" {
-		return exceptions.NewForbiddenException("cannot truncate Studio site data")
+		return exceptions.NewForbiddenException("cannot truncate studio site data")
 	}
 
 	if !session.GetSitePermissions().HasNamedPermission(constant.WorkspaceAdminPerm) {
-		return exceptions.NewForbiddenException("you must be a Studio workspace admin to truncate workspace data")
+		return exceptions.NewForbiddenException("you must be a studio workspace admin to truncate workspace data")
 	}
 
 	err := datasource.WithTransaction(session, nil, func(conn wire.Connection) error {
 		return conn.TruncateTenantData(tenantID)
 	})
 	if err != nil {
-		return errors.New("unable to truncate workspace data: " + err.Error())
+		return fmt.Errorf("unable to truncate workspace data: %w", err)
 	}
 
 	return nil

--- a/apps/platform/pkg/types/file/filemetadata.go
+++ b/apps/platform/pkg/types/file/filemetadata.go
@@ -25,12 +25,12 @@ func (m MetadataWrapper) MarshalJSON() ([]byte, error) {
 		MimeType string    `json:"mimetype"`
 	}
 
-	filePath := m.Metadata.Path()
+	filePath := m.Path()
 
 	return json.Marshal(metadataJSON{
-		FileSize: m.Metadata.ContentLength(),
+		FileSize: m.ContentLength(),
 		Path:     filePath,
-		Modified: m.Metadata.LastModified(),
+		Modified: m.LastModified(),
 		MimeType: mime.TypeByExtension(path.Ext(filePath)),
 	})
 }

--- a/apps/platform/pkg/types/wire/aggregate.go
+++ b/apps/platform/pkg/types/wire/aggregate.go
@@ -10,14 +10,14 @@ import (
 
 func GetAggregationFieldNames(aggregateFields []AggregationField, groupByFields []AggregationField, getDBAggregateFieldName func(*AggregationField) string) ([]string, error) {
 	if len(aggregateFields) == 0 {
-		return nil, errors.New("No aggregate fields selected")
+		return nil, errors.New("no aggregate fields selected")
 	}
 
 	i := 0
 	dbNames := make([]string, len(aggregateFields)+len(groupByFields))
 	for _, aggregation := range aggregateFields {
 		if aggregation.Function == "" {
-			return nil, errors.New("Missing function for aggregation field")
+			return nil, errors.New("missing function for aggregation field")
 		}
 		dbNames[i] = getDBAggregateFieldName(&aggregation)
 		i++
@@ -33,7 +33,7 @@ func GetAggregationFieldNames(aggregateFields []AggregationField, groupByFields 
 func GetGroupBySelects(groupByFields []AggregationField, getDBGroupByFieldName func(*AggregationField) string) (string, error) {
 
 	if len(groupByFields) == 0 {
-		return "", errors.New("No group by fields selected")
+		return "", errors.New("no group by fields selected")
 	}
 
 	i := 0
@@ -49,7 +49,7 @@ func GetGroupBySelects(groupByFields []AggregationField, getDBGroupByFieldName f
 func GetGroupByClause(groupByFields []AggregationField, prefix string, getDBGroupByFieldName func(*AggregationField) string) (string, error) {
 
 	if len(groupByFields) == 0 {
-		return "", errors.New("No group by fields selected")
+		return "", errors.New("no group by fields selected")
 	}
 
 	if prefix == "" {

--- a/apps/platform/pkg/types/wire/condition.go
+++ b/apps/platform/pkg/types/wire/condition.go
@@ -62,7 +62,7 @@ func GetStringSlice(input any) ([]string, error) {
 		for _, value := range sliceInterface {
 			stringValue, ok := value.(string)
 			if !ok {
-				return nil, errors.New("Invalid Parameter Value")
+				return nil, errors.New("invalid parameter value")
 			}
 			sliceString = append(sliceString, stringValue)
 		}
@@ -71,7 +71,7 @@ func GetStringSlice(input any) ([]string, error) {
 
 	repeaterString, ok := input.(string)
 	if !ok {
-		return nil, errors.New("Invalid Parameter Value")
+		return nil, errors.New("invalid parameter value")
 	}
 	return strings.Split(repeaterString, ","), nil
 }

--- a/apps/platform/pkg/types/wire/dependency.go
+++ b/apps/platform/pkg/types/wire/dependency.go
@@ -1,7 +1,7 @@
 package wire
 
 import (
-	"errors"
+	"fmt"
 
 	"github.com/thecloudmasters/uesio/pkg/meta"
 )
@@ -21,7 +21,7 @@ func (m *MetadataDependencyMap) AddMap(keys map[string]bool, metadataType string
 func (m *MetadataDependencyMap) AddRequired(change *ChangeItem, metadataType, fieldName string) error {
 	metadataName, err := change.GetFieldAsString(fieldName)
 	if err != nil || metadataName == "" {
-		return errors.New("Missing metadata item in field: " + fieldName)
+		return fmt.Errorf("missing metadata item in field: %s", fieldName)
 	}
 	return m.AddItem(metadataType, metadataName)
 }

--- a/apps/platform/pkg/types/wire/item.go
+++ b/apps/platform/pkg/types/wire/item.go
@@ -1,7 +1,6 @@
 package wire
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
@@ -21,7 +20,7 @@ func (i *Item) GetField(fieldName string) (any, error) {
 	if len(names) == 1 {
 		value, ok := (*i)[fieldName]
 		if !ok {
-			return nil, errors.New("Field not found: " + fieldName)
+			return nil, fmt.Errorf("field not found: %s", fieldName)
 		}
 		return value, nil
 	}
@@ -33,7 +32,7 @@ func (i *Item) GetField(fieldName string) (any, error) {
 		var err error
 		value, err = GetFieldValue(value, name)
 		if err != nil {
-			return nil, errors.New("Field Path not found: " + fieldName)
+			return nil, fmt.Errorf("field path not found: %s", fieldName)
 		}
 	}
 
@@ -47,7 +46,7 @@ func (i *Item) GetFieldAsString(fieldName string) (string, error) {
 	}
 	valueString, ok := value.(string)
 	if !ok {
-		return "", fmt.Errorf("Cannot get field as string: %T", value)
+		return "", fmt.Errorf("cannot get field as string: %T", value)
 	}
 	return valueString, nil
 }

--- a/apps/platform/pkg/types/wire/load.go
+++ b/apps/platform/pkg/types/wire/load.go
@@ -113,14 +113,14 @@ func (op *LoadOp) GetIntegrationConnection() (*IntegrationConnection, error) {
 	if op.integrationConnection != nil {
 		return op.integrationConnection, nil
 	}
-	return nil, errors.New("integrationConnection not available on LoadOp")
+	return nil, errors.New("integration connection not available on load op")
 }
 
 func (op *LoadOp) GetCollectionMetadata() (*CollectionMetadata, error) {
 	if op.metadata != nil {
 		return op.metadata.GetCollection(op.CollectionName)
 	}
-	return nil, errors.New("no collection metadata available on LoadOp")
+	return nil, errors.New("no collection metadata available on load op")
 
 }
 
@@ -128,7 +128,7 @@ func (op *LoadOp) GetMetadata() (*MetadataCache, error) {
 	if op.metadata != nil {
 		return op.metadata, nil
 	}
-	return nil, errors.New("no metadata available on LoadOp")
+	return nil, errors.New("no metadata available on load op")
 }
 
 func (op *LoadOp) AttachMetadataCache(response *MetadataCache) *LoadOp {
@@ -189,7 +189,7 @@ type FieldsResponse struct {
 
 func GetUniqueDBFieldNames(fieldsMap map[string]*FieldMetadata, getDBFieldName func(*FieldMetadata) string) ([]string, error) {
 	if len(fieldsMap) == 0 {
-		return nil, errors.New("No fields selected")
+		return nil, errors.New("no fields selected")
 	}
 
 	i := 0

--- a/apps/platform/pkg/types/wire/metadata.go
+++ b/apps/platform/pkg/types/wire/metadata.go
@@ -2,7 +2,6 @@ package wire
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strings"
 
@@ -27,7 +26,7 @@ func (mc *MetadataCache) AddCollection(key string, metadata *CollectionMetadata)
 func (mc *MetadataCache) GetCollection(key string) (*CollectionMetadata, error) {
 	collectionMetadata, ok := mc.Collections[key]
 	if !ok {
-		return nil, errors.New("No metadata provided for collection: " + key)
+		return nil, fmt.Errorf("no metadata provided for collection: %s", key)
 	}
 	return collectionMetadata, nil
 }
@@ -42,7 +41,7 @@ func (mc *MetadataCache) AddSelectList(key string, metadata *SelectListMetadata)
 func (mc *MetadataCache) GetSelectList(key string) (*SelectListMetadata, error) {
 	selectListMetadata, ok := mc.selectLists[key]
 	if !ok {
-		return nil, errors.New("No metadata found for select list: " + key)
+		return nil, fmt.Errorf("no metadata found for select list: %s", key)
 	}
 	return selectListMetadata, nil
 }
@@ -176,7 +175,7 @@ func (cm *CollectionMetadata) GetFieldWithMetadata(key string, metadata *Metadat
 	if len(names) == 1 {
 		fieldMetadata, ok := cm.Fields[meta.GetFullyQualifiedKey(key, cm.Namespace)]
 		if !ok {
-			return nil, errors.New("No metadata provided for field: " + key + " in collection: " + cm.Name)
+			return nil, fmt.Errorf("no metadata provided for field: %s in collection: %s", key, cm.Name)
 		}
 		return fieldMetadata, nil
 	}
@@ -184,12 +183,12 @@ func (cm *CollectionMetadata) GetFieldWithMetadata(key string, metadata *Metadat
 
 	fieldMetadata, err := cm.GetField(meta.GetFullyQualifiedKey(mainFieldName, cm.Namespace))
 	if err != nil {
-		return nil, errors.New("No metadata provided for field: " + key + " in collection: " + cm.Name)
+		return nil, fmt.Errorf("no metadata provided for field: %s in collection: %s", key, cm.Name)
 	}
 
 	if IsReference(fieldMetadata.Type) {
 		if metadata == nil {
-			return nil, errors.New("no metadata found for reference field: " + mainFieldName)
+			return nil, fmt.Errorf("no metadata found for reference field: %s", mainFieldName)
 		}
 		if refCollectionMetadata, err := metadata.GetCollection(fieldMetadata.ReferenceMetadata.GetCollection()); err != nil {
 			return nil, err
@@ -201,7 +200,7 @@ func (cm *CollectionMetadata) GetFieldWithMetadata(key string, metadata *Metadat
 		var subFieldMetadata *FieldMetadata
 		for _, namePart := range names[1:] {
 			if tmp, exists := fieldMetadata.SubFields[namePart]; !exists {
-				return nil, fmt.Errorf("subfield '%s' doesn't exist on Struct field: '%s'.", namePart, mainFieldName)
+				return nil, fmt.Errorf("subfield '%s' doesn't exist on Struct field: '%s'", namePart, mainFieldName)
 			} else {
 				subFieldMetadata = tmp
 			}
@@ -429,14 +428,14 @@ func (fm *FieldMetadata) GetSubField(key string) (*FieldMetadata, error) {
 	if len(names) == 1 {
 		fieldMetadata, ok := fm.SubFields[key]
 		if !ok {
-			return nil, errors.New("No metadata provided for sub-field: " + key + " in collection: " + fm.Name)
+			return nil, fmt.Errorf("no metadata provided for sub-field: %s in collection: %s", key, fm.Name)
 		}
 		return fieldMetadata, nil
 	}
 
 	fieldMetadata, err := fm.GetSubField(names[0])
 	if err != nil {
-		return nil, errors.New("No metadata provided for sub-field: " + key + " in collection: " + fm.Name)
+		return nil, fmt.Errorf("no metadata provided for sub-field: %s in collection: %s", key, fm.Name)
 	}
 
 	return fieldMetadata.GetSubField(strings.Join(names[1:], constant.RefSep))

--- a/apps/platform/pkg/types/wire/save.go
+++ b/apps/platform/pkg/types/wire/save.go
@@ -216,7 +216,7 @@ func (ci *ChangeItem) MarshalJSONObject(enc *gojay.Encoder) {
 
 		jsonValue, err := json.Marshal(value)
 		if err != nil {
-			return errors.New("Error getting json value: " + fieldMetadata.GetFullName())
+			return fmt.Errorf("error getting json value: %s", fieldMetadata.GetFullName())
 		}
 		ej := gojay.EmbeddedJSON(jsonValue)
 		enc.AddEmbeddedJSONKey(fieldID, &ej)
@@ -453,7 +453,7 @@ func NewFieldChanges(templateString string, collectionMetadata *CollectionMetada
 		}
 		val, err := item.GetField(key)
 		if err != nil {
-			return nil, errors.New("missing key " + key + " : " + collectionMetadata.GetFullName() + " : " + templateString)
+			return nil, fmt.Errorf("missing key %s : %s : %s", key, collectionMetadata.GetFullName(), templateString)
 		}
 		if IsReference(fieldMetadata.Type) {
 			key, err := GetReferenceKey(val)
@@ -461,7 +461,7 @@ func NewFieldChanges(templateString string, collectionMetadata *CollectionMetada
 				return nil, err
 			}
 			if key == "" {
-				return nil, errors.New("Bad Reference Key in template: " + templateString)
+				return nil, fmt.Errorf("bad reference key in template: %s", templateString)
 			}
 			return key, nil
 		}

--- a/apps/platform/pkg/usage/usage.go
+++ b/apps/platform/pkg/usage/usage.go
@@ -18,11 +18,12 @@ var activeHandler string
 
 func init() {
 	usageHandler := os.Getenv("UESIO_USAGE_HANDLER")
-	if usageHandler == "redis" {
+	switch usageHandler {
+	case "redis":
 		activeHandler = "redis"
-	} else if usageHandler == "" || usageHandler == "memory" {
+	case "", "memory":
 		activeHandler = "memory"
-	} else {
+	default:
 		// TODO: The panic here is not ideal but do the way we use init throughout the
 		// codebase we can't handle errors and would only panic anyway.  Need to
 		// refactor how we initialize so that we can improve error handling and avoid
@@ -48,7 +49,7 @@ func RegisterEvent(actiontype, metadatatype, metadataname string, size int64, se
 	}
 
 	if user.ID == "" {
-		return fmt.Errorf("Error Registering Usage Event: Empty User ID")
+		return fmt.Errorf("error registering usage event: empty user id")
 	}
 
 	currentTime := time.Now()

--- a/apps/platform/pkg/usage/usage.go
+++ b/apps/platform/pkg/usage/usage.go
@@ -49,7 +49,7 @@ func RegisterEvent(actiontype, metadatatype, metadataname string, size int64, se
 	}
 
 	if user.ID == "" {
-		return fmt.Errorf("error registering usage event: empty user id")
+		return errors.New("error registering usage event: empty user id")
 	}
 
 	currentTime := time.Now()

--- a/apps/platform/pkg/usage/usage.go
+++ b/apps/platform/pkg/usage/usage.go
@@ -1,6 +1,7 @@
 package usage
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"time"

--- a/apps/platform/pkg/usage/usage_common/usage_common.go
+++ b/apps/platform/pkg/usage/usage_common/usage_common.go
@@ -32,10 +32,10 @@ func SaveBatch(usage meta.UsageCollection, session *sess.Session) error {
 
 	err := datasource.SaveWithOptions(requests, session, nil)
 	if err != nil {
-		return fmt.Errorf("Failed to update usage events: %w : %v", err, len(usage))
+		return fmt.Errorf("failed to update usage events: %w : %v", err, len(usage))
 	}
 
-	slog.Info(fmt.Sprintf("Successfully processed %d usage events", len(usage)))
+	slog.Info(fmt.Sprintf("successfully processed %d usage events", len(usage)))
 	return nil
 
 }
@@ -47,7 +47,7 @@ func GetUsageItem(key string, value int64) *meta.Usage {
 	}
 	keyParts := strings.Split(key, ":")
 	if len(keyParts) != 9 {
-		slog.Error("Usage key did not match expected pattern: " + key)
+		slog.Error("usage key did not match expected pattern: " + key)
 		return nil
 	}
 

--- a/apps/platform/pkg/usage/usage_redis/usage_redis.go
+++ b/apps/platform/pkg/usage/usage_redis/usage_redis.go
@@ -32,11 +32,11 @@ func (ruh *RedisUsageHandler) ApplyBatch(session *sess.Session) error {
 	// in order to ensure that a subsequent job processes them.
 	keys, err := redis.Strings(conn.Do("SPOP", KEYS_SET_NAME, MAX_USAGE_PER_RUN))
 	if err != nil {
-		return fmt.Errorf("Error getting usage set members: %w", err)
+		return fmt.Errorf("error getting usage set members: %w", err)
 	}
 
 	if len(keys) == 0 {
-		slog.Info("Job completed, no usage events to process")
+		slog.Info("job completed, no usage events to process")
 		return nil
 	}
 
@@ -44,7 +44,7 @@ func (ruh *RedisUsageHandler) ApplyBatch(session *sess.Session) error {
 
 	values, err := redis.Strings(conn.Do("MGET", keyArgs...))
 	if err != nil {
-		return fmt.Errorf("Error fetching usage keys: %w", err)
+		return fmt.Errorf("error fetching usage keys: %w", err)
 	}
 
 	changes := meta.UsageCollection{}
@@ -69,7 +69,7 @@ func (ruh *RedisUsageHandler) ApplyBatch(session *sess.Session) error {
 		originalError := err
 		// Restore the usage keys which we failed to process back to the set
 		_, err = conn.Do("SADD", redis.Args{}.Add(KEYS_SET_NAME).AddFlat(keys))
-		return fmt.Errorf("Failed to update usage events: %w : %w : %v", originalError, err, len(keys))
+		return fmt.Errorf("failed to update usage events: %w : %w : %v", originalError, err, len(keys))
 	}
 	return nil
 }
@@ -94,11 +94,11 @@ func setRedisUsage(key string, size int64) error {
 
 	err := conn.Flush()
 	if err != nil {
-		return fmt.Errorf("Error Setting cache value: %w", err)
+		return fmt.Errorf("error Setting cache value: %w", err)
 	}
 	_, err = conn.Receive()
 	if err != nil {
-		return fmt.Errorf("Error Setting cache value: %w", err)
+		return fmt.Errorf("error Setting cache value: %w", err)
 	}
 
 	return nil

--- a/apps/platform/pkg/usage/usage_worker/usage_worker.go
+++ b/apps/platform/pkg/usage/usage_worker/usage_worker.go
@@ -2,7 +2,7 @@ package usage_worker
 
 import (
 	"context"
-	"errors"
+	"fmt"
 	"log/slog"
 
 	"github.com/thecloudmasters/uesio/pkg/auth"
@@ -19,7 +19,7 @@ func UsageWorker(ctx context.Context) error {
 
 	session, err := auth.GetStudioSystemSession(ctx, nil)
 	if err != nil {
-		return errors.New("Unable to obtain a system session to use for usage events job: " + err.Error())
+		return fmt.Errorf("unable to obtain a system session to use for usage events job: %w", err)
 	}
 
 	err = usage.ApplyBatch(session)

--- a/apps/platform/pkg/validation/jsonschemas.go
+++ b/apps/platform/pkg/validation/jsonschemas.go
@@ -1,12 +1,12 @@
 package validation
 
 import (
-	"errors"
 	"fmt"
-	"github.com/xeipuuv/gojsonschema"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/xeipuuv/gojsonschema"
 )
 
 var schemasCache = map[string]*gojsonschema.Schema{}
@@ -44,15 +44,15 @@ func loadSchemaFromStaticFile(uri string) (*gojsonschema.Schema, error) {
 	resolvedPath := filepath.Join(baseDir, "../../dist", requestPath)
 	fileBody, err := os.ReadFile(resolvedPath)
 	if err != nil {
-		return nil, errors.New("unable to load schema file from uri: " + uri)
+		return nil, fmt.Errorf("unable to load schema file from uri: %s", uri)
 	}
 	jsonLoader := gojsonschema.NewBytesLoader(fileBody)
 	if jsonLoader == nil {
-		return nil, errors.New("unable to parse schema file from uri: " + uri)
+		return nil, fmt.Errorf("unable to parse schema file from uri: %s", uri)
 	}
 	schema, err := gojsonschema.NewSchema(jsonLoader)
 	if err != nil {
-		return nil, errors.New("unable to parse schema file from uri: " + uri)
+		return nil, fmt.Errorf("unable to parse schema file from uri: %s", uri)
 	}
 	AddSchema(uri, schema)
 	return schema, nil

--- a/libs/apps/uesio/studio/bundle/bots/load/loadexternalbundleversion/bot.ts
+++ b/libs/apps/uesio/studio/bundle/bots/load/loadexternalbundleversion/bot.ts
@@ -21,7 +21,7 @@ export default function loadexternalbundleversion(bot: LoadBotApi) {
     | undefined
 
   if (!bundleVersionValue) {
-    bot.addError("Missing Uniquekey")
+    bot.addError("missing unique key")
     return
   }
 

--- a/libs/ui/test/wire/wireinit.spec.ts
+++ b/libs/ui/test/wire/wireinit.spec.ts
@@ -66,10 +66,10 @@ test("regular wire with view-only field and collection field", () => {
     },
   })
   const myWire = context.getWire(wireId)
-  if (!myWire) throw new Error("Wire not created")
+  if (!myWire) throw new Error("wire not created")
 
   const myCollection = myWire.getCollection()
-  if (!myCollection) throw new Error("Collection not created")
+  if (!myCollection) throw new Error("collection not created")
 
   const viewOnlyField = myCollection.getField("myfield")
   if (!viewOnlyField) throw new Error("view only field not created")


### PR DESCRIPTION
# What does this PR do?

More linting fixes.

1. Uses consistent error message formatting. (no capitals and punctuation)
2. Uses `fmt.Errorf()` when relevant instead of concatenating strings.
3. Uses switch statements instead of else if.
4. Other minor linting changes.

# Testing

Automated tests should cover.