### PR TITLE
Fix slot context issues

### DIFF
--- a/libs/ui/src/component/component.spec.tsx
+++ b/libs/ui/src/component/component.spec.tsx
@@ -87,12 +87,14 @@ const componentTypeWithSlotsAndContext = {
   ],
 }
 
-const getViewContext = () =>
-  new Context().addViewFrame({
-    params: { foo: "oof", bar: "rab" },
-    view: viewName,
-    viewDef,
-  })
+const getViewFrame = () => ({
+  params: { foo: "oof", bar: "rab" },
+  view: viewName,
+  viewDef,
+  type: "VIEW",
+})
+
+const getViewContext = () => new Context().addViewFrame(getViewFrame())
 
 const resolveDeclarativeComponentDefinitionTests = [
   {
@@ -187,6 +189,31 @@ const resolveDeclarativeComponentDefinitionTests = [
                 path: "",
                 componentType: "me/myapp.testcomponent",
                 readonly: false,
+                context: expect.objectContaining({
+                  stack: [
+                    {
+                      componentType: "me/myapp.testcomponent",
+                      data: {
+                        header: [
+                          {
+                            "uesio/io.text": {
+                              text: "$ComponentOutput{uesio/tests.notloadedyet:someproperty}",
+                            },
+                          },
+                        ],
+                        title: "$Param{foo}",
+                      },
+                      path: "",
+                      slots: [
+                        {
+                          name: "header",
+                        },
+                      ],
+                      type: "PROPS",
+                    },
+                    getViewFrame(),
+                  ],
+                }),
               },
             },
           ],

--- a/libs/ui/src/component/component.spec.tsx
+++ b/libs/ui/src/component/component.spec.tsx
@@ -187,6 +187,9 @@ const resolveDeclarativeComponentDefinitionTests = [
                 path: "",
                 componentType: "me/myapp.testcomponent",
                 readonly: false,
+                slotDef: {
+                  name: "header",
+                },
                 context: expect.objectContaining({
                   stack: [
                     {
@@ -265,6 +268,51 @@ const resolveDeclarativeComponentDefinitionTests = [
                 path: "",
                 componentType: "me/myapp.testcomponent",
                 readonly: false,
+                slotDef: {
+                  name: "header",
+                  providesContexts: [
+                    {
+                      type: "WIRE",
+                      wireProperty: "wire",
+                    },
+                  ],
+                },
+                context: expect.objectContaining({
+                  stack: [
+                    {
+                      componentType: "me/myapp.testcomponent",
+                      data: {
+                        header: [
+                          {
+                            "uesio/io.text": {
+                              text: "$ComponentOutput{uesio/tests.notloadedyet:someproperty}",
+                            },
+                          },
+                        ],
+                        title: "$Param{foo}",
+                      },
+                      path: "",
+                      slots: [
+                        {
+                          name: "header",
+                          providesContexts: [
+                            {
+                              type: "WIRE",
+                              wireProperty: "wire",
+                            },
+                          ],
+                        },
+                      ],
+                      type: "PROPS",
+                    },
+                    {
+                      params: { foo: "oof", bar: "rab" },
+                      view: viewName,
+                      viewDef,
+                      type: "VIEW",
+                    },
+                  ],
+                }),
               },
             },
           ],

--- a/libs/ui/src/component/component.spec.tsx
+++ b/libs/ui/src/component/component.spec.tsx
@@ -87,14 +87,12 @@ const componentTypeWithSlotsAndContext = {
   ],
 }
 
-const getViewFrame = () => ({
-  params: { foo: "oof", bar: "rab" },
-  view: viewName,
-  viewDef,
-  type: "VIEW",
-})
-
-const getViewContext = () => new Context().addViewFrame(getViewFrame())
+const getViewContext = () =>
+  new Context().addViewFrame({
+    params: { foo: "oof", bar: "rab" },
+    view: viewName,
+    viewDef,
+  })
 
 const resolveDeclarativeComponentDefinitionTests = [
   {
@@ -211,7 +209,12 @@ const resolveDeclarativeComponentDefinitionTests = [
                       ],
                       type: "PROPS",
                     },
-                    getViewFrame(),
+                    {
+                      params: { foo: "oof", bar: "rab" },
+                      view: viewName,
+                      viewDef,
+                      type: "VIEW",
+                    },
                   ],
                 }),
               },

--- a/libs/ui/src/components/slot.tsx
+++ b/libs/ui/src/components/slot.tsx
@@ -22,9 +22,21 @@ const Slot: UC<SlotDefinition> = (props) => {
     definition,
     readonly,
     path,
+    context: slotContext,
   } = props.definition
 
   if (!definition) return null
