### PR TITLE
chore: upgrade go 1.24.4

### DIFF
--- a/apps/cli/go.mod
+++ b/apps/cli/go.mod
@@ -1,6 +1,6 @@
 module github.com/thecloudmasters/cli
 
-go 1.24.3
+go 1.24.4
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7

--- a/apps/platform/Dockerfile
+++ b/apps/platform/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.3-alpine AS multistage
+FROM golang:1.24.4-alpine AS multistage
 
 WORKDIR /src
 RUN go env -w GOMODCACHE=/root/.cache/go-build

--- a/apps/platform/go.mod
+++ b/apps/platform/go.mod
@@ -1,6 +1,6 @@
 module github.com/thecloudmasters/uesio
 
-go 1.24.3
+go 1.24.4
 
 require (
 	github.com/NYTimes/gziphandler v1.1.1

--- a/go.work
+++ b/go.work
@@ -9,7 +9,7 @@
 // development and not used when building the modules.
 // See https://github.com/golang/go/issues/51941 & https://github.com/golang/go/issues/53502
 
-go 1.24.3
+go 1.24.4
 
 use (
 	./apps/cli


### PR DESCRIPTION
# What does this PR do?

Upgrade go 1.24.4

# Testing

ci & e2e will cover.
