### PR TITLE
chore: add support for parallel file uploads

### DIFF
--- a/apps/cli/go.mod
+++ b/apps/cli/go.mod
@@ -12,6 +12,7 @@ require (
 
 require (
 	github.com/PaesslerAG/gval v1.2.4 // indirect
+	github.com/dolmen-go/contextio v1.0.0 // indirect
 	github.com/francoispqt/gojay v1.2.13 // indirect
 	github.com/gofrs/uuid v4.4.0+incompatible // indirect
 	github.com/gomodule/redigo v1.9.2 // indirect

--- a/apps/cli/go.sum
+++ b/apps/cli/go.sum
@@ -29,6 +29,8 @@ github.com/creack/pty v1.1.17/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dolmen-go/contextio v1.0.0 h1:bNfCo4gsRIhMeo6Z1ImXzkxZG81B6I5t2fUFJjphdAU=
+github.com/dolmen-go/contextio v1.0.0/go.mod h1:cxc20xI7fOgsFHWgt+PenlDDnMcrvh7Ocuj5hEFIdEk=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/evanw/esbuild v0.25.5 h1:E+JpeY5S/1LFmnX1vtuZqUKT7qDVcfXdhzMhM3uIKFs=
 github.com/evanw/esbuild v0.25.5/go.mod h1:D2vIQZqV/vIf/VRHtViaUtViZmG7o+kKmlBfVQuRi48=

--- a/apps/platform/go.mod
+++ b/apps/platform/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/bigkevmcd/go-cachewrapper v0.0.0-20240507155736-346a72d92df1
 	github.com/crewjam/saml v0.5.1
 	github.com/dimchansky/utfbom v1.1.1
+	github.com/dolmen-go/contextio v1.0.0
 	github.com/dop251/goja v0.0.0-20250624190929-4d26883d182a
 	github.com/evanw/esbuild v0.25.5
 	github.com/francoispqt/gojay v1.2.13

--- a/apps/platform/go.sum
+++ b/apps/platform/go.sum
@@ -124,6 +124,8 @@ github.com/docker/go-connections v0.5.0 h1:USnMq7hx7gwdVZq1L49hLXaFtUdTADjXGp+uj
 github.com/docker/go-connections v0.5.0/go.mod h1:ov60Kzw0kKElRwhNs9UlUHAE/F9Fe6GLaXnqyDdmEXc=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
+github.com/dolmen-go/contextio v1.0.0 h1:bNfCo4gsRIhMeo6Z1ImXzkxZG81B6I5t2fUFJjphdAU=
+github.com/dolmen-go/contextio v1.0.0/go.mod h1:cxc20xI7fOgsFHWgt+PenlDDnMcrvh7Ocuj5hEFIdEk=
 github.com/dop251/goja v0.0.0-20250624190929-4d26883d182a h1:QIWJoaD2+zxUjN28l8zixmbuvtYqqcxj49Iwzw7mDpk=
 github.com/dop251/goja v0.0.0-20250624190929-4d26883d182a/go.mod h1:MxLav0peU43GgvwVgNbLAj1s/bSGboKkhuULvq/7hx4=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=

--- a/apps/platform/pkg/bundlestore/filebundlestore/filebundlestore.go
+++ b/apps/platform/pkg/bundlestore/filebundlestore/filebundlestore.go
@@ -265,7 +265,7 @@ func (b *FileBundleStoreConnection) StoreItem(path string, reader io.Reader) err
 
 	fullFilePath := filepath.Join(b.Namespace, b.Version, path)
 
-	_, err := b.FileConnection.Upload(reader, fullFilePath)
+	_, err := b.FileConnection.Upload(file.NewFileUploadRequest(reader, fullFilePath))
 	if err != nil {
 		return fmt.Errorf("error writing file: %w", err)
 	}

--- a/apps/platform/pkg/fileadapt/s3/upload.go
+++ b/apps/platform/pkg/fileadapt/s3/upload.go
@@ -1,11 +1,14 @@
 package s3
 
 import (
+	"context"
 	"io"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/thecloudmasters/uesio/pkg/types/file"
+	"golang.org/x/sync/errgroup"
 )
 
 type contentLengthReader struct {
@@ -30,14 +33,43 @@ func (r *contentLengthReader) GetContentLength() int64 {
 	return r.contentLength
 }
 
-func (c *Connection) Upload(fileData io.Reader, path string) (int64, error) {
+func (c *Connection) Upload(req file.FileUploadRequest) (int64, error) {
+	uploader := manager.NewUploader(c.client)
+	return handleFileUpload(c.ctx, uploader, c.bucket, req.Data(), req.Path())
+}
 
+func (c *Connection) UploadMany(reqs []file.FileUploadRequest) ([]int64, error) {
 	uploader := manager.NewUploader(c.client)
 
+	// TODO: make maxConcurrency configurable
+	maxConcurrency := 5
+	g := &errgroup.Group{}
+	g, uploadCtx := errgroup.WithContext(c.ctx)
+	g.SetLimit(maxConcurrency)
+	bytesWritten := make([]int64, len(reqs))
+
+	for i, req := range reqs {
+		g.Go(func() error {
+			size, err := handleFileUpload(uploadCtx, uploader, c.bucket, req.Data(), req.Path())
+			if err == nil {
+				bytesWritten[i] = size
+			}
+			return err
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+
+	return bytesWritten, nil
+}
+
+func handleFileUpload(ctx context.Context, uploader *manager.Uploader, bucket string, fileData io.Reader, path string) (int64, error) {
 	reader := newContentLengthReader(fileData)
 
-	_, err := uploader.Upload(c.ctx, &s3.PutObjectInput{
-		Bucket: aws.String(c.bucket),
+	_, err := uploader.Upload(ctx, &s3.PutObjectInput{
+		Bucket: aws.String(bucket),
 		Key:    aws.String(path),
 		Body:   reader,
 	})

--- a/apps/platform/pkg/types/file/fileconnection.go
+++ b/apps/platform/pkg/types/file/fileconnection.go
@@ -1,9 +1,37 @@
 package file
 
-import "io"
+import (
+	"io"
+)
+
+type FileUploadRequest interface {
+	Data() io.Reader
+	Path() string
+}
+
+func NewFileUploadRequest(fileData io.Reader, path string) FileUploadRequest {
+	return &fileUploadRequest{
+		FileData: fileData,
+		FilePath: path,
+	}
+}
+
+type fileUploadRequest struct {
+	FileData io.Reader
+	FilePath string
+}
+
+func (f *fileUploadRequest) Data() io.Reader {
+	return f.FileData
+}
+
+func (f *fileUploadRequest) Path() string {
+	return f.FilePath
+}
 
 type Connection interface {
-	Upload(fileData io.Reader, path string) (int64, error)
+	Upload(req FileUploadRequest) (int64, error)
+	UploadMany(reqs []FileUploadRequest) ([]int64, error)
 	Download(path string) (io.ReadSeekCloser, Metadata, error)
 	Delete(path string) error
 	List(path string) ([]Metadata, error)


### PR DESCRIPTION
# What does this PR do?

This is step 1 of N towards improving reliability and performance of uploading & downloading files, specifically catering towards S3 backend.

This PR adds `UploadMany` api which adds support for uploading multiple files in parallel.  The only use case around this currently is on a "deploy" of a bundle as file uploads from a view are currently limited to single files.

In manual testing, deploying a zip file with ~385 files inside of it from local machine to S3 was taking ~30 seconds and now takes about 3-4 seconds.

More work to be done on uploads/downloads.

# Testing

Manual testing confirms expected outcomes. ci & e2e will cover basics.
