### PR TITLE
Feat: Add Signal to Clear View Context

### DIFF
--- a/libs/ui/src/context/context.ts
+++ b/libs/ui/src/context/context.ts
@@ -380,6 +380,19 @@ class Context {
     return this.clone(this.stack.slice(index + 1)).removeViewFrame(times - 1)
   }
 
+  removeViewFrameById = (viewDef: string): Context => {
+    // Find the index where we are a view frame with the matching id
+    const index = this.stack.findIndex(
+      (frame): frame is ViewContextFrame =>
+        hasViewContext(frame) && frame.viewDef === viewDef,
+    )
+    // If we didn't find this view frame don't do anything
+    if (index === -1) {
+      return this
+    }
+    return this.clone(this.stack.slice(index + 1))
+  }
+
   removeAllPropsFrames = (): Context =>
     this.clone(
       this.stack.filter(

--- a/libs/ui/src/context/contextsignals.spec.ts
+++ b/libs/ui/src/context/contextsignals.spec.ts
@@ -1,0 +1,77 @@
+import { runMany } from "../signals/signals"
+import { Context } from "./context"
+
+const viewName = "uesio/core.foo"
+const viewDef = `
+name: ${viewName}}
+definition:
+    wires: {}
+    components: {}
+`
+
+const viewContext = new Context().addViewFrame({
+  params: { foo: "bar" },
+  view: viewName,
+  viewDef,
+})
+
+const testCases = [
+  {
+    name: "sanity",
+    initialContext: new Context(),
+    signals: [],
+    expectedContext: new Context(),
+  },
+  {
+    name: "sanity - with view context",
+    initialContext: viewContext,
+    signals: [],
+    expectedContext: viewContext,
+  },
+  {
+    name: "clear view context - no viewdef specified",
+    initialContext: viewContext,
+    signals: [
+      {
+        signal: "context/CLEAR",
+        type: "VIEW",
+      },
+    ],
+    expectedContext: new Context(),
+  },
+  {
+    name: "clear view context - with viewDef specified",
+    initialContext: viewContext,
+    signals: [
+      {
+        signal: "context/CLEAR",
+        type: "VIEW",
+        viewDef,
+      },
+    ],
+    expectedContext: new Context(),
+  },
+  {
+    // This should not make any changes to the context because the view
+    // defs do not match.
+    name: "clear view context - with different viewDef specified",
+    initialContext: viewContext,
+    signals: [
+      {
+        signal: "context/CLEAR",
+        type: "VIEW",
+        viewDef: "uesio/core.foo2",
+      },
+    ],
+    expectedContext: viewContext,
+  },
+]
+
+describe("testContextSignal", () => {
+  testCases.forEach((tc) => {
+    test(tc.name, async () => {
+      const finalContext = await runMany(tc.signals, tc.initialContext)
+      expect(finalContext.stack).toMatchObject(tc.expectedContext.stack)
+    })
+  })
+})

--- a/libs/ui/src/context/signals.ts
+++ b/libs/ui/src/context/signals.ts
@@ -5,17 +5,37 @@ import { Context } from "./context"
 // The key for the entire band
 const CONTEXT_BAND = "context"
 
-type Type = "WORKSPACE" | "SITE_ADMIN"
-
-interface ClearContextSignal extends SignalDefinition {
-  type: Type
+interface ClearWorkspaceContextSignal extends SignalDefinition {
+  type: "WORKSPACE"
 }
 
-interface SetContextSignal extends SignalDefinition {
-  type: Type
+interface ClearSiteAdminContextSignal extends SignalDefinition {
+  type: "SITE_ADMIN"
+}
+
+interface ClearViewContextSignal extends SignalDefinition {
+  type: "VIEW"
+  viewDef: string
+}
+
+type ClearContextSignal =
+  | ClearWorkspaceContextSignal
+  | ClearSiteAdminContextSignal
+  | ClearViewContextSignal
+
+interface SetWorkspaceContextSignal extends SignalDefinition {
+  type: "WORKSPACE"
   name: string
   app: string
 }
+
+interface SetSiteAdminContextSignal extends SignalDefinition {
+  type: "SITE_ADMIN"
+  name: string
+  app: string
+}
+
+type SetContextSignal = SetWorkspaceContextSignal | SetSiteAdminContextSignal
 
 // "Signal Handlers" for all of the signals in the band
 const signals: Record<string, SignalDescriptor> = {
@@ -25,6 +45,15 @@ const signals: Record<string, SignalDescriptor> = {
         context = context.deleteSiteAdmin()
       } else if (signal.type === "WORKSPACE") {
         context = context.deleteWorkspace()
+      } else if (signal.type === "VIEW") {
+        // If the signal included a viewDef, only remove if the topmost
+        // view in the stack is defined by that viewDef. If no viewDef
+        // is provided, always remove the view frame.
+        if (signal.viewDef) {
+          context = context.removeViewFrameById(signal.viewDef)
+        } else {
+          context = context.removeViewFrame(1)
+        }
       }
       return context
     },


### PR DESCRIPTION
# What does this PR do?

When trying to encapsulate wires and components into sub views, it is sometimes important for the subview to escape it's own context to run signals that were passed in as parameters.

This PR adds the `VIEW` type to `context/CLEAR` signal. If no viewDef is specified, it just removes the first VIEW context frame on the stack. If a viewDef is specified, it removes that particular view context. If a view with that particular viewDef is not found, nothing happens.
