### PR TITLE
feat: serve any componentpack file

### DIFF
--- a/apps/platform/pkg/cmd/serve.go
+++ b/apps/platform/pkg/cmd/serve.go
@@ -280,8 +280,7 @@ func serve(cmd *cobra.Command, args []string) error {
 	sr.HandleFunc(routeByKey, controller.RouteByKey).Methods(http.MethodGet)
 	wr.HandleFunc(routeByKey, controller.RouteByKey).Methods(http.MethodGet)
 
-	// NOTE: Gorilla Mux requires use of non-capturing groups, hence the use of ?: here
-	componentPackFileSuffix := "/{filename:[a-zA-Z0-9\\-_]+\\.(?:json|js|xml|txt|css){1}(?:\\.map)?}"
+	componentPackFileSuffix := "/{filename:.*}"
 
 	// Versioned component pack file routes
 	versionedComponentPackPath := "/componentpacks/" + versionedItemParam

--- a/apps/platform/pkg/controller/file/componentpack.go
+++ b/apps/platform/pkg/controller/file/componentpack.go
@@ -3,7 +3,6 @@ package file
 import (
 	"bytes"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -49,16 +48,8 @@ func ServeComponentPackFile(w http.ResponseWriter, r *http.Request) {
 		lastModified = time.Unix(componentPack.UpdatedAt, 0)
 	}
 
-	usePath := "pack.js"
-	if path != "runtime.js" && strings.HasSuffix(path, ".json") {
-		usePath = path
-	}
-	if path == "runtime.css" {
-		usePath = path
-	}
-
 	respondFile(w, r, &FileRequest{
-		Path:         usePath,
+		Path:         path,
 		LastModified: lastModified,
 		Namespace:    namespace,
 		Version:      resourceVersion,


### PR DESCRIPTION
# What does this PR do?

Allows any file within a component pack to be served.

Previously, serving files from within a componentpack was limited to the regex `[a-zA-Z0-9\\-_]+\\.(?:json|js|xml|txt|css){1}(?:\\.map)?}"` so in short, only files with a single `.` and were of the listed extensions could be served.  This limitations seems to be somewhat historical but presents issues when componentpacks need to contain other files that need to be served.  

There does not seem to be any reason for limiting the files served from a component pack (the component pack review process should vet and discover anything that it not appropriate) so in order to support all uses cases, any file inside of a componentpack can be served.

Additionally, the `Content-Disposition` header `filename` property will contain the actual filename of the file being served instead of the generic `pack.js`.  The `Content-Disposition` isn't really required since files within the component pack aren't being "downloaded" via the browser but leaving the `filename` property in-place for now, just with the correct name of the file. 

# Testing

Tested locally and all tests pass.  e2e & ci will cover rest.
