### PR TITLE
feat: add bundledefs to bundle cache

### DIFF
--- a/apps/platform/pkg/bundlestore/filebundlestore/filebundlestore.go
+++ b/apps/platform/pkg/bundlestore/filebundlestore/filebundlestore.go
@@ -262,6 +262,13 @@ func (b *FileBundleStoreConnection) DeleteBundle() error {
 }
 
 func (b *FileBundleStoreConnection) GetBundleDef() (*meta.BundleDef, error) {
+
+	if b.Cache != nil {
+		if cachedItem, ok := b.Cache.GetBundleDefFromCache(b.Namespace, b.Version); ok {
+			return cachedItem, nil
+		}
+	}
+
 	var by meta.BundleDef
 	buf := &bytes.Buffer{}
 	_, err := b.download(buf, filepath.Join(b.PathFunc(b.Namespace, b.Version), "", "bundle.yaml"))
@@ -272,6 +279,13 @@ func (b *FileBundleStoreConnection) GetBundleDef() (*meta.BundleDef, error) {
 	err = bundlestore.DecodeYAML(&by, buf)
 	if err != nil {
 		return nil, err
+	}
+
+	if b.Cache != nil {
+		err := b.Cache.AddBundleDefToCache(b.Namespace, b.Version, &by)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return &by, nil
 }


### PR DESCRIPTION
# What does this PR do?

We cache bundle file paths and individual bundle items, but we never implemented a cache for bundle definitions (the bundle.yaml file). This was causing a local file system / s3 load every time we went to get metadata.

This PR implements a cache for package bundle definitions.