### PR TITLE
feat: file attachments view

### DIFF
--- a/libs/apps/uesio/appkit/bundle/components/tile_file.yaml
+++ b/libs/apps/uesio/appkit/bundle/components/tile_file.yaml
@@ -1,0 +1,93 @@
+name: tile_file
+category: LAYOUT
+type: DECLARATIVE
+definition:
+  - uesio/io.card:
+      uesio.variant: uesio/appkit.main
+      uesio.styleTokens:
+        panelHeader:
+          - p-4
+        titlebarTitle:
+          - break-all
+      title: ${uesio/core.path}
+      subtitle: ${uesio/core.mimetype}
+      actions:
+        - uesio/io.group:
+            components:
+              - uesio/io.box:
+                  uesio.display:
+                    - type: hasValue
+                      value: ${uesio/core.id}
+                  components:
+                    - uesio/io.button:
+                        uesio.variant: uesio/appkit.itemaction
+                        icon: delete
+                        tooltip: Delete
+                        signals:
+                          - signal: userfile/DELETE
+                            id: ${uesio/core.id}
+                          - signal: context/CLEAR
+                            type: VIEW
+                            viewDef: uesio/appkit.file_attachments
+                          - signal: wire/LOAD
+              - uesio/io.box:
+                  components:
+                    - uesio/io.text:
+                        uesio.styleTokens:
+                          root:
+                            - bg-white
+                            - w-max
+                        uesio.variant: uesio/appkit.badge
+                        text: $FileSize{${uesio/core.contentlength}}
+                        element: div
+      avatar:
+        - uesio/io.box:
+            uesio.display:
+              - type: hasValue
+                value: $StartsWith{${uesio/core.mimetype}:image}
+              - type: hasValue
+                value: ${uesio/core.id}
+            components:
+              - uesio/io.avatar:
+                  uesio.variant: uesio/appkit.main
+                  image: $UserFile{}
+        - uesio/io.box:
+            uesio.display:
+              - type: hasValue
+                value: $StartsWith{${uesio/core.mimetype}:image}
+              - type: hasNoValue
+                value: ${uesio/core.id}
+            components:
+              - uesio/io.avatar:
+                  uesio.display:
+                    - type: paramIsSet
+                      param: app
+                    - type: paramIsSet
+                      param: workspacename
+                  uesio.context:
+                    workspace:
+                      name: $Param{workspacename}
+                      app: $Param{app}
+                  uesio.variant: uesio/appkit.main
+                  image: $File{$Parent.Record{uesio/studio.namespace}.$Parent.Record{uesio/studio.name}:${uesio/core.path}}
+
+        - uesio/io.box:
+            uesio.display:
+              - type: hasNoValue
+                value: $StartsWith{${uesio/core.mimetype}:image}
+            components:
+              - uesio/io.text:
+                  text: collections
+                  uesio.styleTokens:
+                    root:
+                      - w-12
+                      - h-12
+                      - text-lg
+                  uesio.variant: uesio/appkit.avataricon
+title: File Tile Component
+discoverable: true
+description: A file tile
+sections:
+  - type: HOME
+    properties:
+  - type: DISPLAY

--- a/libs/apps/uesio/appkit/bundle/componentvariants/uesio/io/grid/two_columns_large.yaml
+++ b/libs/apps/uesio/appkit/bundle/componentvariants/uesio/io/grid/two_columns_large.yaml
@@ -1,0 +1,9 @@
+name: two_columns_large
+label: Two Column Responsive Large
+public: true
+definition:
+  uesio.styleTokens:
+    root:
+      - gap-x-6
+      - grid-cols-1
+      - md:grid-cols-2

--- a/libs/apps/uesio/appkit/bundle/permissionsets/public.yaml
+++ b/libs/apps/uesio/appkit/bundle/permissionsets/public.yaml
@@ -7,6 +7,7 @@ views:
   uesio/appkit.login_platform: true
   uesio/appkit.login_request_password: true
   uesio/appkit.login_change_password: true
+  uesio/appkit.file_attachments: true
 routes:
   uesio/appkit.login_request_password: true
   uesio/appkit.login_change_password: true

