### PR TITLE
chore: more explicit on cache-control headers

### DIFF
--- a/apps/platform/pkg/controller/file/serve_file.go
+++ b/apps/platform/pkg/controller/file/serve_file.go
@@ -80,6 +80,8 @@ func ServeFileContent(file *meta.File, path string, supportsCaching bool, w http
 
 	if supportsCaching {
 		middleware.Set1YearCache(w)
+	} else {
+		middleware.SetNoCache(w)
 	}
 
 	respondFile(w, r, path, fileMetadata.LastModified(), rs)

--- a/apps/platform/pkg/controller/file/userfile.go
+++ b/apps/platform/pkg/controller/file/userfile.go
@@ -103,6 +103,8 @@ func DownloadUserFile(w http.ResponseWriter, r *http.Request) {
 
 	if version != "" {
 		middleware.Set1YearCache(w)
+	} else {
+		middleware.SetNoCache(w)
 	}
 
 	respondFile(w, r, userFile.Path(), userFile.LastModified(), rs)
@@ -132,6 +134,8 @@ func DownloadAttachment(w http.ResponseWriter, r *http.Request) {
 
 	if version != "" {
 		middleware.Set1YearCache(w)
+	} else {
+		middleware.SetNoCache(w)
 	}
 
 	respondFile(w, r, userFile.Path(), userFile.LastModified(), rs)


### PR DESCRIPTION
# What does this PR do?

In cases where we were setting cache control header to 1 year, in cases where caching isn't enabled (e.g., dev mode) or we conditionally set the header, explictly set the header to not cache.

Note - There are several places in the code that do not set cache-control at all and there are shortcomings with the current values we use with cache-control.  This PR does not address those, only modifies current locations where we did set cache control headers to always set cache control headers (either to cache or not to cache).  See https://github.com/ues-io/uesio/issues/4993.

# Testing

Manually verified cache-control headers are explicitly set to `no cache` in the cases were 1 year cache was conditionally applied.
