### PR TITLE
Update to latest models

### DIFF
--- a/apps/platform/pkg/bot/systemdialect/systembot_listener_runagent.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_listener_runagent.go
@@ -31,7 +31,7 @@ func runAgentListenerBot(params map[string]any, connection wire.Connection, sess
 		return nil, err
 	}
 
-	modelID := param.GetOptionalString(params, "model", bedrock.CLAUDE_3_5_SONNET_MODEL_ID)
+	modelID := param.GetOptionalString(params, "model", bedrock.CLAUDE_4_SONNET_MODEL_ID)
 
 	hiddenInputPrefix := param.GetOptionalString(params, "hiddenInputPrefix", "")
 

--- a/apps/platform/pkg/integ/bedrock/bedrock.go
+++ b/apps/platform/pkg/integ/bedrock/bedrock.go
@@ -82,21 +82,21 @@ type ModelHandler interface {
 	Stream(c *Connection, options *InvokeModelOptions) (stream *integ.Stream, err error)
 }
 
-const CLAUDE_3_HAIKU_MODEL_ID = "anthropic.claude-3-haiku-20240307-v1:0"
-const CLAUDE_3_SONNET_MODEL_ID = "anthropic.claude-3-sonnet-20240229-v1:0"
-const CLAUDE_3_5_SONNET_MODEL_ID = "anthropic.claude-3-5-sonnet-20241022-v2:0"
-const CLAUDE_3_OPUS_MODEL_ID = "anthropic.claude-3-opus-20240229-v1:0"
+const CLAUDE_3_5_HAIKU_MODEL_ID = "us.anthropic.claude-3-5-haiku-20241022-v1:0"
+const CLAUDE_4_OPUS_MODEL_ID = "us.anthropic.claude-opus-4-20250514-v1:0"
+const CLAUDE_4_SONNET_MODEL_ID = "us.anthropic.claude-sonnet-4-20250514-v1:0"
 const STABILITY_IMAGE_ULTRA_MODEL_ID = "stability.stable-image-ultra-v1:0"
 const UESIO_TEST_SIMPLE_MODEL_ID = "uesio.test-simple-responder"
 const UESIO_TEST_ANTHROPIC_MODEL_ID = "uesio.test-anthropic-format"
 
+const BEDROCK_DEFAULT_MODEL_ID = CLAUDE_3_5_HAIKU_MODEL_ID
+
 var modelHandlers = map[string]ModelHandler{
 	UESIO_TEST_ANTHROPIC_MODEL_ID:  uesioTestAnthropicModelHandler,
 	UESIO_TEST_SIMPLE_MODEL_ID:     uesioTestModelHandler,
-	CLAUDE_3_HAIKU_MODEL_ID:        claudeModelHandler,
-	CLAUDE_3_SONNET_MODEL_ID:       claudeModelHandler,
-	CLAUDE_3_5_SONNET_MODEL_ID:     claudeModelHandler,
-	CLAUDE_3_OPUS_MODEL_ID:         claudeModelHandler,
+	CLAUDE_3_5_HAIKU_MODEL_ID:      claudeModelHandler,
+	CLAUDE_4_OPUS_MODEL_ID:         claudeModelHandler,
+	CLAUDE_4_SONNET_MODEL_ID:       claudeModelHandler,
 	STABILITY_IMAGE_ULTRA_MODEL_ID: stabilityModelHandler,
 }
 