--- a/libs/apps/uesio/appkit/bundle/views/file_attachments.yaml
+++ b/libs/apps/uesio/appkit/bundle/views/file_attachments.yaml
@@ -1,0 +1,69 @@
+name: file_attachments
+public: true
+definition:
+  wires:
+    newattachment:
+      collection: uesio/core.userfile
+      fields:
+        uesio/core.id:
+        uesio/core.path:
+        uesio/core.recordid:
+        uesio/core.contentlength:
+        uesio/core.collectionid:
+        uesio/core.mimetype:
+        uesio/core.updatedat:
+      init:
+        create: true
+        query: false
+      defaults:
+        - field: uesio/core.recordid
+          valueSource: VALUE
+          value: $Param{recordid}
+        - field: uesio/core.collectionid
+          valueSource: VALUE
+          value: $Param{collection}
+  components:
+    - uesio/io.box:
+        uesio.variant: uesio/appkit.section
+        components:
+          - uesio/io.titlebar:
+              title: Contents
+              uesio.variant: uesio/appkit.sub
+          - uesio/io.box:
+              uesio.styleTokens:
+                root:
+                  - mt-6
+              components:
+                - uesio/io.box:
+                    uesio.display:
+                      - type: paramIsNotSet
+                        param: readonly
+                    uesio.styleTokens:
+                      root:
+                        - min-h-[84px]
+                    components:
+                      - uesio/io.item:
+                          wire: newattachment
+                          components:
+                            - uesio/io.fileattachment:
+                                mode: EDIT
+                                onUploadSignals:
+                                  - signal: wire/RESET
+                                    wire: newattachment
+                                  - signal: context/CLEAR
+                                    type: VIEW
+                                  - signal: wire/LOAD
+                - uesio/io.grid:
+                    uesio.variant: uesio/appkit.two_columns_large
+                    uesio.styleTokens:
+                      root:
+                        - mt-6
+                        - gap-6
+                    items:
+                      - uesio/io.field:
+                          wrapperVariant: uesio/io.minimal
+                          fieldId: uesio/core.attachments
+                          labelPosition: none
+                          reference:
+                            components:
+                              - uesio/appkit.tile_file:

--- a/libs/apps/uesio/io/bundle/components/card.yaml
+++ b/libs/apps/uesio/io/bundle/components/card.yaml
@@ -59,8 +59,12 @@ definition:
             uesio.styleTokens:
               root:
                 - $Region{panel}
+              header:
+                - $Region{panelHeader}
               inner:
                 - $Region{panelInner}
+              footer:
+                - $Region{panelFooter}
             header:
               - uesio/io.titlebar:
                   title: $Prop{title}

--- a/libs/apps/uesio/io/bundle/componentvariants/uesio/io/filefield/default.yaml
+++ b/libs/apps/uesio/io/bundle/componentvariants/uesio/io/filefield/default.yaml
@@ -10,7 +10,8 @@ definition:
       - border(& dashed slate-200 4)
       - hover:border(& dashed blue-200 4)
       - rounded-lg
-      - p-10
+      - px-10
+      - py-7
       - text-sm
       - text-slate-400
       - font-light

--- a/libs/apps/uesio/studio/bundle/views/file.yaml
+++ b/libs/apps/uesio/studio/bundle/views/file.yaml
@@ -32,32 +32,6 @@ definition:
           value: true
         - field: uesio/studio.item
           value: $Param{namespace}.$Param{filename}
-    newattachment:
-      collection: uesio/core.userfile
-      fields:
-        uesio/core.id:
-        uesio/core.path:
-        uesio/core.recordid:
-        uesio/core.contentlength:
-        uesio/core.collectionid:
-        uesio/core.mimetype:
-        uesio/core.updatedat:
-      conditions:
-        - field: uesio/core.recordid
-          valueSource: LOOKUP
-          lookupWire: files
-          lookupField: uesio/core.id
-      init:
-        create: true
-        query: false
-      defaults:
-        - field: uesio/core.recordid
-          valueSource: LOOKUP
-          lookupWire: files
-          lookupField: uesio/core.id
-        - field: uesio/core.collectionid
-          valueSource: VALUE
-          value: uesio/studio.file
   # Components are how we describe the layout of our view
   components:
     - uesio/io.viewlayout:
@@ -99,106 +73,12 @@ definition:
                                       fieldId: uesio/studio.name
                                   - uesio/io.field:
                                       fieldId: uesio/studio.path
