### PR TITLE
fix: toggle mode when save/cancel in form_detail

### DIFF
--- a/libs/apps/uesio/appkit/bundle/components/form_detail.yaml
+++ b/libs/apps/uesio/appkit/bundle/components/form_detail.yaml
@@ -26,6 +26,11 @@ slots:
             - signal: wire/SAVE
               wires:
                 - $Prop{wire}
+            - signal: component/CALL
+              component: uesio/io.item
+              componentsignal: TOGGLE_MODE
+              targettype: specific
+              componentid: $Prop{wire}_item                
           text: Save
           hotkey: "meta+s"
           uesio.variant: uesio/appkit.primary
@@ -37,30 +42,18 @@ slots:
           signals:
             - signal: wire/CANCEL
               wire: $Prop{wire}
-          text: Cancel
-          uesio.variant: uesio/appkit.secondary
-          uesio.display:
-            - type: wireHasChanges
-              operator: EQUALS
-              wire: $Prop{wire}
-      - uesio/io.button:
-          signals:
             - signal: component/CALL
               component: uesio/io.item
               componentsignal: TOGGLE_MODE
               targettype: specific
               componentid: $Prop{wire}_item
-          text: Read
+          text: Cancel
           uesio.variant: uesio/appkit.secondary
-          icon: task_alt
           uesio.display:
             - type: mergeValue
               operator: EQUALS
               sourceValue: $FieldMode{}
               value: EDIT
-            - type: wireHasNoChanges
-              operator: EQUALS
-              wire: $Prop{wire}
       - uesio/io.button:
           signals:
             - signal: component/CALL

--- a/libs/apps/uesio/appkit/bundle/components/form_detail.yaml
+++ b/libs/apps/uesio/appkit/bundle/components/form_detail.yaml
@@ -30,7 +30,7 @@ slots:
               component: uesio/io.item
               componentsignal: SET_READ_MODE
               targettype: specific
-              componentid: $Prop{wire}_item                
+              componentid: $Prop{wire}_item
           text: Save
           hotkey: "meta+s"
           uesio.variant: uesio/appkit.primary
@@ -59,7 +59,7 @@ slots:
                   value: EDIT
                 - type: wireHasChanges
                   operator: EQUALS
-                  wire: $Prop{wire}       
+                  wire: $Prop{wire}
       - uesio/io.button:
           signals:
             - signal: component/CALL

--- a/libs/apps/uesio/appkit/bundle/components/form_detail.yaml
+++ b/libs/apps/uesio/appkit/bundle/components/form_detail.yaml
@@ -28,7 +28,7 @@ slots:
                 - $Prop{wire}
             - signal: component/CALL
               component: uesio/io.item
-              componentsignal: TOGGLE_MODE
+              componentsignal: SET_READ_MODE
               targettype: specific
               componentid: $Prop{wire}_item                
           text: Save
@@ -44,21 +44,27 @@ slots:
               wire: $Prop{wire}
             - signal: component/CALL
               component: uesio/io.item
-              componentsignal: TOGGLE_MODE
+              componentsignal: SET_READ_MODE
               targettype: specific
               componentid: $Prop{wire}_item
           text: Cancel
           uesio.variant: uesio/appkit.secondary
           uesio.display:
-            - type: mergeValue
-              operator: EQUALS
-              sourceValue: $FieldMode{}
-              value: EDIT
+            - type: group
+              conjunction: OR
+              conditions:
+                - type: mergeValue
+                  operator: EQUALS
+                  sourceValue: $FieldMode{}
+                  value: EDIT
+                - type: wireHasChanges
+                  operator: EQUALS
+                  wire: $Prop{wire}       
       - uesio/io.button:
           signals:
             - signal: component/CALL
               component: uesio/io.item
-              componentsignal: TOGGLE_MODE
+              componentsignal: SET_EDIT_MODE
               targettype: specific
               componentid: $Prop{wire}_item
           text: EDIT
@@ -85,6 +91,7 @@ definition:
   - uesio/io.item:
       wire: $Prop{wire}
       uesio.id: $Prop{wire}_item
+      mode: READ
       components:
         - uesio/io.titlebar:
             title: $If{[$Prop{title}][$Prop{title}][$RecordMeta{name}]}


### PR DESCRIPTION
# What does this PR do?

1. Ensures that after a save or cancel, the form mode is toggled back to read
2. Eliminates the "Read" button since it's technically a cancel button and cancel seems more intuitive language for a user
3. Ensure the cancel button appears whenever form is in EDIT mode

# Testing

Tested manually and confirmed behaves as expected.
