### PR TITLE
fix: page title on user view

### DIFF
--- a/libs/apps/uesio/studio/bundle/routes/user.yaml
+++ b/libs/apps/uesio/studio/bundle/routes/user.yaml
@@ -2,4 +2,4 @@ name: user
 path: app/{app:\w*\/\w*}/site/{sitename}/users/{userid}
 view: user
 theme: default
-title: "User: $Record{users:uesio/core.username}"
+title: "User: $Param{userid}"


### PR DESCRIPTION
# What does this PR do?

Change page title to use $Param{userid} instead of $Record{username} because the users wire is loaded asynchronously so the username isn't available when page title is generated and it was resulting in a page title of "User: ".

Not that there are two downsides to this approach and possibly could consider just using "Manage User" for the page title but having the userid in the title is helpful for site navigation:

1. If no {userid} is specified in the route, the page title will remain "User: "
2. If the {userid} is not valid, the page title will contain the user id even though technically it's not a page for that user since the user isn't valid

Side note - When an invalid user is specified, the page shows blank instead of serving a page not found 404 but that is a separate issue from this one.

# Testing

Tested manually and confirmed.