--- a/apps/platform/pkg/integ/bedrock/claude.go
+++ b/apps/platform/pkg/integ/bedrock/claude.go
@@ -76,18 +76,6 @@ type ClaudeModelHandler struct {
 var claudeModelHandler = &ClaudeModelHandler{}
 
 func (cmh *ClaudeModelHandler) GetClientOptions(input *bedrockruntime.InvokeModelInput) func(o *bedrockruntime.Options) {
-
-	// TODO: Claude 3.5 Sonnet is currently only supported on us-west-2
-	// see: https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html
-	// If there becomes broader support for this model on other regions, we can remove this.
-	// Also there is a thing called cross region inference, which I don't fully understand.
-	// https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference.html
-	if *input.ModelId == CLAUDE_3_5_SONNET_MODEL_ID {
-		return func(o *bedrockruntime.Options) {
-			o.Region = "us-west-2"
-		}
-	}
-
 	return func(o *bedrockruntime.Options) {}
 }
 
@@ -106,12 +94,6 @@ func (cmh *ClaudeModelHandler) GetBody(options *InvokeModelOptions) ([]byte, err
 	}
 
 	anthropicBeta := []string{}
-	// NOTE: This computer use antropic beta flag allows us to use tools
-	// like the "text_editor_20241022" tool provided by anthropic.
-	// It changes the schema validator to allow tools to have a "type" property.
-	if options.Model == CLAUDE_3_5_SONNET_MODEL_ID {
-		anthropicBeta = []string{"computer-use-2024-10-22"}
-	}
 
 	return json.Marshal(AnthropicMessagesInput{
 		Messages:         messages,

--- a/apps/platform/pkg/integ/bedrock/invoke.go
+++ b/apps/platform/pkg/integ/bedrock/invoke.go
@@ -19,7 +19,7 @@ func (c *Connection) invokeModel(requestOptions map[string]any) (any, error) {
 
 	handler, ok := modelHandlers[options.Model]
 	if !ok {
-		return nil, fmt.Errorf("model note supported: %s", options.Model)
+		return nil, fmt.Errorf("model not supported: %s", options.Model)
 	}
 
 	result, inputTokens, outputTokens, err := handler.Invoke(c, options)

--- a/apps/platform/pkg/integ/bedrock/invoke.go
+++ b/apps/platform/pkg/integ/bedrock/invoke.go
@@ -13,9 +13,13 @@ func (c *Connection) invokeModel(requestOptions map[string]any) (any, error) {
 		return nil, err
 	}
 
+	if options.Model == "" {
+		options.Model = BEDROCK_DEFAULT_MODEL_ID
+	}
+
 	handler, ok := modelHandlers[options.Model]
 	if !ok {
-		return nil, fmt.Errorf("model not supported: %s", options.Model)
+		return nil, fmt.Errorf("model note supported: %s", options.Model)
 	}
 
 	result, inputTokens, outputTokens, err := handler.Invoke(c, options)

--- a/apps/platform/pkg/integ/bedrock/stream.go
+++ b/apps/platform/pkg/integ/bedrock/stream.go
@@ -31,6 +31,10 @@ func (c *Connection) streamModel(requestOptions map[string]any) (any, error) {
 		return nil, err
 	}
 
+	if options.Model == "" {
+		options.Model = BEDROCK_DEFAULT_MODEL_ID
+	}
+
 	handler, ok := modelHandlers[options.Model]
 	if !ok {
 		return nil, fmt.Errorf("model not supported: %s", options.Model)

--- a/libs/apps/uesio/aikit/bundle/bots/listener/ai_chat/bot.ts
+++ b/libs/apps/uesio/aikit/bundle/bots/listener/ai_chat/bot.ts
@@ -43,8 +43,6 @@ export default function ai_chat(bot: ListenerBotApi) {
     "uesio/aikit.bedrock",
     "invokemodel",
     {
-      //model: "anthropic.claude-3-sonnet-20240229-v1:0",
-      model: "anthropic.claude-3-haiku-20240307-v1:0",
       messages,
       system: systemPrompt,
     },

--- a/libs/apps/uesio/aikit/bundle/bots/listener/summarize_thread/bot.ts
+++ b/libs/apps/uesio/aikit/bundle/bots/listener/summarize_thread/bot.ts
@@ -41,8 +41,6 @@ export default function summarize_thread(bot: ListenerBotApi) {
     "uesio/aikit.bedrock",
     "invokemodel",
     {
-      //model: "anthropic.claude-3-sonnet-20240229-v1:0",
-      model: "anthropic.claude-3-haiku-20240307-v1:0",
       messages,
       system:
         "You are an assistant who summarizes chat threads. Please bring out the important points of the conversation into a title. Try to be brief and only respond with the title.",

--- a/libs/apps/uesio/aikit/bundle/componentpacks/main/src/components/agent_chat/agent_chat.tsx
+++ b/libs/apps/uesio/aikit/bundle/componentpacks/main/src/components/agent_chat/agent_chat.tsx
@@ -29,7 +29,7 @@ type AgentChatDefinition = {
   afterChatSignals?: signal.SignalDefinition[] | string
 }
 
-const REPLACEMENT_TOOL = "str_replace_editor"
+const REPLACEMENT_TOOL = "str_replace_based_edit_tool"
 
 const StyleDefaults = Object.freeze({
   root: [],

--- a/libs/apps/uesio/aikit/bundle/componentpacks/main/src/utilities/claudebutton/claudebutton.tsx
+++ b/libs/apps/uesio/aikit/bundle/componentpacks/main/src/utilities/claudebutton/claudebutton.tsx
@@ -67,7 +67,6 @@ const ClaudeInvokeButton: definition.UtilityComponent<Props> = (props) => {
                 stepId,
                 params: {
                   input: prompt,
-                  model: "anthropic.claude-3-haiku-20240307-v1:0",
                   temperature: 0.5,
                   tools,
                   tool_choice: toolChoice,

--- a/libs/apps/uesio/appkit/bundle/bots/generator/collection/bot.js
+++ b/libs/apps/uesio/appkit/bundle/bots/generator/collection/bot.js
@@ -27,8 +27,6 @@ function run(bot) {
     .concat("user")
     .concat(...(additionalCollections || []))
 
-  const modelID = "anthropic.claude-3-haiku-20240307-v1:0"
-
   const systemPrompt = `
 		You are an assistant who specializes in creating data models for databases.
 		You deeply understand relational databases and seek to complete the task in
@@ -140,7 +138,6 @@ function run(bot) {
     "uesio/aikit.bedrock",
     "invokemodel",
     {
-      model: modelID,
       messages: [
         {
           role: "user",

--- a/libs/apps/uesio/appkit/bundle/bots/generator/collections/bot.js
+++ b/libs/apps/uesio/appkit/bundle/bots/generator/collections/bot.js
@@ -1,5 +1,4 @@
 function run(bot) {
-  const modelID = "anthropic.claude-3-haiku-20240307-v1:0"
   const appInfo = bot.getApp()
   const appFullName = bot.getAppName()
   const appDescription = appInfo.getDescription()
@@ -195,7 +194,6 @@ function run(bot) {
     "uesio/aikit.bedrock",
     "invokemodel",
     {
-      model: modelID,
       messages: [
         {
           role: "user",

--- a/libs/apps/uesio/appkit/bundle/bots/generator/sample_data_collection/bot.js
+++ b/libs/apps/uesio/appkit/bundle/bots/generator/sample_data_collection/bot.js
@@ -12,7 +12,6 @@ function run(bot) {
     ],
   })
 
-  const modelID = "anthropic.claude-3-haiku-20240307-v1:0"
   const appInfo = bot.getApp()
   const user = bot.getUser()
   const appName = appInfo.getName()
@@ -143,7 +142,6 @@ function run(bot) {
     "uesio/aikit.bedrock",
     "invokemodel",
     {
-      model: modelID,
       messages: [
         {
           role: "user",

--- a/libs/apps/uesio/builder/bundle/componentpacks/main/src/components/mainwrapper/editortool.tsx
+++ b/libs/apps/uesio/builder/bundle/componentpacks/main/src/components/mainwrapper/editortool.tsx
@@ -109,7 +109,7 @@ const handleMessage = (
   context: context.Context,
   message: ToolUseResponse,
 ): ToolResultResponse => {
-  if (message.name === "str_replace_editor") {
+  if (message.name === "str_replace_based_edit_tool") {
     return handleReplaceEditor(context, message)
   }
 

--- a/libs/apps/uesio/sitekit/bundle/bots/generator/starter/bot.js
+++ b/libs/apps/uesio/sitekit/bundle/bots/generator/starter/bot.js
@@ -16,8 +16,6 @@ function run(bot) {
   const doLogoAndBackground =
     doLogoAndBackgroundParam && doLogoAndBackgroundParam !== "false"
 
-  const modelID = "anthropic.claude-3-haiku-20240307-v1:0"
-
   let headerLogoFile = "uesio/sitekit.yourlogo"
   let headerLogoFilePath = ""
   let footerLogoFile = "uesio/sitekit.yourlogo"
@@ -301,7 +299,6 @@ function run(bot) {
       "uesio/aikit.bedrock",
       "invokemodel",
       {
-        model: modelID,
         messages: [
           {
             role: "user",

--- a/libs/apps/uesio/studio/bundle/agents/viewbuilder/agent.yaml
+++ b/libs/apps/uesio/studio/bundle/agents/viewbuilder/agent.yaml
@@ -2,6 +2,6 @@ name: viewbuilder
 label: View Builder
 description: An AI assistant to help with building views.
 tools:
-  - name: str_replace_editor
-    type: text_editor_20241022
+  - name: str_replace_based_edit_tool
+    type: text_editor_20250429
 public: true


### PR DESCRIPTION
# What does this PR do?

1. Adds a default model to be used for bedrock when one isn't provided.
2. Uses the default model whenever possible in our calling code.
3. Removes special region handling for Claude 3.5 and switches to cross-region inference models.

Now, most of our AI features will use Claude 3.5 Haiku (Upgraded from Claude 3 Haiku). The builder agent will now use Claude 4 (Upgraded from Claude 3.5 v2).

# Testing (I did each of these things)

1. Test creating fields for a collection
2. Test image generation models in sitekit.
3. Test the sitekit starter template.
4. Test the appkit starter template.
5. Test the view builder agent.

NOTE: I have not requested model access to these new models in the PROD AWS account, only DEV.
