### PR TITLE
chore: include platform go code in cli target inputs

### DIFF
--- a/apps/cli/project.json
+++ b/apps/cli/project.json
@@ -11,7 +11,13 @@
         "cwd": "{projectRoot}",
         "outputPath": "../../dist/cli/uesio"
       },
-      "inputs": ["golang", "default", "^production", "sharedGlobals"],
+      "inputs": [
+        "golang",
+        "default",
+        "^production",
+        "sharedGlobals",
+        { "projects": ["platform"], "input": "golang" }
+      ],
       "outputs": ["{options.outputPath}"]
     },
     "test": {
@@ -20,7 +26,13 @@
         "command": "go test -v ./...",
         "cwd": "{projectRoot}"
       },
-      "inputs": ["golang", "default", "^production", "sharedGlobals"]
+      "inputs": [
+        "golang",
+        "default",
+        "^production",
+        "sharedGlobals",
+        { "projects": ["platform"], "input": "golang" }
+      ]
     },
     "format": {
       "dependsOn": ["format:write"]
@@ -37,7 +49,13 @@
         "command": "gofmt -l -w -s -e .",
         "cwd": "{projectRoot}"
       },
-      "inputs": ["golang", "default", "^production", "sharedGlobals"],
+      "inputs": [
+        "golang",
+        "default",
+        "^production",
+        "sharedGlobals",
+        { "projects": ["platform"], "input": "golang" }
+      ],
       "cache": true
     },
     "gofmt:check": {
@@ -46,7 +64,13 @@
         "command": "output=\"$(gofmt -d -e .)\" && echo \"$output\" && test -z \"$output\"",
         "cwd": "{projectRoot}"
       },
-      "inputs": ["golang", "default", "^production", "sharedGlobals"],
+      "inputs": [
+        "golang",
+        "default",
+        "^production",
+        "sharedGlobals",
+        { "projects": ["platform"], "input": "golang" }
+      ],
       "cache": true
     },
     "lint": {
@@ -58,7 +82,13 @@
         "command": "go mod tidy",
         "cwd": "{projectRoot}"
       },
-      "inputs": ["golang", "default", "^production", "sharedGlobals"],
+      "inputs": [
+        "golang",
+        "default",
+        "^production",
+        "sharedGlobals",
+        { "projects": ["platform"], "input": "golang" }
+      ],
       "cache": true
     },
     "tidy:check": {
@@ -67,7 +97,13 @@
         "command": "go mod tidy -diff",
         "cwd": "{projectRoot}"
       },
-      "inputs": ["golang", "default", "^production", "sharedGlobals"],
+      "inputs": [
+        "golang",
+        "default",
+        "^production",
+        "sharedGlobals",
+        { "projects": ["platform"], "input": "golang" }
+      ],
       "cache": true
     },
     "vet": {
@@ -76,7 +112,13 @@
         "command": "go vet ./...",
         "cwd": "{projectRoot}"
       },
-      "inputs": ["golang", "default", "^production", "sharedGlobals"],
+      "inputs": [
+        "golang",
+        "default",
+        "^production",
+        "sharedGlobals",
+        { "projects": ["platform"], "input": "golang" }
+      ],
       "cache": true
     }
   },


### PR DESCRIPTION
# What does this PR do?

Adds go related files to CLI nx target inputs.

The CLI does not depend on the platform project, however it does depend on code in the platform project since the platform project is a "shared" library as currently architected.  Prior to this PR. if code in the platform project was modified that the CLI relied on, nx would not detect those changes as it relates to the CLI project and therefore would not re-run tasks and instead pull from cache.  Adding in go specific inputs from the platform project ensures that NX can properly detect when code that the CLI may use has changed.

# Testing

Tested manual changes to go related files in the platform project and confirmed that the CLI re-executes it's tasks and do not pull from cache.  ci & e2e will cover rest.
