### PR TITLE
refactor: remove server start timestamp from server urls

### DIFF
--- a/apps/platform/pkg/cmd/serve.go
+++ b/apps/platform/pkg/cmd/serve.go
@@ -5,7 +5,6 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
-	"time"
 
 	"github.com/aarol/reload"
 	"github.com/thecloudmasters/uesio/pkg/bundlestore/platformbundlestore"
@@ -67,9 +66,7 @@ var versionedItemParam = fmt.Sprintf("%s/%s/%s", nsParam, versionParam, namePara
 var groupingParam = getFullItemOrTextParam("grouping")
 var collectionParam = getFullItemParam("collectionname")
 
-var (
-	staticPrefix = "/static"
-)
+var staticPrefix = "/static"
 
 func serve(cmd *cobra.Command, args []string) error {
 
@@ -78,15 +75,9 @@ func serve(cmd *cobra.Command, args []string) error {
 
 	// If we have UESIO_BUILD_VERSION, append that to the prefixes to enable us to have versioned assets
 	version := os.Getenv("UESIO_BUILD_VERSION")
-	cacheStaticAssets := false
 	staticAssetsPath := ""
 	if version != "" {
 		staticAssetsPath = "/" + version
-	} else if env.ShouldCacheSiteBundles() {
-		staticAssetsPath = fmt.Sprintf("/%d", time.Now().Unix())
-	}
-	if staticAssetsPath != "" {
-		cacheStaticAssets = true
 		file.SetAssetsPath(staticAssetsPath)
 		staticPrefix = staticAssetsPath + staticPrefix
 	}
@@ -94,7 +85,7 @@ func serve(cmd *cobra.Command, args []string) error {
 	// Profiler Info
 	// r.PathPrefix("/debug/pprof").Handler(http.DefaultServeMux)
 
-	r.Handle(staticPrefix+"/{filename:.*}", file.Static(staticPrefix, cacheStaticAssets)).Methods(http.MethodGet)
+	r.Handle(staticPrefix+"/{filename:.*}", file.Static(staticPrefix)).Methods(http.MethodGet)
 	r.HandleFunc("/health", controller.Health).Methods(http.MethodGet)
 
 	//r.HandleFunc("/api/weather", testapis.TestApi).Methods(http.MethodGet, http.MethodPost, http.MethodDelete)

--- a/apps/platform/pkg/controller/file/static_assets.go
+++ b/apps/platform/pkg/controller/file/static_assets.go
@@ -31,13 +31,13 @@ func GetAssetsHost() string {
 	return staticAssetsHost
 }
 
-func Static(routePrefix string, cache bool) http.Handler {
+func Static(routePrefix string) http.Handler {
 	fileServer := http.FileServer(http.Dir(filepath.Join("..", "..", "dist")))
 	handler := http.StripPrefix(routePrefix, fileServer)
 	if staticAssetsHost != "" {
 		handler = middleware.WithAccessControlAllowOriginHeader(handler, "*")
 	}
-	if cache {
+	if staticAssetsPath != "" {
 		handler = middleware.With1YearCache(handler)
 	}
 	return handler


### PR DESCRIPTION
# What does this PR do?

In the commit linked below, functionality was added to put the server's start timestamp at the beginning of static urls. This adds additional complexity to our caching strategies.
https://github.com/ues-io/uesio/commit/b3984db8daa35a0d04ecf6bbc3519122dd9fc415

Another problem with this approach is that it makes use of the UESIO_CACHE_SITE_BUNDLES environment variable. By using this variable, it actually gives the flag a double meaning.

1. The expected meaning: Use a server side-cache for quickly getting site bundle info instead of always going to the bundlestore.

2. The unexpected meaning: Append all static urls with the server's start timestamp, so that restarting the server will bust all client-side caches for these files. (Which are not site bundle metadata anyways).

NEW BEHAVIOR:

If no build version is provided, (typically dev mode) no prefix will be added to static urls. Our other caching/busting mechanisms will be used.

ALTERNATIVE: NOT IMPLEMENTED HERE

Bring back the server date, but just always use it if no build version is provided. I don't think this is the best approach because it allows us to fix caching issues by just restarting the server instead of fixing the underlying issue. Currently, `npm run watch-dev` does not restart the server if changes are made to static assets, like uesio.js. So this caching mechanism isn't all that useful anyways.


