### PR TITLE
chore: migrate to nx 21 continuous tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ Uesio is a **low-code** application development platform.
   - `jq` (for JSON manipulation in Shell): `brew install jq`
   - `wget` (for fetching URLs): `brew install wget`
 - [Configure environment variables](#environment-variables)
-- [Start dependencies](#dependencies)
+- [Prepare dependencies](#prepare-dependencies)
 - [Build](#build)
-- [Run](#run)
+- [Run](#run-the-web-application-locally)
 
 ## Optional
 
@@ -151,7 +151,7 @@ If you'd like to use the Uesio CLI that you have built elsewhere on your machine
 - Linux/macOS: create a symlink for the Uesio CLI into your bin (NOT an alias, which won't work with `nx`): `sudo ln -s <absolute project root path>/dist/cli/uesio /usr/local/bin`
 - Windows: add `<absolute project root path>/dist/cli` to your PATH
 
-# <a id="dependencies"></a>Start dependencies
+# Prepare dependencies
 
 1. Launch all local dependencies (e.g. Postgres, Redis) in docker:
 
@@ -166,7 +166,7 @@ npm run migrations
 npm run seeds
 ```
 
-# <a id="run"></a>Run the web application locally
+# Run the web application locally
 
 ```
 npm run start
@@ -333,7 +333,7 @@ To run the worker process, use `npm run nx -- worker platform` (Or `nx worker pl
 
 ```
 
-# <a id="environment-variables"></a> Environment Variables
+# Environment Variables
 
 If you'd like to get started immediately, you can run `npm run in-docker` and access the site via http://studio.uesio.localhost:3000.
 
@@ -484,9 +484,9 @@ To run the various test suites, there are a number of commands available:
 5. `npm run tests-e2e`
    - Runs _just_ the E2E Tests (against your local app).
 6. `npm run tests-init`
-   - Deletes the `uesio/tests` app if it exists and then creates the `uesio/tests` app with related workspaces and sites and loads seed data. All of the above scripts execute this script automatically so there is not typically a need to run it. However, if you want to run individual tests (via hurl, cypress, etc.) separate from one of the above scripts which runs an entire suite, you will need to run this script to prepare for test execution.
+   - Deletes the `uesio/tests` app if it exists along with any app that starts with `tests_` and then creates the `uesio/tests` app with related workspaces and sites and loads seed data. All of the above scripts execute this script automatically so there is not typically a need to run it. However, if you want to run individual tests (via hurl, cypress, etc.) separate from one of the above scripts which runs an entire suite, you will need to run this script to prepare for test execution.
 7. `npm run tests-cleanup`
-   - Removes the `uesio/tests` app (if it exists). Similar to `tests-init`, the automated test suite scripts will execute this script prior to completion. However, if a test run terminates abnormally and/or if you ran `tests-init` manually, you can execute this script to remove the test related `uesio/tests` app.
+   - Removes the `uesio/tests` app (if it exists) along wit hany app that starts with `tests_`. Similar to `tests-init`, the automated test suite scripts will execute this script prior to completion. However, if a test run terminates abnormally and/or if you ran `tests-init` manually, you can execute this script to remove the test related `uesio/tests` app.
 8. `npm run tests-cypress-open`
    - Runs the cypress visual UI where you can run E2E tests from. See [E2E testing with cypress](#e2e-testing-with-cypress) for details.
 9. `npm run tests-cypress-run`
@@ -538,7 +538,7 @@ npx nx run platform-integration-tests:integration --very-verbose hurl_specs/allm
 If you want to run a single test and avoid having to run `npm run tests-init` prior to each test run, you can use `npx nx run platform-integration-tests:run-test <...other hurl options> <path to testfile>`, e.g.,
 
 ```bash
-npx nx run platform-e2e:run-test --very-verbose hurl_specs/allmetadata.hurl
+npx nx run platform-integration-tests:run-test --very-verbose hurl_specs/allmetadata.hurl
 ```
 
 # Continous integration (CI)

--- a/apps/platform-e2e/project.json
+++ b/apps/platform-e2e/project.json
@@ -12,7 +12,7 @@
         "commands": [
           "npx tsc --build --emitDeclarationOnly --pretty --verbose"
         ],
-        "cwd": "apps/platform-e2e"
+        "cwd": "{projectRoot}"
       }
     },
     "run-test": {
@@ -24,6 +24,14 @@
     },
     "test-e2e": {
       "executor": "nx:run-commands",
+      "dependsOn": ["platform:wait-for-dev"],
+      "options": {
+        "command": ["nx run platform-e2e:test-e2e:run"],
+        "cwd": "{projectRoot}"
+      }
+    },
+    "test-e2e:run": {
+      "executor": "nx:run-commands",
       "options": {
         "commands": [
           "npx nx run platform-integration-tests:setup-data",
@@ -34,7 +42,7 @@
           "npx nx run platform-integration-tests:cleanup-data"
         ],
         "forwardAllArgs": false,
-        "cwd": "apps/platform-integration-tests",
+        "cwd": "{projectRoot}",
         "parallel": false
       }
     }

--- a/apps/platform-integration-tests/project.json
+++ b/apps/platform-integration-tests/project.json
@@ -14,14 +14,14 @@
         "commands": [
           "npx tsc --build --emitDeclarationOnly --pretty --verbose"
         ],
-        "cwd": "apps/platform-integration-tests"
+        "cwd": "{projectRoot}"
       }
     },
     "integration": {
       "executor": "nx:run-commands",
       "options": {
         "commands": [". ./scripts/setup-env.sh && npx hurl --jobs 1 -k"],
-        "cwd": "apps/platform-integration-tests"
+        "cwd": "{projectRoot}"
       }
     },
     "run-test": {
@@ -36,11 +36,19 @@
           "npx nx run platform-integration-tests:cleanup-data"
         ],
         "forwardAllArgs": false,
-        "cwd": "apps/platform-integration-tests",
+        "cwd": "{projectRoot}",
         "parallel": false
       }
     },
     "test-integration": {
+      "executor": "nx:run-commands",
+      "dependsOn": ["platform:wait-for-dev"],
+      "options": {
+        "command": "nx run platform-integration-tests:test-integration:run",
+        "cwd": "{projectRoot}"
+      }
+    },
+    "test-integration:run": {
       "executor": "nx:run-commands",
       "options": {
         "commands": [
@@ -52,7 +60,7 @@
           "npx nx run platform-integration-tests:integration --test --very-verbose hurl_specs_single_run/perf_stats.hurl",
           "npx nx run platform-integration-tests:cleanup-data"
         ],
-        "cwd": "apps/platform-integration-tests",
+        "cwd": "{projectRoot}",
         "forwardAllArgs": false,
         "parallel": false
       }
@@ -61,14 +69,14 @@
       "executor": "nx:run-commands",
       "options": {
         "commands": ["bash ./scripts/setup-data.sh"],
-        "cwd": "apps/platform-integration-tests"
+        "cwd": "{projectRoot}"
       }
     },
     "cleanup-data": {
       "executor": "nx:run-commands",
       "options": {
         "commands": ["bash ./scripts/cleanup-data.sh"],
-        "cwd": "apps/platform-integration-tests"
+        "cwd": "{projectRoot}"
       }
     }
   }

--- a/apps/platform/project.json
+++ b/apps/platform/project.json
@@ -80,7 +80,7 @@
       "executor": "nx:run-commands",
       "options": {
         "command": "docker build --tag uesio-dev:latest -f ./apps/platform/Dockerfile .",
-        "cwd": "."
+        "cwd": "{workspaceRoot}"
       },
       "dependsOn": [{ "projects": "tag:type:platform-dep", "target": "build" }]
     },
@@ -88,7 +88,7 @@
       "executor": "nx:run-commands",
       "options": {
         "command": "docker compose -f docker-compose.yaml -f docker-compose-local.yaml up -d --build",
-        "cwd": "."
+        "cwd": "{workspaceRoot}"
       },
       "dependsOn": [{ "projects": "tag:type:platform-dep", "target": "build" }]
     },
