### PR TITLE
chore: refactor section_delete display conditions

### DIFF
--- a/libs/apps/uesio/appkit/bundle/components/section_delete.yaml
+++ b/libs/apps/uesio/appkit/bundle/components/section_delete.yaml
@@ -6,12 +6,23 @@ properties:
     defaultValue: Delete this $Collection{label}
   - name: subtitle
     defaultValue: You will not be able to access the information associated with this $Collection{label} again.
+  - name: editModeOnly
+    label: Edit Mode Only
+    defaultValue: true
+    type: CHECKBOX
 definition:
   - uesio/io.box:
       uesio.variant: uesio/appkit.section
       uesio.display:
-        - type: fieldMode
-          mode: EDIT
+        - type: group
+          conjunction: OR
+          conditions:
+            - type: fieldMode
+              mode: EDIT
+            - type: mergeValue
+              operator: EQUALS
+              sourceValue: $Prop{editModeOnly}
+              value: false
         - type: recordIsDeleteable
       components:
         - uesio/io.titlebar:
@@ -38,4 +49,5 @@ description: Delete Section
 sections:
   - type: HOME
     properties:
+      - editModeOnly
   - type: DISPLAY

--- a/libs/apps/uesio/studio/bundle/views/user.yaml
+++ b/libs/apps/uesio/studio/bundle/views/user.yaml
@@ -432,30 +432,25 @@ definition:
                                                       - font-mono
                                                   title: Temporary Password
                                                   subtitle: ${uesio/core.temporary_password}
-                      - uesio/io.item:
-                          # uesio/appkit.section_delete has a hardcoded display condition that the record must be in EDIT mode
-                          # so we wrap it inside an item with EDIT mode since the io.list can be in READ or EDIT mode
-                          mode: EDIT
-                          wire: users
-                          components:
-                            - uesio/appkit.section_delete:
-                                confirm: true
-                                confirmTitle: Are you sure?
-                                confirmMessage: The user ${uesio/core.username} will be deleted. This action cannot be undone.
-                                subtitle: The user will be permanently deleted from the system. Please be sure this what you want to do!
-                                signals:
-                                  - signal: context/SET
-                                    type: SITE_ADMIN
-                                    name: $Param{sitename}
-                                    app: $Param{app}
-                                  - signal: wire/MARK_FOR_DELETE
-                                  - signal: wire/SAVE
-                                    wires:
-                                      - "users"
-                                  - signal: context/CLEAR
-                                    type: SITE_ADMIN
-                                  - signal: "route/NAVIGATE"
-                                    path: app/$Param{app}/site/$Param{sitename}/users
+                      - uesio/appkit.section_delete:
+                          editModeOnly: false
+                          confirm: true
+                          confirmTitle: Are you sure?
+                          confirmMessage: The user ${uesio/core.username} will be deleted. This action cannot be undone.
+                          subtitle: The user will be permanently deleted from the system. Please be sure this what you want to do!
+                          signals:
+                            - signal: context/SET
+                              type: SITE_ADMIN
+                              name: $Param{sitename}
+                              app: $Param{app}
+                            - signal: wire/MARK_FOR_DELETE
+                            - signal: wire/SAVE
+                              wires:
+                                - "users"
+                            - signal: context/CLEAR
+                              type: SITE_ADMIN
+                            - signal: "route/NAVIGATE"
+                              path: app/$Param{app}/site/$Param{sitename}/users
   panels:
     newLoginMethod:
       uesio.type: uesio/io.dialog


### PR DESCRIPTION
# What does this PR do?

Adds `editModeOnly` property to section_delete component so that it can be used in EDIT or READ situations.

# Testing

Tested locally and confirmed expected behavior.
