### PR TITLE
feat: Improve file ui in workspaces

### DIFF
--- a/apps/platform/pkg/datasource/load_metadata.go
+++ b/apps/platform/pkg/datasource/load_metadata.go
@@ -45,7 +45,7 @@ var specialRefs = map[string]SpecialReferences{
 		ReferenceMetadata: &wire.ReferenceMetadata{
 			Collection: "uesio/core.userfile",
 		},
-		Fields: []string{"uesio/core.mimetype", "uesio/core.path", "uesio/core.updatedat"},
+		Fields: []string{"uesio/core.mimetype", "uesio/core.path", "uesio/core.updatedat", "uesio/core.fieldid"},
 	},
 	"USER": {
 		ReferenceMetadata: &wire.ReferenceMetadata{

--- a/apps/platform/pkg/types/file/filemetadata.go
+++ b/apps/platform/pkg/types/file/filemetadata.go
@@ -1,9 +1,6 @@
 package file
 
 import (
-	"encoding/json"
-	"mime"
-	"path"
 	"time"
 )
 
@@ -11,26 +8,4 @@ type Metadata interface {
 	ContentLength() int64
 	LastModified() time.Time
 	Path() string
-}
-
-type MetadataWrapper struct {
-	Metadata
-}
-
-func (m MetadataWrapper) MarshalJSON() ([]byte, error) {
-	type metadataJSON struct {
-		FileSize int64     `json:"filesize"`
-		Path     string    `json:"path"`
-		Modified time.Time `json:"modified"`
-		MimeType string    `json:"mimetype"`
-	}
-
-	filePath := m.Path()
-
-	return json.Marshal(metadataJSON{
-		FileSize: m.ContentLength(),
-		Path:     filePath,
-		Modified: m.LastModified(),
-		MimeType: mime.TypeByExtension(path.Ext(filePath)),
-	})
 }

--- a/libs/apps/uesio/io/bundle/componentpacks/main/src/components/fileattachment/fileattachment.tsx
+++ b/libs/apps/uesio/io/bundle/componentpacks/main/src/components/fileattachment/fileattachment.tsx
@@ -34,15 +34,6 @@ const FileAttachment: definition.UC<FileDefinition> = (props) => {
   // If we don't have a record in context, bail
   if (!record) return null
 
-  const collectionName = record.getWire().getCollection().getFullName()
-
-  if (collectionName !== "uesio/core.userfile")
-    throw new Error(
-      "Wrong Record Type In Context: " +
-        collectionName +
-        " Expecting a userfile",
-    )
-
   const userFile = record.source as UserFileMetadata
 
   return (

--- a/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/file/file.tsx
+++ b/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/file/file.tsx
@@ -9,6 +9,7 @@ type FileInfo = {
   url: string
   name: string
   mimetype: string
+  isAttachment: boolean
 }
 
 interface FileUtilityProps {
@@ -49,7 +50,7 @@ const File: definition.UtilityComponent<FileUtilityProps> = (props) => {
     <>
       {mode === "EDIT" && (
         <UploadArea
-          onUpload={onUpload}
+          onUpload={fileInfo?.isAttachment ? undefined : onUpload}
           onDelete={onDelete}
           context={context}
           accept={accept}
@@ -68,12 +69,12 @@ const File: definition.UtilityComponent<FileUtilityProps> = (props) => {
         </UploadArea>
       )}
 
-      {
+      {fileInfo && fileInfo.url && (
         <Tile
           context={context}
           className={styles.cx(classes.root, classes.input, classes.readonly)}
         >
-          {fileInfo && (
+          {
             <div className={classes.selecteditemwrapper}>
               <div className={classes.selectediteminner}>{fileInfo.name}</div>
               <a href={fileInfo.url}>
@@ -95,9 +96,9 @@ const File: definition.UtilityComponent<FileUtilityProps> = (props) => {
                 </label>
               )}
             </div>
-          )}
+          }
         </Tile>
-      }
+      )}
     </>
   )
 }

--- a/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/fileimage/fileimage.tsx
+++ b/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/fileimage/fileimage.tsx
@@ -14,6 +14,13 @@ interface FileImageProps {
   accept?: string
 }
 
+interface EditButtonsProps {
+  mode?: context.FieldMode
+  fileInfo?: FileInfo
+  uploadLabelId: string
+  deleteLabelId: string
+}
+
 const StyleDefaults = Object.freeze({
   root: ["relative", "group"],
   actionicon: [
@@ -35,6 +42,37 @@ const StyleDefaults = Object.freeze({
   nofileicon: ["text-4xl", "p-8", "text-slate-400"],
 })
 
+const EditButtons: definition.UtilityComponent<EditButtonsProps> = (props) => {
+  const { mode, fileInfo, uploadLabelId, deleteLabelId, classes, context } =
+    props
+  if (!classes) return
+  if (mode !== "EDIT") return
+  // only show the edit button if we're not an attachment
+  // or we don't have any file info
+  const showEditButton = !fileInfo || !fileInfo?.isAttachment
+  const showDeleteButton = !!fileInfo
+  return (
+    <>
+      {showEditButton && (
+        <label
+          className={styles.cx(classes.editicon, classes.actionicon)}
+          htmlFor={uploadLabelId}
+        >
+          <Icon context={context} icon="edit" />
+        </label>
+      )}
+      {showDeleteButton && (
+        <label
+          className={styles.cx(classes.deleteicon, classes.actionicon)}
+          htmlFor={deleteLabelId}
+        >
+          <Icon context={context} icon="delete" />
+        </label>
+      )}
+    </>
+  )
+}
+
 const FileImage: definition.UtilityComponent<FileImageProps> = (props) => {
   const { context, mode, fileInfo, accept, onUpload, onDelete } = props
 
@@ -53,24 +91,14 @@ const FileImage: definition.UtilityComponent<FileImageProps> = (props) => {
       uploadLabelId={uploadLabelId}
       deleteLabelId={deleteLabelId}
     >
-      {mode === "EDIT" && (
-        <>
-          <label
-            className={styles.cx(classes.editicon, classes.actionicon)}
-            htmlFor={uploadLabelId}
-          >
-            <Icon context={context} icon="edit" />
-          </label>
-          {fileInfo && (
-            <label
-              className={styles.cx(classes.deleteicon, classes.actionicon)}
-              htmlFor={deleteLabelId}
-            >
-              <Icon context={context} icon="delete" />
-            </label>
-          )}
-        </>
-      )}
+      <EditButtons
+        context={context}
+        mode={mode}
+        fileInfo={fileInfo}
+        classes={classes}
+        uploadLabelId={uploadLabelId}
+        deleteLabelId={deleteLabelId}
+      />
       {fileInfo ? (
         // eslint-disable-next-line jsx-a11y/alt-text -- TODO See https://github.com/ues-io/uesio/issues/4489
         <img className={classes.image} src={fileInfo.url} />
@@ -87,6 +115,6 @@ const FileImage: definition.UtilityComponent<FileImageProps> = (props) => {
   )
 }
 
-export { StyleDefaults }
+export { StyleDefaults, EditButtons }
 
 export default FileImage

--- a/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/filevideo/filevideo.tsx
+++ b/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/filevideo/filevideo.tsx
@@ -2,7 +2,7 @@ import { definition, styles, context } from "@uesio/ui"
 import { nanoid } from "@reduxjs/toolkit"
 import Icon from "../icon/icon"
 import UploadArea from "../uploadarea/uploadarea"
-import { StyleDefaults } from "../fileimage/fileimage"
+import { EditButtons, StyleDefaults } from "../fileimage/fileimage"
 import { FileInfo } from "../file/file"
 
 interface FileVideoProps {
@@ -45,24 +45,14 @@ const FileVideo: definition.UtilityComponent<FileVideoProps> = (props) => {
       uploadLabelId={uploadLabelId}
       deleteLabelId={deleteLabelId}
     >
-      {mode === "EDIT" && (
-        <>
-          <label
-            className={styles.cx(classes.editicon, classes.actionicon)}
-            htmlFor={uploadLabelId}
-          >
-            <Icon context={context} icon="edit" />
-          </label>
-          {fileInfo && (
-            <label
-              className={styles.cx(classes.deleteicon, classes.actionicon)}
-              htmlFor={deleteLabelId}
-            >
-              <Icon context={context} icon="delete" />
-            </label>
-          )}
-        </>
-      )}
+      <EditButtons
+        context={context}
+        mode={mode}
+        fileInfo={fileInfo}
+        classes={classes}
+        uploadLabelId={uploadLabelId}
+        deleteLabelId={deleteLabelId}
+      />
       {fileInfo ? (
         <video autoPlay={autoplay || true} muted={muted || true}>
           <source src={fileUrl} />

--- a/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/uploadarea/uploadarea.tsx
+++ b/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/uploadarea/uploadarea.tsx
@@ -3,7 +3,7 @@ import { definition, styles } from "@uesio/ui"
 
 interface UploadAreaProps {
   accept?: string
-  onUpload: (files: FileList | null) => void
+  onUpload?: (files: FileList | null) => void
   onDelete?: () => void
   onClick?: () => void
   uploadLabelId?: string
@@ -32,7 +32,7 @@ const UploadArea: definition.UtilityComponent<UploadAreaProps> = (props) => {
   const onDrop = (e: DragEvent) => {
     e.preventDefault()
     e.stopPropagation()
-    onUpload(e.dataTransfer.files)
+    onUpload?.(e.dataTransfer.files)
   }
 
   const onDragOver = (e: DragEvent) => {
@@ -61,33 +61,37 @@ const UploadArea: definition.UtilityComponent<UploadAreaProps> = (props) => {
 
   return (
     <>
-      <div
-        onDrop={onDrop}
-        onDragOver={onDragOver}
-        onDragEnter={onDragEnter}
-        onDragLeave={onDragLeave}
-        className={classes.root}
-        onClick={(e) => {
-          if (props.onClick) {
-            e.preventDefault()
-            e.stopPropagation()
-            props.onClick()
-          }
-        }}
-      >
-        {children}
-      </div>
-      <input
-        className={classes.fileinput}
-        type="file"
-        accept={accept}
-        onChange={(e) => {
-          onUpload(e.target.files)
-          resetFile()
-        }}
-        ref={fileInputRef}
-        id={uploadLabelId}
-      />
+      {onUpload && (
+        <>
+          <div
+            onDrop={onDrop}
+            onDragOver={onDragOver}
+            onDragEnter={onDragEnter}
+            onDragLeave={onDragLeave}
+            className={classes.root}
+            onClick={(e) => {
+              if (props.onClick) {
+                e.preventDefault()
+                e.stopPropagation()
+                props.onClick()
+              }
+            }}
+          >
+            {children}
+          </div>
+          <input
+            className={classes.fileinput}
+            type="file"
+            accept={accept}
+            onChange={(e) => {
+              onUpload(e.target.files)
+              resetFile()
+            }}
+            ref={fileInputRef}
+            id={uploadLabelId}
+          />
+        </>
+      )}
       {onDelete && (
         <input
           className={classes.fileinput}

--- a/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/userfile/userfile.tsx
+++ b/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/userfile/userfile.tsx
@@ -81,6 +81,7 @@ const UserFile: definition.UtilityComponent<UserFileUtilityProps> = (props) => {
           url: fileUrl,
           name: userFile["uesio/core.path"],
           mimetype: userFile["uesio/core.mimetype"],
+          isAttachment: !userFile["uesio/core.fieldid"],
         }
       : undefined
 

--- a/libs/apps/uesio/studio/bundle/views/file.yaml
+++ b/libs/apps/uesio/studio/bundle/views/file.yaml
@@ -111,6 +111,7 @@ definition:
                                   root:
                                     - mt-6
                                     - gap-6
+                                    - lg:gap-y-6
                                 items:
                                   - uesio/io.field:
                                       wrapperVariant: uesio/io.minimal

--- a/libs/apps/uesio/studio/bundle/views/file.yaml
+++ b/libs/apps/uesio/studio/bundle/views/file.yaml
@@ -19,7 +19,7 @@ definition:
         uesio/studio.name:
         uesio/studio.namespace:
         uesio/studio.path:
-        uesio/studio.attachments:
+        uesio/core.attachments:
         uesio/studio.appicon:
         uesio/studio.appcolor:
         uesio/core.owner:
@@ -32,7 +32,7 @@ definition:
           value: true
         - field: uesio/studio.item
           value: $Param{namespace}.$Param{filename}
-    attachments:
+    newattachment:
       collection: uesio/core.userfile
       fields:
         uesio/core.id:
@@ -49,7 +49,7 @@ definition:
           lookupField: uesio/core.id
       init:
         create: true
-        query: true
+        query: false
       defaults:
         - field: uesio/core.recordid
           valueSource: LOOKUP
@@ -110,27 +110,21 @@ definition:
                                 uesio.styleTokens:
                                   root:
                                     - mt-6
-                                    - lg:gap-y-6
-                                uesio.display:
-                                  - type: paramValue
-                                    param: app
-                                    operator: NOT_EQUALS
-                                    value: $Param{namespace}
+                                    - gap-6
                                 items:
                                   - uesio/io.field:
                                       wrapperVariant: uesio/io.minimal
-                                      fieldId: uesio/studio.attachments
+                                      fieldId: uesio/core.attachments
                                       labelPosition: none
-                                      displayAs: DECK
-                                      list:
+                                      reference:
                                         components:
                                           - uesio/io.card:
                                               uesio.variant: uesio/appkit.main
                                               uesio.styleTokens:
                                                 titlebarTitle:
                                                   - break-all
-                                              title: ${path}
-                                              subtitle: ${mimetype}
+                                              title: ${uesio/core.path}
+                                              subtitle: ${uesio/core.mimetype}
                                               actions:
                                                 - uesio/io.box:
                                                     components:
@@ -140,72 +134,70 @@ definition:
                                                               - bg-white
                                                               - w-max
                                                           uesio.variant: uesio/appkit.badge
-                                                          text: $FileSize{${filesize}}
+                                                          text: $FileSize{${uesio/core.contentlength}}
                                                           element: div
                                               content:
-                                                - uesio/io.image:
-                                                    uesio.context:
-                                                      workspace:
-                                                        name: $Param{workspacename}
-                                                        app: $Param{app}
-                                                    file: $Parent.Record{uesio/studio.namespace}.$Parent.Record{uesio/studio.name}
-                                                    filepath: ${path}
+                                                - uesio/io.box:
                                                     uesio.display:
-                                                      - type: hasValue
-                                                        value: $StartsWith{${mimetype}:image}
-                                                - uesio/io.emptystate:
-                                                    subtitle: No Preview Available
-                                                    icon: mist
+                                                      - type: paramValue
+                                                        param: app
+                                                        operator: EQUALS
+                                                        value: $Param{namespace}
+                                                    components:
+                                                      - uesio/io.fileattachment:
+                                                          displayAs: PREVIEW
+                                                          mode: EDIT
+                                                          onUploadSignals:
+                                                            - signal: wire/LOAD
+                                                              wires:
+                                                                - files
+                                                          onDeleteSignals:
+                                                            - signal: wire/LOAD
+                                                              wires:
+                                                                - files
+                                                - uesio/io.box:
                                                     uesio.display:
-                                                      - type: hasNoValue
-                                                        value: $StartsWith{${mimetype}:image}
-                            - uesio/io.grid:
-                                uesio.variant: uesio/appkit.two_columns
-                                uesio.styleTokens:
-                                  root:
-                                    - mt-6
-                                    - lg:gap-y-6
-                                uesio.display:
-                                  - type: paramValue
-                                    param: app
-                                    operator: EQUALS
-                                    value: $Param{namespace}
-                                items:
-                                  - uesio/io.list:
-                                      id: Attachments
-                                      wire: attachments
+                                                      - type: paramValue
+                                                        param: app
+                                                        operator: NOT_EQUALS
+                                                        value: $Param{namespace}
+                                                    components:
+                                                      - uesio/io.image:
+                                                          uesio.context:
+                                                            workspace:
+                                                              name: $Param{workspacename}
+                                                              app: $Param{app}
+                                                          file: $Parent.Record{uesio/studio.namespace}.$Parent.Record{uesio/studio.name}
+                                                          filepath: ${uesio/core.path}
+                                                          uesio.display:
+                                                            - type: hasValue
+                                                              value: $StartsWith{${uesio/core.mimetype}:image}
+                                                      - uesio/io.emptystate:
+                                                          subtitle: No Preview Available
+                                                          icon: mist
+                                                          uesio.display:
+                                                            - type: hasNoValue
+                                                              value: $StartsWith{${uesio/core.mimetype}:image}
+                                  - uesio/io.item:
+                                      wire: newattachment
+                                      uesio.display:
+                                        - type: paramValue
+                                          param: app
+                                          operator: EQUALS
+                                          value: $Param{namespace}
                                       components:
-                                        - uesio/io.card:
-                                            uesio.variant: uesio/appkit.main
-                                            uesio.styleTokens:
-                                              titlebarTitle:
-                                                - break-all
-                                            title: ${uesio/core.path}
-                                            subtitle: ${uesio/core.mimetype}
-                                            actions:
-                                              - uesio/io.box:
-                                                  components:
-                                                    - uesio/io.text:
-                                                        uesio.styleTokens:
-                                                          root:
-                                                            - bg-white
-                                                            - w-max
-                                                        uesio.variant: uesio/appkit.badge
-                                                        text: $FileSize{${uesio/core.contentlength}}
-                                                        element: div
-                                            content:
+                                        - uesio/io.box:
+                                            components:
                                               - uesio/io.fileattachment:
                                                   displayAs: PREVIEW
                                                   mode: EDIT
                                                   onUploadSignals:
                                                     - signal: wire/LOAD
                                                       wires:
-                                                        - workspaces
                                                         - files
-                                                        - attachments
+                                                    - signal: wire/RESET
+                                                      wire: newattachment
                                                   onDeleteSignals:
                                                     - signal: wire/LOAD
                                                       wires:
-                                                        - workspaces
                                                         - files
-                                                        - attachments

--- a/libs/ui/src/context/merge.ts
+++ b/libs/ui/src/context/merge.ts
@@ -213,13 +213,10 @@ const handlers: Record<MergeType, MergeHandler> = {
     }).format(value)
   },
   FileSize: (expression, context) => {
-    const bytes = context.merge(expression) as number
-    if (!bytes) {
-      return ""
-    }
+    const bytes = context.merge(expression) as number | 0
     const units = ["byte", "kilobyte", "megabyte", "terabyte", "petabyte"]
     const divisor = 1024
-    const unit = Math.floor(Math.log(bytes) / Math.log(divisor))
+    const unit = bytes ? Math.floor(Math.log(bytes) / Math.log(divisor)) : 0
     return new Intl.NumberFormat("en", {
       style: "unit",
       unit: units[unit],


### PR DESCRIPTION
# What does this PR do?
<img width="788" alt="Screenshot 2025-07-03 at 1 32 37 PM" src="https://github.com/user-attachments/assets/72530e65-a7e3-4ef5-85c8-bd2cd906653e" />

This PR improves the File UI for working with Files Metadata in a workspace.

1. Switch to using the new `uesio/core.attachments` field instead of the hacked in `uesio/studio.attachments` field.
2. Prevent editing of "attachment" files. The should only be able to be created or deleted.
3. Allow creating additional file items in a "file set". (Previously you could only create one if no others existed.)

# Testing

1. Go to the Files area of a workspace.
2. Create a new file.
3. Upload a file to the file. 🤦 
4. Upload another file to the file.
5. Delete a file.
6. Verify that you cannot edit existing attachments.
7. Go to your user profile in the studio by clicking the icon in the bottom left.
8. Change your profile picture. (Verifying that FILE fields still allow updating)