@@ -132,27 +132,59 @@
       "executor": "nx:run-commands",
       "options": {
         "commands": [
-          "mkdir -p apps/platform/.watch",
-          "nx watch -p tag:type:platform-dep  -- \"date && nx run-many -t build -p \\$NX_PROJECT_NAME && date > apps/platform/.watch/nxwatch.log\""
-        ]
+          "mkdir -p .watch",
+          "nx watch -p tag:type:platform-dep  -- \"date && nx run-many -t build -p \\$NX_PROJECT_NAME && date > .watch/nxwatch.log\""
+        ],
+        "cwd": "{projectRoot}"
       }
     },
     "serve:watch": {
       "executor": "nx:run-commands",
       "options": {
-        "commands": [
-          "cd apps/platform && air serve",
-          "nx run platform:watch-deps"
-        ],
+        "commands": ["air serve", "nx run platform:watch-deps"],
+        "cwd": "{projectRoot}",
         "parallel": true
       },
       "dependsOn": [{ "projects": "tag:type:platform-dep", "target": "build" }]
+    },
+    "dev": {
+      "executor": "nx:run-commands",
+      "continuous": true,
+      "options": {
+        "command": "bash ./scripts/dev.sh",
+        "cwd": "{projectRoot}"
+      },
+      "dependsOn": [
+        { "projects": "tag:type:platform-dep", "target": "build" },
+        "start-deps"
+      ]
+    },
+    "wait-for-dev": {
+      "executor": "nx:run-commands",
+      "dependsOn": [
+        {
+          "target": "dev",
+          "params": "forward"
+        }
+      ],
+      "options": {
+        "commands": ["bash ./scripts/wait-for-dev.sh"],
+        "cwd": "{projectRoot}",
+        "forwardAllArgs": false
+      }
     },
     "setup-ssl": {
       "executor": "nx:run-commands",
       "options": {
         "command": "bash ./create.sh",
         "cwd": "{projectRoot}/ssl"
+      }
+    },
+    "start-deps": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "docker compose -f docker-compose.yaml up -d --wait",
+        "cwd": "{workspaceRoot}"
       }
     }
   },

