### PR TITLE
chore: update major eslint-plugin-cypress 5.1.0

### DIFF
--- a/apps/platform-e2e/eslint.config.mjs
+++ b/apps/platform-e2e/eslint.config.mjs
@@ -1,4 +1,4 @@
-import cypress from "eslint-plugin-cypress/flat"
+import cypress from "eslint-plugin-cypress"
 import baseConfig from "../../eslint.config.mjs"
 
 /** @type {import('@typescript-eslint/utils/ts-eslint').FlatConfig.Config[]} */

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,7 @@
         "esbuild": "^0.25.5",
         "eslint": "^9.28.0",
         "eslint-config-prettier": "^10.1.5",
-        "eslint-plugin-cypress": "^4.3.0",
+        "eslint-plugin-cypress": "^5.1.0",
         "eslint-plugin-import": "^2.31.0",
         "eslint-plugin-jsx-a11y": "^6.10.2",
         "eslint-plugin-react": "^7.37.5",
@@ -11340,16 +11340,29 @@
       }
     },
     "node_modules/eslint-plugin-cypress": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-cypress/-/eslint-plugin-cypress-4.3.0.tgz",
-      "integrity": "sha512-CgS/S940MJlT8jtnWGKI0LvZQBGb/BB0QCpgBOxFMM/Z6znD+PZUwBhCTwHKN2GEr5AOny3xB92an0QfzBGooQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-cypress/-/eslint-plugin-cypress-5.1.0.tgz",
+      "integrity": "sha512-tdLXm4aq9vX2hTtKJTUFD3gdNseMKqsf8+P6hI4TtOPdz1LU4xvTpQBd1++qPAsPZP2lyYh71B5mvzu2lBr4Ow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "globals": "^15.15.0"
+        "globals": "^16.2.0"
       },
       "peerDependencies": {
         "eslint": ">=9"
+      }
+    },
+    "node_modules/eslint-plugin-cypress/node_modules/globals": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-16.2.0.tgz",
+      "integrity": "sha512-O+7l9tPdHCU320IigZZPj5zmRCFG9xHmx9cU8FqU2Rp+JN714seHV+2S9+JslCpY4gJwU2vOGox0wzgae/MCEg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/eslint-plugin-import": {

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "esbuild": "^0.25.5",
     "eslint": "^9.28.0",
     "eslint-config-prettier": "^10.1.5",
-    "eslint-plugin-cypress": "^4.3.0",
+    "eslint-plugin-cypress": "^5.1.0",
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-react": "^7.37.5",


### PR DESCRIPTION
# What does this PR do?

Update major eslint-plugin-cypress 5.1.0

# Testing

ci & e2e will cover.
