### PR TITLE
feat: add after region to list and deck

### DIFF
--- a/libs/apps/uesio/io/bundle/componentpacks/main/src/components/deck/deck.tsx
+++ b/libs/apps/uesio/io/bundle/componentpacks/main/src/components/deck/deck.tsx
@@ -5,7 +5,6 @@ import { default as IOGrid } from "../../utilities/grid/grid"
 
 type DeckDefinition = {
   gridVariant?: metadata.MetadataKey
-  emptyState?: definition.DefinitionList
 } & ListDefinition
 
 const Deck: definition.UC<DeckDefinition> = (props) => {

--- a/libs/apps/uesio/io/bundle/componentpacks/main/src/components/list/list.tsx
+++ b/libs/apps/uesio/io/bundle/componentpacks/main/src/components/list/list.tsx
@@ -9,6 +9,7 @@ type ListDefinition = {
   recordDisplay?: component.DisplayCondition[]
   iterate?: boolean
   emptyState?: definition.DefinitionList
+  after?: definition.DefinitionList
 }
 
 const signals: Record<string, signal.ComponentSignalDescriptor> = {
@@ -25,6 +26,16 @@ const List: definition.UC<ListDefinition> = (props) => {
   const componentId = api.component.getComponentIdFromProps(props)
   const [mode] = api.component.useMode(componentId, definition.mode)
 
+  const afterNode = definition.after && (
+    <component.Slot
+      definition={definition}
+      listName="after"
+      path={path}
+      context={context}
+      componentType={componentType}
+    />
+  )
+
   if (!iterate) {
     if (!wire) return null
     const wireContext = context.addWireFrame({
@@ -32,13 +43,16 @@ const List: definition.UC<ListDefinition> = (props) => {
       view: wire.getViewId(),
     })
     return (
-      <component.Slot
-        definition={definition}
-        listName="components"
-        path={path}
-        context={mode ? wireContext.addFieldModeFrame(mode) : wireContext}
-        componentType={componentType}
-      />
+      <>
+        <component.Slot
+          definition={definition}
+          listName="components"
+          path={path}
+          context={mode ? wireContext.addFieldModeFrame(mode) : wireContext}
+          componentType={componentType}
+        />
+        {afterNode}
+      </>
     )
   }
 
@@ -63,13 +77,16 @@ const List: definition.UC<ListDefinition> = (props) => {
 
   if (!itemContexts.length) {
     return (
-      <component.Slot
-        definition={definition}
-        listName="emptyState"
-        path={path}
-        context={context}
-        componentType={componentType}
-      />
+      <>
+        <component.Slot
+          definition={definition}
+          listName="emptyState"
+          path={path}
+          context={context}
+          componentType={componentType}
+        />
+        {afterNode}
+      </>
     )
   }
 
@@ -85,6 +102,7 @@ const List: definition.UC<ListDefinition> = (props) => {
           componentType={componentType}
         />
       ))}
+      {afterNode}
     </>
   )
 }

--- a/libs/apps/uesio/io/bundle/components/card.yaml
+++ b/libs/apps/uesio/io/bundle/components/card.yaml
@@ -50,6 +50,8 @@ definition:
       uesio.styleTokens:
         root:
           - $Region{tile}
+        content:
+          - $Region{tileContent}
       signals: $Prop{signals}
       content:
         - uesio/io.scrollpanel:

--- a/libs/apps/uesio/io/bundle/components/deck.yaml
+++ b/libs/apps/uesio/io/bundle/components/deck.yaml
@@ -13,6 +13,7 @@ slots:
       - type: FIELD_MODE
         modeProperty: mode
   - name: emptyState
+  - name: after
 defaultVariant: uesio/io.default
 defaultDefinition:
   mode: READ

--- a/libs/apps/uesio/io/bundle/components/list.yaml
+++ b/libs/apps/uesio/io/bundle/components/list.yaml
@@ -15,6 +15,7 @@ slots:
       - type: FIELD_MODE
         modeProperty: mode
   - name: emptyState
+  - name: after
 defaultDefinition:
   mode: READ
 properties:


### PR DESCRIPTION
# What does this PR do?

Adds a slot to lists and decks that allow for additional content after the list that is still part of the styling grid.

Example: This deck has a + card that allows for adding new items. Just put the card in the `after` slot and it will display after the content of the list.

<img width="879" alt="Screenshot 2025-06-08 at 7 41 31 PM" src="https://github.com/user-attachments/assets/3056990e-87ec-441c-9061-75d851f6550d" />