--- a/apps/platform/scripts/dev.sh
+++ b/apps/platform/scripts/dev.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+
+has_watch=false
+for arg in "$@"; do
+  if [ "$arg" = "--watch" ]; then
+    has_watch=true
+    break
+  fi
+done
+
+if $has_watch; then
+  nx run platform:serve:watch
+else
+  nx run platform:serve
+fi

--- a/apps/platform/scripts/wait-for-dev.sh
+++ b/apps/platform/scripts/wait-for-dev.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -e
+
+site_scheme=$([ "${UESIO_USE_HTTPS}" = "true" ] && echo "https" || echo "http")
+site_primary_domain=${UESIO_PRIMARY_DOMAIN:-uesio.localhost}
+site_port=${UESIO_PORT:-3000}
+site_url="$site_scheme://studio.$site_primary_domain:$site_port"
+site_health_url="$site_url/health"
+
+timeout=5
+interval=0.2
+elapsed=0
+
+# Wait for server to become healthy
+while (( $(echo "$elapsed < $timeout" | bc -l) )); do
+    status=$(curl -k -s -o /dev/null -w "%{http_code}" "$site_health_url" || true)
+    if [ "$status" -eq 200 ]; then
+        echo "Healthy (HTTP 200)"
+        exit 0
+    fi
+    sleep $interval
+    elapsed=$(echo "$elapsed + $interval" | bc)
+done
+
+echo "Timeout: $URL did not return HTTP 200 within $timeout seconds"
+exit 1

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,11 @@
 services:
   redis:
     image: "redis:alpine"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 1s
+      timeout: 10s
+      retries: 5
     ports:
       - "6379:6379"
     volumes:
@@ -19,6 +24,11 @@ services:
       # - dev: postgresio (owned by postgres user)
       # - test: pgtest (owned by pgtest user)
       POSTGRES_MULTIPLE_DATABASES: "postgresio,postgres:pgtest,pgtest"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -d postgres -U postgres"]
+      interval: 1s
+      timeout: 10s
+      retries: 5
     volumes:
       - ./apps/platform/scripts/create-multiple-databases.sh:/docker-entrypoint-initdb.d/create-multiple-databases.sh
       - pgdata:/var/lib/postgresql/data

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "tests-e2e": "nx run-many -t test-e2e",
     "tests-init": "nx run platform-integration-tests:setup-data",
     "tests-integration": "nx run-many -t test-integration",
-    "tests-all": "nx run-many -t test && nx run-many -t test-integration test-e2e --parallel=1",
+    "tests-all": "npm run test && npm run tests-integration && npm run tests-e2e",
     "tests-docker": "nx run uesio:tests-docker",
     "tests-cypress-open": "nx run platform-e2e:open-cypress",
     "tests-cypress-run": "nx run platform-e2e:e2e",
@@ -32,7 +32,7 @@
     "format-check-all": "nx format:check --all && nx run-many -t format:check || echo \"Formatting Errors Found!\"",
     "help": "nx help",
     "in-docker": "nx run platform:serve-image",