-                      - uesio/io.box:
-                          uesio.variant: uesio/appkit.section
-                          components:
-                            - uesio/io.titlebar:
-                                title: Contents
-                                uesio.variant: uesio/appkit.sub
-                            - uesio/io.grid:
-                                uesio.variant: uesio/appkit.two_columns
-                                uesio.styleTokens:
-                                  root:
-                                    - mt-6
-                                    - gap-6
-                                    - lg:gap-y-6
-                                items:
-                                  - uesio/io.field:
-                                      wrapperVariant: uesio/io.minimal
-                                      fieldId: uesio/core.attachments
-                                      labelPosition: none
-                                      reference:
-                                        components:
-                                          - uesio/io.card:
-                                              uesio.variant: uesio/appkit.main
-                                              uesio.styleTokens:
-                                                titlebarTitle:
-                                                  - break-all
-                                              title: ${uesio/core.path}
-                                              subtitle: ${uesio/core.mimetype}
-                                              actions:
-                                                - uesio/io.box:
-                                                    components:
-                                                      - uesio/io.text:
-                                                          uesio.styleTokens:
-                                                            root:
-                                                              - bg-white
-                                                              - w-max
-                                                          uesio.variant: uesio/appkit.badge
-                                                          text: $FileSize{${uesio/core.contentlength}}
-                                                          element: div
-                                              content:
-                                                - uesio/io.box:
-                                                    uesio.display:
-                                                      - type: paramValue
-                                                        param: app
-                                                        operator: EQUALS
-                                                        value: $Param{namespace}
-                                                    components:
-                                                      - uesio/io.fileattachment:
-                                                          displayAs: PREVIEW
-                                                          mode: EDIT
-                                                          onUploadSignals:
-                                                            - signal: wire/LOAD
-                                                              wires:
-                                                                - files
-                                                          onDeleteSignals:
-                                                            - signal: wire/LOAD
-                                                              wires:
-                                                                - files
-                                                - uesio/io.box:
-                                                    uesio.display:
-                                                      - type: paramValue
-                                                        param: app
-                                                        operator: NOT_EQUALS
-                                                        value: $Param{namespace}
-                                                    components:
-                                                      - uesio/io.image:
-                                                          uesio.context:
-                                                            workspace:
-                                                              name: $Param{workspacename}
-                                                              app: $Param{app}
-                                                          file: $Parent.Record{uesio/studio.namespace}.$Parent.Record{uesio/studio.name}
-                                                          filepath: ${uesio/core.path}
-                                                          uesio.display:
-                                                            - type: hasValue
-                                                              value: $StartsWith{${uesio/core.mimetype}:image}
-                                                      - uesio/io.emptystate:
-                                                          subtitle: No Preview Available
-                                                          icon: mist
-                                                          uesio.display:
-                                                            - type: hasNoValue
-                                                              value: $StartsWith{${uesio/core.mimetype}:image}
-                                  - uesio/io.item:
-                                      wire: newattachment
-                                      uesio.display:
-                                        - type: paramValue
-                                          param: app
-                                          operator: EQUALS
-                                          value: $Param{namespace}
-                                      components:
-                                        - uesio/io.box:
-                                            components:
-                                              - uesio/io.fileattachment:
-                                                  displayAs: PREVIEW
-                                                  mode: EDIT
-                                                  onUploadSignals:
-                                                    - signal: wire/LOAD
-                                                      wires:
-                                                        - files
-                                                    - signal: wire/RESET
-                                                      wire: newattachment
-                                                  onDeleteSignals:
-                                                    - signal: wire/LOAD
-                                                      wires:
-                                                        - files
+                      - uesio/core.view:
+                          view: uesio/appkit.file_attachments
+                          uesio.id: attachments
+                          params:
+                            collection: uesio/studio.file
+                            recordid: ${uesio/core.id}
+                            app: $Param{app}
+                            workspacename: $Param{workspacename}
+                            readonly: $NotEquals{$Param{namespace}:$Param{app}}


### PR DESCRIPTION
# What does this PR do?

<img width="1300" alt="Screenshot 2025-07-04 at 12 58 41 PM" src="https://github.com/user-attachments/assets/c70df64c-7ca6-4f54-9104-3cb7dd3d2e83" />

1. Abstracts file attachments for a record into a single subview component.
2. Uses this new view for the Files UI in Workspaces.

# Note

For the functionality of this PR to work, the following PRs must be merged.
https://github.com/ues-io/uesio/pull/4988
https://github.com/ues-io/uesio/pull/4987
https://github.com/ues-io/uesio/pull/4986

# Testing

Try out the Files UI and verify that everything works as expected for both files from the local namespace, as well as files that are installed from a bundle.
