### PR TITLE
add mergestring to context type

### DIFF
--- a/apps/platform-integration-tests/generated/@types/@uesio/index.d.ts
+++ b/apps/platform-integration-tests/generated/@types/@uesio/index.d.ts
@@ -710,12 +710,29 @@ type Context = {
    * @returns new Context object
    */
   addSignalOutputFrame: (label: string, data: unknown) => Context
-  /**
-   * Merges a text string containing merges, e.g. ${uesio/core.uniquekey} in the current context
-   * @param text - the text to be merged
-   * @returns the merged text
-   */
+	/**
+	 * Merges a template containing merge syntax, e.g. ${uesio/core.uniquekey} in the current context.
+	 * If the template specified is not a string or does not contain any merge syntax, the template
+	 * is returned as-is.
+	 * @param template - the template to be merged
+	 * @returns the merged result
+	 */
   merge: (text: string) => string
+  /**
+   * Merges a template containing merge syntax, e.g. ${uesio/core.uniquekey} in the current context
+   * with the result coerced in to a string. If the template specified is not a string or does not contain 
+   * any merge syntax, the value returned is the template coerced to a string.
+   * @param template - the template to be merged
+   * @returns the merged result as a string
+   */
+	mergeString: (template: Mergeable) => string
+  /**
+   * Merges a template containing merge syntax, e.g. ${uesio/core.uniquekey} in the current context
+   * with the result coerced in to a string. If the template specified is not a string or does not contain 
+   * any merge syntax, the value returned is the template coerced to a string.
+   * @param template - the template to be merged
+   * @returns the merged result as a string
+   */
   /**
    * Returns an array of errors that are part of the current context
    * @returns Array of error strings

--- a/libs/ui/src/public_types/client/index.d.ts
+++ b/libs/ui/src/public_types/client/index.d.ts
@@ -76,12 +76,22 @@ type Context = {
    * @returns new Context object
    */
   addSignalOutputFrame: (label: string, data: unknown) => Context
-  /**
-   * Merges a text string containing merges, e.g. ${uesio/core.uniquekey} in the current context
-   * @param text - the text to be merged
-   * @returns the merged text
-   */
+	/**
+	 * Merges a template containing merge syntax, e.g. ${uesio/core.uniquekey} in the current context.
+	 * If the template specified is not a string or does not contain any merge syntax, the template
+	 * is returned as-is.
+	 * @param template - the template to be merged
+	 * @returns the merged result
+	 */
   merge: (text: string) => string
+  /**
+   * Merges a template containing merge syntax, e.g. ${uesio/core.uniquekey} in the current context
+   * with the result coerced in to a string. If the template specified is not a string or does not contain 
+   * any merge syntax, the value returned is the template coerced to a string.
+   * @param template - the template to be merged
+   * @returns the merged result as a string
+   */
+	mergeString: (template: Mergeable) => string  
   /**
    * Returns an array of errors that are part of the current context
    * @returns Array of error strings


### PR DESCRIPTION
# What does this PR do?

Adds `mergeString` to context type

# Testing

Verified locally, ci & e2e will cover rest.