-    "start-deps": "nx run uesio:start-deps",
+    "start-deps": "nx run platform:start-deps",
     "lint-all": "nx run-many --target=lint --all",
     "migrations": "nx migrate-db platform",
     "migrate:create": "migrate create -dir apps/platform/migrations -ext sql -seq -digits 1",
@@ -43,11 +43,12 @@
     "seeds": "nx seed platform",
     "setup-ssl": "nx run platform:setup-ssl",
     "setup-local-dns": "nx run uesio:setup-local-dns",
-    "start": "nx run platform:serve",
-    "test": "nx run-many --target=test --all",
+    "start": "npm run dev",
+    "dev": "nx run platform:dev",
+    "test": "nx run-many -t test",
     "watch-all": "npm run build-all && nx watch --all -- nx run-many -t build -p \\$NX_PROJECT_NAME",
     "watch-platform-deps": "nx run platform:watch-deps",
-    "watch-dev": "nx run platform:serve:watch"
+    "watch-dev": "nx run platform:dev --watch"
   },
   "nx": {
     "includedScripts": [],
@@ -56,13 +57,6 @@
         "executor": "nx:run-commands",
         "options": {
           "command": "bash ./scripts/run-docker-tests.sh",
-          "cwd": "{workspaceRoot}"
-        }
-      },
-      "start-deps": {
-        "executor": "nx:run-commands",
-        "options": {
-          "command": "docker compose -f docker-compose.yaml up -d",
           "cwd": "{workspaceRoot}"
         }
       },

--- a/scripts/run-docker-tests.sh
+++ b/scripts/run-docker-tests.sh
@@ -31,9 +31,11 @@ fi
 docker compose -f docker-compose-tests.yaml down --volumes
 docker compose -f docker-compose-tests.yaml up -d --wait
 
-# parallel=1 to ensure the tests run sequentially as they rely on the same "test data"
+# parallel=1 seems to be broken in NX 21 so invoking separately until nx resolves the issue
+# TODO: Monitor https://github.com/nrwl/nx/issues/31494 and update to "nx run-many -t test-integration:run test-e2e:run --parallel=1" once a fix is released
 # TODO: refactor e2e and integration tests so that they don't rely on the same "test data" so that they can be run in parallel
-nx run-many -t test-integration test-e2e --parallel=1
+nx run-many -t test-integration:run 
+nx run-many -t test-e2e:run
 
 # Spin down the tests network's Docker containers
 # In CI, we leave it up so that we can collect the logs


### PR DESCRIPTION
# What does this PR do?

Migrates to [continuous tasks](https://nx.dev/recipes/running-tasks/defining-task-pipeline#continuous-task-dependencies) which was introduced in [Nx 21](https://nx.dev/blog/nx-21-continuous-tasks).

1. All `tests-*` targets will now automatically start the `platform` dependencies (e.g., Postgres & Redis) along with the `platform` itself.  `npm run start` (which is just a proxy to `npm run dev`) and `npm run watch-dev` will also start dependencies in addition to the platform.  If the platform and/or its dependencies are already running, starting them will be "skipped" which allows you to manually start the server (e.g., `npm run start` or `npm run watch-dev` and then simply run `npm run tests-integration`, etc.) just like before.  In short, running any `test-*` target will ensure that everything is "ready" for testing to start.
2. Nx 21 introduced a new [Terminal](https://nx.dev/recipes/running-tasks/terminal-ui#nx-terminal-ui) so output and behavior will be a little different than previous.  For example, when running `npm run tests-all` instead of everything just being streamed in a single console output, three separate "nx steps" are completed with the opportunity to review the steps output prior to moving to the next step (next step will automatically start after the default 3 second wait configurable via [tui auto-exit](https://nx.dev/recipes/running-tasks/terminal-ui#autoexit)).
3. There are some limitations/issues with nx 21 related to continuous tasks and terminal UI which needed to be worked around.  The workarounds can be eliminated once the following are resolved:
    1. https://github.com/nrwl/nx/issues/31494
    2. https://github.com/nrwl/nx/issues/31495
    3. https://github.com/nrwl/nx/issues/31496
    4. https://github.com/nrwl/nx/issues/31499 - There is no workaround for this one, just need to wait until it's resolved. When running, output will not be discernable but after completion and closing TUI, it will be.

# Testing

All npm scripts, nx targets, etc. behave as expected when run manually.  ci & e2e will cover rest.
