### PR TITLE
fix: ensure retrieving bundle or app sets content-disposition header correctly

### DIFF
--- a/apps/platform/pkg/controller/bundlesretrieve.go
+++ b/apps/platform/pkg/controller/bundlesretrieve.go
@@ -1,13 +1,13 @@
 package controller
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/gorilla/mux"
 
 	"github.com/thecloudmasters/uesio/pkg/bundlestore"
 	"github.com/thecloudmasters/uesio/pkg/controller/ctlutil"
+	"github.com/thecloudmasters/uesio/pkg/controller/file"
 	"github.com/thecloudmasters/uesio/pkg/middleware"
 	"github.com/thecloudmasters/uesio/pkg/types/exceptions"
 )
@@ -41,7 +41,8 @@ func BundlesRetrieve(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Header().Set("Content-Disposition", fmt.Sprintf("; filename=\"%s.zip\"", version))
+	w.Header().Set("Content-Type", "application/zip")
+	file.SetContentDispositionHeader(w, "attachment", version+".zip")
 	middleware.Set1YearCache(w)
 	ctlutil.AddTrailingStatus(w)
 

--- a/apps/platform/pkg/controller/file/serve_file.go
+++ b/apps/platform/pkg/controller/file/serve_file.go
@@ -45,7 +45,16 @@ func respondFile(w http.ResponseWriter, r *http.Request, path string, modified t
 	if filename == "." || filename == separatorStr || filename == "" {
 		filename = ""
 	} else {
-		setContentDispositionHeader(w, filename)
+		// TODO: Previous code did not specify a disposition type so it would be browser dependent
+		// but most default to inline when not specified so for backwards compatibility properly
+		// setting the header value (not having a type is an invalid header value). This should
+		// be evaluated to ensure inline is the default we want even if it will break some backwards
+		// compat scenarios if we change to attachment instead. The file component could offer
+		// it as a property and then we could dynamically set it based on that setting but beyond
+		// that we have non-user types of files that go through this path as well. In short,
+		// being explicit here to correct the invalid header value but more thought is needed
+		// on this.
+		SetContentDispositionHeader(w, "inline", path)
 	}
 
 	http.ServeContent(w, r, filename, modified, stream)
@@ -93,17 +102,7 @@ func ServeFile(w http.ResponseWriter, r *http.Request) {
 }
 
 // setContentDispositionHeader sets the Content-Disposition header for modern browsers
-func setContentDispositionHeader(w http.ResponseWriter, filename string) {
-	// TODO: Previous code did not specify a disposition type so it would be browser dependent
-	// but most default to inline when not specified so for backwards compatibility properly
-	// setting the header value (not having a type is an invalid header value). This should
-	// be evaluated to ensure inline is the default we want even if it will break some backwards
-	// compat scenarios if we change to attachment instead. The file component could offer
-	// it as a property and then we could dynamically set it based on that setting but beyond
-	// that we have non-user types of files that go through this path as well. In short,
-	// being explicit here to correct the invalid header value but more thought is needed
-	// on this.
-	dispositionType := "inline"
+func SetContentDispositionHeader(w http.ResponseWriter, dispositionType string, filename string) {
 	if needsRFC5987Encoding(filename) {
 		// Modern browsers only - use RFC 5987 encoding for non-ASCII
 		encoded := url.PathEscape(filename)

--- a/apps/platform/pkg/controller/retrieve.go
+++ b/apps/platform/pkg/controller/retrieve.go
@@ -11,6 +11,7 @@ import (
 	"github.com/thecloudmasters/uesio/pkg/bundle"
 	"github.com/thecloudmasters/uesio/pkg/bundlestore"
 	"github.com/thecloudmasters/uesio/pkg/controller/ctlutil"
+	"github.com/thecloudmasters/uesio/pkg/controller/file"
 	"github.com/thecloudmasters/uesio/pkg/middleware"
 )
 
@@ -27,9 +28,9 @@ func Retrieve(w http.ResponseWriter, r *http.Request) {
 
 	appName := strings.ReplaceAll(session.GetContextAppName(), "/", "_")
 	versionName := strings.ReplaceAll(session.GetContextVersionName(), "/", "_")
-	fileName := strings.ReplaceAll(fmt.Sprintf("uesio_retrieve_%s_%s_%s", appName, versionName, time.Now().Format(time.RFC3339)), ":", "_")
+	fileName := strings.ReplaceAll(fmt.Sprintf("uesio_retrieve_%s_%s_%s.zip", appName, versionName, time.Now().Format(time.RFC3339)), ":", "_")
 	w.Header().Set("Content-Type", "application/zip")
-	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s.zip\"", fileName))
+	file.SetContentDispositionHeader(w, "attachment", fileName)
 	ctlutil.AddTrailingStatus(w)
 
 	if err := bs.GetBundleZip(w, &bundlestore.BundleZipOptions{


### PR DESCRIPTION
# What does this PR do?

Ensure `Content-Type` and `Content-Disposition` headers are set properly on bundle & app retrieve.

# Testing

tested manually to ensure headers are set as expected.
