### PR TITLE
fix: permission set editor bug

### DIFF
--- a/libs/apps/uesio/studio/bundle/components/multipermissionpicker.yaml
+++ b/libs/apps/uesio/studio/bundle/components/multipermissionpicker.yaml
@@ -15,3 +15,5 @@ variants:
   - uesio/io.table:uesio/io.default
   - uesio/io.fieldwrapper:uesio/io.table
   - uesio/io.table:uesio/appkit.main
+components:
+  - uesio/studio.item_metadata

--- a/libs/apps/uesio/studio/bundle/components/permissionmapeditor.yaml
+++ b/libs/apps/uesio/studio/bundle/components/permissionmapeditor.yaml
@@ -58,5 +58,4 @@ definition:
             sourceWires:
               - $Prop{metadataRecordsWireName}
             permissionFields:
-              - type: CHECKBOX
-                label: $Prop{accessFieldLabel}
+              - label: $Prop{accessFieldLabel}

--- a/libs/apps/uesio/studio/bundle/views/permissionset.yaml
+++ b/libs/apps/uesio/studio/bundle/views/permissionset.yaml
@@ -283,25 +283,16 @@ definition:
                                           permissionFields:
                                             - name: read
                                               label: Read
-                                              type: CHECKBOX
                                             - name: create
                                               label: Create
-                                              type: CHECKBOX
                                             - name: edit
                                               label: Edit
-                                              type: CHECKBOX
                                             - name: delete
                                               label: Delete
-                                              type: CHECKBOX
                                             - name: modifyall
                                               label: Modify all
-                                              type: CHECKBOX
                                             - name: viewall
                                               label: View all
-                                              type: CHECKBOX
-                                            - name: fields
-                                              label: Fields
-                                              type: MAP
                             - id: integrationactions
                               label: Integration Actions
                               uesio.display:
@@ -352,10 +343,6 @@ definition:
                                           permissionFields:
                                             - name: allowAllActions
                                               label: Allow all Actions provided by this Integration
-                                              type: CHECKBOX
-                                            - name: actions
-                                              label: Action Access
-                                              type: MAP
                 - uesio/appkit.section_audit_info:
                 - uesio/appkit.section_delete:
                     confirm: true

--- a/libs/apps/uesio/studio/bundle/views/permissionsetcollection.yaml
+++ b/libs/apps/uesio/studio/bundle/views/permissionsetcollection.yaml
@@ -38,16 +38,29 @@ definition:
         uesio/studio.namespace:
           type: TEXT
           label: Namespace
+        uesio/studio.label:
+          type: TEXT
+          label: Label
+        uesio/studio.appicon:
+          type: TEXT
+          label: App Icon
+        uesio/studio.appcolor:
+          type: TEXT
+          label: App Color
       init:
         create: true
         query: false
       defaults:
         - field: uesio/studio.name
-          valueSource: VALUE
           value: "owner"
         - field: uesio/studio.namespace
-          valueSource: VALUE
           value: "uesio/core"
+        - field: uesio/studio.label
+          value: "Owner"
+        - field: uesio/studio.appicon
+          value: "hub"
+        - field: uesio/studio.appcolor
+          value: "#a05195"
   # Components are how we describe the layout of our view
   components:
     - uesio/io.viewlayout:
@@ -73,14 +86,14 @@ definition:
               mode: READ
               components:
                 - uesio/io.titlebar:
-                    uesio.variant: uesio/io.main
+                    uesio.variant: uesio/appkit.main
                     title: Permission Set - ${uesio/studio.name}
                     subtitle: $Param{namespace}
                     actions:
                       - uesio/io.group:
                           components:
                             - uesio/io.button:
-                                uesio.variant: uesio/io.secondary
+                                uesio.variant: uesio/appkit.secondary
                                 text: $Label{uesio/io.edit}
                                 uesio.display:
                                   - type: fieldMode
@@ -101,7 +114,7 @@ definition:
                                     targettype: specific
                                     componentid: fieldPerms-table
                             - uesio/io.button:
-                                uesio.variant: uesio/io.primary
+                                uesio.variant: uesio/appkit.primary
                                 text: $Label{uesio/io.save}
                                 uesio.display:
                                   - type: wireHasChanges
@@ -121,7 +134,7 @@ definition:
                                     targettype: specific
                                     componentid: fieldPerms-table
                             - uesio/io.button:
-                                uesio.variant: uesio/io.secondary
+                                uesio.variant: uesio/appkit.secondary
                                 text: $Label{uesio/io.cancel}
                                 uesio.display:
                                   - type: fieldMode
@@ -140,7 +153,7 @@ definition:
                                     targettype: specific
                                     componentid: fieldPerms-table
                 - uesio/io.box:
-                    uesio.variant: uesio/io.section
+                    uesio.variant: uesio/appkit.primarysection
                     components:
                       - uesio/io.titlebar:
                           title: Fields
@@ -162,7 +175,5 @@ definition:
                                 permissionFields:
                                   - name: read
                                     label: Read
-                                    type: CHECKBOX
                                   - name: edit
                                     label: Edit
-                                    type: CHECKBOX

--- a/libs/apps/uesio/studio/bundle/views/permissionsetintegration.yaml
+++ b/libs/apps/uesio/studio/bundle/views/permissionsetintegration.yaml
@@ -62,14 +62,14 @@ definition:
               mode: READ
               components:
                 - uesio/io.titlebar:
-                    uesio.variant: uesio/io.main
+                    uesio.variant: uesio/appkit.main
                     title: Permission Set - ${uesio/studio.name}
                     subtitle: $Param{namespace}
                     actions:
                       - uesio/io.group:
                           components:
                             - uesio/io.button:
-                                uesio.variant: uesio/io.secondary
+                                uesio.variant: uesio/appkit.secondary
                                 text: $Label{uesio/io.edit}
                                 uesio.display:
                                   - type: fieldMode
@@ -90,7 +90,7 @@ definition:
                                     targettype: specific
                                     componentid: integrationActionPerms-table
                             - uesio/io.button:
-                                uesio.variant: uesio/io.primary
+                                uesio.variant: uesio/appkit.primary
                                 text: $Label{uesio/io.save}
                                 uesio.display:
                                   - type: wireHasChanges
@@ -110,7 +110,7 @@ definition:
                                     targettype: specific
                                     componentid: integrationActionPerms-table
                             - uesio/io.button:
-                                uesio.variant: uesio/io.secondary
+                                uesio.variant: uesio/appkit.secondary
                                 text: $Label{uesio/io.cancel}
                                 uesio.display:
                                   - type: fieldMode
@@ -129,7 +129,7 @@ definition:
                                     targettype: specific
                                     componentid: integrationActionPerms-table
                 - uesio/io.box:
-                    uesio.variant: uesio/io.section
+                    uesio.variant: uesio/appkit.primarysection
                     components:
                       - uesio/io.titlebar:
                           title: Integration Actions
@@ -148,4 +148,3 @@ definition:
                                   - integrationActions
                                 permissionFields:
                                   - label: Allow access to this Action
-                                    type: CHECKBOX


### PR DESCRIPTION
# What does this PR do?

Fixes a bug in the permission set editor where previous permissions were wiped out when a new permission checkbox was selected.

Resolves https://github.com/ues-io/uesio/issues/4868