### PR TITLE
fix bundle dependency error handling

### DIFF
--- a/apps/platform/pkg/bot/systemdialect/systembot_after_bundledependency.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_after_bundledependency.go
@@ -57,10 +57,10 @@ func runBundleDependencyAfterSaveBot(request *wire.SaveOp, connection wire.Conne
 			session,
 		)
 		if err != nil {
-			if exceptions.IsNotFoundException(err) {
-				// It's ok if we didn't find an existing license.
+			// It's ok if we didn't find an existing license.
+			if !exceptions.IsNotFoundException(err) {
+				return err
 			}
-			return err
 		}
 
 		if existingLicense.UniqueKey != "" {
@@ -89,10 +89,10 @@ func runBundleDependencyAfterSaveBot(request *wire.SaveOp, connection wire.Conne
 			session,
 		)
 		if err != nil {
-			if exceptions.IsNotFoundException(err) {
-				// It's ok if we didn't find a license template.
+			// It's ok if we didn't find a license template.
+			if !exceptions.IsNotFoundException(err) {
+				return err
 			}
-			return err
 		}
 
 		if lt.AutoCreate {

--- a/apps/platform/pkg/bot/systemdialect/systembot_after_bundledependency.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_after_bundledependency.go
@@ -8,6 +8,7 @@ import (
 	"github.com/thecloudmasters/uesio/pkg/datasource"
 	"github.com/thecloudmasters/uesio/pkg/meta"
 	"github.com/thecloudmasters/uesio/pkg/sess"
+	"github.com/thecloudmasters/uesio/pkg/types/exceptions"
 	"github.com/thecloudmasters/uesio/pkg/types/wire"
 )
 
@@ -41,7 +42,7 @@ func runBundleDependencyAfterSaveBot(request *wire.SaveOp, connection wire.Conne
 		visited[pairKey] = true
 
 		var existingLicense meta.License
-		datasource.PlatformLoadOne(
+		err = datasource.PlatformLoadOne(
 			&existingLicense,
 			&datasource.PlatformLoadOptions{
 				Connection: connection,
@@ -55,6 +56,12 @@ func runBundleDependencyAfterSaveBot(request *wire.SaveOp, connection wire.Conne
 			},
 			session,
 		)
+		if err != nil {
+			if exceptions.IsNotFoundException(err) {
+				// It's ok if we didn't find an existing license.
+			}
+			return err
+		}
 
 		if existingLicense.UniqueKey != "" {
 			// If the AppLicensed is nil, then this license is corrupted and needs to be recreated
@@ -68,7 +75,7 @@ func runBundleDependencyAfterSaveBot(request *wire.SaveOp, connection wire.Conne
 		}
 
 		var lt meta.LicenseTemplate
-		datasource.PlatformLoadOne(
+		err = datasource.PlatformLoadOne(
 			&lt,
 			&datasource.PlatformLoadOptions{
 				Connection: connection,
@@ -81,6 +88,12 @@ func runBundleDependencyAfterSaveBot(request *wire.SaveOp, connection wire.Conne
 			},
 			session,
 		)
+		if err != nil {
+			if exceptions.IsNotFoundException(err) {
+				// It's ok if we didn't find a license template.
+			}
+			return err
+		}
 
 		if lt.AutoCreate {
 			LicenseTemplateDeps = append(LicenseTemplateDeps, &wire.Item{


### PR DESCRIPTION
# What does this PR do?

Errors in queries for adding licenses were not handled correctly. We now handle any errors, except for the record not found error. Previously, we expected that error, but were not handling any other errors that may arise from those queries.
