### PR TITLE
chore: display username in user titles

### DIFF
--- a/libs/apps/uesio/studio/bundle/views/site.yaml
+++ b/libs/apps/uesio/studio/bundle/views/site.yaml
@@ -231,7 +231,7 @@ definition:
                                       text: ${uesio/core.firstname} ${uesio/core.lastname}
                                       element: div
                                   - uesio/io.text:
-                                      text: ${uesio/core.id}
+                                      text: ${uesio/core.username}
                                       uesio.variant: uesio/io.aside
                                       element: div
                                 signals:

--- a/libs/apps/uesio/studio/bundle/views/team.yaml
+++ b/libs/apps/uesio/studio/bundle/views/team.yaml
@@ -40,9 +40,12 @@ definition:
         uesio/studio.app:
         uesio/studio.member:
           fields:
+            uesio/core.id:
             uesio/core.firstname:
             uesio/core.lastname:
             uesio/core.picture:
+            uesio/core.username:
+            uesio/core.initials:
         uesio/studio.team:
       conditions:
         - field: uesio/studio.app
@@ -58,6 +61,12 @@ definition:
       fields:
         uesio/core.id:
         uesio/studio.member:
+          fields:
+            uesio/core.firstname:
+            uesio/core.lastname:
+            uesio/core.picture:
+            uesio/core.username:
+            uesio/core.initials:
         uesio/studio.team:
       init:
         query: false
@@ -157,6 +166,8 @@ definition:
                                         - uesio/io.field:
                                             fieldId: uesio/studio.member
                                             labelPosition: "none"
+                                            user:
+                                              subtitle: ${uesio/studio.member->uesio/core.username}
                                         - uesio/io.button:
                                             signals:
                                               - signal: wire/MARK_FOR_DELETE
@@ -209,11 +220,15 @@ definition:
                     searchFields:
                       - uesio/core.firstname
                       - uesio/core.lastname
+                      - uesio/core.username
+                      - uesio/core.id
                     returnFields:
+                      - uesio/core.id
                       - uesio/core.firstname
                       - uesio/core.lastname
                       - uesio/core.picture
                       - uesio/core.username
+                      - uesio/core.initials
                     components:
                       - uesio/io.tile:
                           content:
@@ -227,7 +242,7 @@ definition:
                           avatar:
                             - uesio/io.avatar:
                                 image: $UserFile{uesio/core.picture}
-                                text: "-"
+                                text: ${uesio/core.initials}
       actions:
         - uesio/io.button:
             uesio.variant: uesio/io.primary

--- a/libs/apps/uesio/studio/bundle/views/users.yaml
+++ b/libs/apps/uesio/studio/bundle/views/users.yaml
@@ -121,6 +121,7 @@ definition:
                       - uesio/core.firstname
                       - uesio/core.lastname
                       - uesio/core.username
+                      - uesio/core.id
                 - uesio/io.deck:
                     uesio.id: userslist
                     wire: users
@@ -133,7 +134,7 @@ definition:
                                 text: ${uesio/core.firstname} ${uesio/core.lastname}
                                 element: div
                             - uesio/io.text:
-                                text: ${uesio/core.id}
+                                text: ${uesio/core.username}
                                 uesio.variant: uesio/io.aside
                                 element: div
                           signals:


### PR DESCRIPTION
# What does this PR do?

Adds `username` to user tiles in a few places in the system (hopefully all of them).  Also, in situations where search user is supported, ensure that username and id are both search fields.

# Testing

Tested locally and confirmed display & search behavior.