+
+  let contextToUse = context
+
+  // If we have a custom slot context in our parent context, we need to transfer it
+  if (slotContext) {
+    contextToUse = slotContext
+    const slotLoader = context.getCustomSlotLoader()
+    if (slotLoader) {
+      contextToUse = contextToUse.setCustomSlotLoader(slotLoader)
+    }
+  }
 
   return (
     <SlotUtility
@@ -32,7 +44,7 @@ const Slot: UC<SlotDefinition> = (props) => {
       listName={name}
       readonly={readonly}
       path={path}
-      context={context
+      context={contextToUse
         .removeAllComponentFrames(DECLARATIVE_COMPONENT)
         .removeAllPropsFrames()}
       componentType={props.definition.componentType || componentType}

--- a/libs/ui/src/components/slot.tsx
+++ b/libs/ui/src/components/slot.tsx
@@ -1,5 +1,6 @@
 import { DECLARATIVE_COMPONENT } from "../component/component"
 import { Context } from "../context/context"
+import { SlotDef } from "../definition/component"
 import { DefinitionMap, UC } from "../definition/definition"
 
 import SlotUtility, { DefaultSlotName } from "../utilities/slot"
@@ -12,26 +13,49 @@ type SlotDefinition = {
   readonly?: boolean
   path: string
   componentType: string | undefined
+  slotDef: SlotDef
   context: Context
 }
 
 const Slot: UC<SlotDefinition> = (props) => {
-  const { context, componentType } = props
+  const {
+    // The context coming from the parent of this slot.
+    // That is, the context of the component that declared that
+    // the slot exists and used the $Slot{myslot} merge.
+    context,
+    // The componentType of the slot component.
+    // (This should always be uesio/core.slot)
+    componentType,
+  } = props
   const {
     name = DefaultSlotName,
+    // The view definition markup of the contents of the slot.
     definition,
+    // In build-time this defines whether the contents of this slot
+    // can be changed.
     readonly,
     path,
+    // The context coming from the view that "used" this slot by giving
+    // it a definition for its contents.
     context: slotContext,
+    // The definition of the slot as defined by the component that declared it.
+    slotDef,
   } = props.definition
 
   if (!definition) return null
 
-  let contextToUse = context
+  let contextToUse
 
-  // If we have a custom slot context in our parent context, we need to transfer it
-  if (slotContext) {
+  // If the slot has declared that it provides additional context for its contents,
+  // then just use the context that it provides.
+  if (slotDef.providesContexts) {
+    contextToUse = context
+  }
+  // Otherwise, we should use the context from the component that provided the content.
+  else {
     contextToUse = slotContext
+    // We still need to keep the custom slot loader from our parent context.
+    // So add that to our slotContext if it exists.
     const slotLoader = context.getCustomSlotLoader()
     if (slotLoader) {
       contextToUse = contextToUse.setCustomSlotLoader(slotLoader)

--- a/libs/ui/src/context/merge.ts
+++ b/libs/ui/src/context/merge.ts
@@ -414,6 +414,10 @@ const handlers: Record<MergeType, MergeHandler> = {
         path: propsFrame.path || "",
         readonly: !!componentFrame,
         componentType: propsFrame.componentType,
+        // Our context typing setup isn't really meant to store
+        // a complex object like this, but it's necessary to
+        // keep the context of the creator of a slot so that
+        // it can be used when the slot is eventually rendered.
         context: slotContext as unknown as FieldValue,
       },
     }

--- a/libs/ui/src/context/merge.ts
+++ b/libs/ui/src/context/merge.ts
@@ -401,6 +401,10 @@ const handlers: Record<MergeType, MergeHandler> = {
       return {}
     }
 
+    // If the slot says it provides context, then let it render its contents
+    // in the context of itself instead of the parent.
+    const slotContext = slotDef.providesContexts ? undefined : context
+
     return {
       "uesio/core.slot": {
         name: expression,
@@ -410,6 +414,7 @@ const handlers: Record<MergeType, MergeHandler> = {
         path: propsFrame.path || "",
         readonly: !!componentFrame,
         componentType: propsFrame.componentType,
+        context: slotContext as unknown as FieldValue,
       },
     }
   },

--- a/libs/ui/src/context/merge.ts
+++ b/libs/ui/src/context/merge.ts
@@ -401,10 +401,6 @@ const handlers: Record<MergeType, MergeHandler> = {
       return {}
     }
 
-    // If the slot says it provides context, then let it render its contents
-    // in the context of itself instead of the parent.
-    const slotContext = slotDef.providesContexts ? undefined : context
-
     return {
       "uesio/core.slot": {
         name: expression,
@@ -414,11 +410,12 @@ const handlers: Record<MergeType, MergeHandler> = {
         path: propsFrame.path || "",
         readonly: !!componentFrame,
         componentType: propsFrame.componentType,
-        // Our context typing setup isn't really meant to store
-        // a complex object like this, but it's necessary to
-        // keep the context of the creator of a slot so that
+        // Our merge handler typing setup isn't really meant to store
+        // a complex object like slotDef or context, but it's necessary
+        // to keep the context of the creator of a slot so that
         // it can be used when the slot is eventually rendered.
-        context: slotContext as unknown as FieldValue,
+        slotDef: slotDef as unknown as FieldValue,
+        context: context as unknown as FieldValue,
       },
     }
   },


### PR DESCRIPTION
# What does this PR do?

This PR reverts some of the changes I made in February. https://github.com/ues-io/uesio/pull/4599

1. Pass the context of the creator of the slot as part of the slot definition so that it can be used when it's time to render.
2. For example, if the contents of a slot reference a wire in the same view, it should be available when that slot is rendered. Even if that slot is being rendered as part of a different view.

EXAMPLE:
```
- uesio/core.view:
    view: uesio/cms.admin_nav
    params:
      selected: articles
    slots:
      crumbs:
        - uesio/io.group:
            uesio.variant: uesio/appkit.breadcrumbs
            components:
              - uesio/appkit.icontile:
                  tileVariant: uesio/appkit.breadcrumb
                  title: Articles
                  icon: article
                  signals:
                    - signal: route/NAVIGATE_TO_ASSIGNMENT
                      collection: uesio/cms.article
                      viewtype: list
              - uesio/appkit.icontile:
                  tileVariant: uesio/appkit.breadcrumb
                  avatarVariant: uesio/appkit.breadcrumb
                  title: ${article:uesio/cms.name}
```
In this example, on the last line there is a merge of `${article:uesio/cms.name}` but it happens inside of a view slot.
This will not merge correctly without the changes made in this PR.

However, to keep the fix that https://github.com/ues-io/uesio/pull/4599 fixes, we need to pass on the customSlotLoader from the current rendering context. (This PR also does that)

This is pretty complicated, so I'm happy to discuss on a call.
