### PR TITLE
fix: use site name for user cache key instead of site id

### DIFF
--- a/apps/platform/pkg/auth/cache.go
+++ b/apps/platform/pkg/auth/cache.go
@@ -19,7 +19,7 @@ func init() {
 }
 
 func GetUserCacheKey(userid string, site *meta.Site) string {
-	return fmt.Sprintf("%s:%s:%s", userid, site.GetAppFullName(), site.ID)
+	return fmt.Sprintf("%s:%s", userid, site.GetFullName())
 }
 
 func getHostKey(domainType, domainValue string) string {


### PR DESCRIPTION
# What does this PR do?

Uses the site name for user cache key instead of the site id.

A userid is unique to a site so technically, only it needs to be part of the cachekey since we cache for a given site.  However, having the site/app name info in the keys is helpful for troubleshooting.

When calling `getStudioSession` a "facade studio session" is created, however it does not have a value for `site ID` since that would require a lookup.  This is used for things like "seed" command.  

Ultimately, the way we handle facade/anon/admin sessions and construct them in certain situations needs to be revisited, however for now, not relying on the site.ID for the user cache key is OK since userid itself is what makes the key unique.

# Testing

Tested locally and confirmed expected behavior.  ci & e2e will cover basics.
