### PR TITLE
fix: ensure upload file trigger in all cases

### DIFF
--- a/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/uploadarea/uploadarea.tsx
+++ b/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/uploadarea/uploadarea.tsx
@@ -56,7 +56,7 @@ const UploadArea: definition.UtilityComponent<UploadAreaProps> = (props) => {
     // even though the physical file might have changed.
     if (fileInputRef?.current) {
       fileInputRef.current.value = ""
-    }    
+    }
   }
 
   return (

--- a/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/uploadarea/uploadarea.tsx
+++ b/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/uploadarea/uploadarea.tsx
@@ -50,6 +50,15 @@ const UploadArea: definition.UtilityComponent<UploadAreaProps> = (props) => {
     e.stopPropagation()
   }
 
+  const resetFile = () => {
+    // Make sure the upload triggers after a delete or an upload as the browser won't trigger onChange if the same file is selected again.
+    // This covers the situation where the file is deleted but also the situation where the same file based on name/path is selected
+    // even though the physical file might have changed.
+    if (fileInputRef?.current) {
+      fileInputRef.current.value = ""
+    }    
+  }
+
   return (
     <>
       <div
@@ -74,6 +83,7 @@ const UploadArea: definition.UtilityComponent<UploadAreaProps> = (props) => {
         accept={accept}
         onChange={(e) => {
           onUpload(e.target.files)
+          resetFile()
         }}
         ref={fileInputRef}
         id={uploadLabelId}
@@ -82,7 +92,10 @@ const UploadArea: definition.UtilityComponent<UploadAreaProps> = (props) => {
         <input
           className={classes.fileinput}
           type="button"
-          onClick={onDelete}
+          onClick={(e) => {
+            onDelete()
+            resetFile()
+          }}
           id={deleteLabelId}
         />
       )}


### PR DESCRIPTION
# What does this PR do?

Ensures that upload file triggers in all cases.  The prior implementation had two shortcomings:

1. After "deleting" the file, uploading the same file again would not trigger the upload
2. If the same "file name/path" is selected but the file itself is different, the upload would not trigger

The above issues are due to the fact that the browser won't trigger onChange when the "same file is detected" but it bases "same file" on name/path, not physical content.

# Testing

Manual testing confirms uploads trigger in all cases.
