### PR TITLE
fix: invalid background_blocks file path

### DIFF
--- a/libs/apps/uesio/studio/bundle/files/background_blocks/file.yaml
+++ b/libs/apps/uesio/studio/bundle/files/background_blocks/file.yaml
@@ -1,3 +1,3 @@
 name: background_blocks
 public: true
-path: files/right_dark.svg
+path: files/right.svg


### PR DESCRIPTION
# What does this PR do?

The file path for background_blocks was pointing to a file that does not exist.

# Testing

Manually confirmed image displays as expected.
