### PR TITLE
chore: support http caching for favicon

### DIFF
--- a/apps/platform/pkg/controller/favicon.go
+++ b/apps/platform/pkg/controller/favicon.go
@@ -12,25 +12,15 @@ import (
 
 func Favicon(w http.ResponseWriter, r *http.Request) {
 
-	session := middleware.GetSession(r)
-	bundledef := session.GetContextAppBundle()
-
-	favicon := bundledef.Favicon
-	if favicon == "" {
-		favicon = "uesio/core.favicon"
-	}
-	fileItem, err := meta.NewFile(favicon)
+	fileItem, err := meta.NewFile(middleware.GetSession(r).GetSite().GetFavicon())
 	if err != nil {
 		ctlutil.HandleError(r.Context(), w, exceptions.NewNotFoundException("favicon file not found"))
 		return
 	}
 
-	// NOTE: We do not set <link rel="icon" href="/favicon.ico"> or similar in HTML and instead rely on browsers automatically
-	// requesting /favicon.ico when no favicon is specified. We should generate the link meta tag in the rendered html
-	// from the site config ideally but for now, we're just going to not cache favicon until permanent solution can be implemented.
-	// We can't use UESIO_BUILD_VERSION as a cache buster (e.g., /favicon.ico?v=UESIO_BUILD_VERSION) because favicon is site specific.
-	// TODO: Implement a proper and permanent solution for including favicon in generated html on a site basis or if not possible,
-	// consider a low cache setting or just leave not-cacheable which is not really ideal especially given it rarely would change.
-	file.ServeFileContent(fileItem, "", false, w, r)
-
+	// NOTE: We include a <link rel="icon" href="/favicon.ico?v={{ .Site.Version }}" sizes="any"> in the HTML currently to support
+	// cache busting so we can set a cache control header here to allow caching. However, the current approach has several
+	// limitations that should be addressed
+	// TODO: see https://github.com/ues-io/uesio/issues/4674
+	file.ServeFileContent(fileItem, "", true, w, r)
 }

--- a/apps/platform/pkg/controller/mergedata.go
+++ b/apps/platform/pkg/controller/mergedata.go
@@ -279,8 +279,8 @@ func GetSiteMergeData(site *meta.Site) *preload.SiteMergeData {
 func getFaviconVersion(site *meta.Site) string {
 	// intentionally ignore error here since it should not happen
 	// and if so we use version of bundle as a fallback
-	fileItem, _ := meta.NewFile(site.GetFavicon())
-	if bundlestore.IsSystemBundle(fileItem.Namespace) {
+	fileItem, err := meta.NewFile(site.GetFavicon())
+	if err == nil && bundlestore.IsSystemBundle(fileItem.Namespace) {
 		return os.Getenv("UESIO_BUILD_VERSION")
 	} else {
 		return site.Bundle.GetVersionString()

--- a/apps/platform/pkg/controller/mergedata.go
+++ b/apps/platform/pkg/controller/mergedata.go
@@ -257,15 +257,33 @@ func GetRoutingMergeData(route *meta.Route, metadata *preload.PreloadMetadata, s
 
 func GetSiteMergeData(site *meta.Site) *preload.SiteMergeData {
 	return &preload.SiteMergeData{
-		Name:         site.Name,
-		App:          site.GetAppFullName(),
-		Subdomain:    site.Subdomain,
-		Domain:       site.Domain,
-		Scheme:       site.Scheme,
-		Version:      site.Bundle.GetVersionString(),
-		Title:        site.Title,
-		EnableSEO:    site.EnableSEO,
-		Dependencies: site.GetAppBundle().Dependencies,
+		Name:           site.Name,
+		App:            site.GetAppFullName(),
+		Subdomain:      site.Subdomain,
+		Domain:         site.Domain,
+		Scheme:         site.Scheme,
+		Version:        site.Bundle.GetVersionString(),
+		Title:          site.Title,
+		EnableSEO:      site.EnableSEO,
+		Dependencies:   site.GetAppBundle().Dependencies,
+		FaviconVersion: getFaviconVersion(site),
+	}
+}
+
+// NOTE: Technically speaking, the actual favicon used by a site could point to a different bundle
+// which could have a version different from the site bundle version. However, looking up the favicon
+// to that level has a perf cost (even though it would be cached) that seems unnecessary in the majority
+// of cases. As written below, we will align the favicon caching with the site bundle version which
+// should be sufficient for most use cases. If needed, a specific lookup to the referenced favicon could
+// be performed and the version of the actual favicon source used instead.
+func getFaviconVersion(site *meta.Site) string {
+	// intentionally ignore error here since it should not happen
+	// and if so we use version of bundle as a fallback
+	fileItem, _ := meta.NewFile(site.GetFavicon())
+	if bundlestore.IsSystemBundle(fileItem.Namespace) {
+		return os.Getenv("UESIO_BUILD_VERSION")
+	} else {
+		return site.Bundle.GetVersionString()
 	}
 }
 

--- a/apps/platform/pkg/meta/site.go
+++ b/apps/platform/pkg/meta/site.go
@@ -33,6 +33,14 @@ func (s *Site) GetAppBundle() *BundleDef {
 	return s.bundleDef
 }
 
+func (s *Site) GetFavicon() string {
+	favicon := s.GetAppBundle().Favicon
+	if favicon == "" {
+		return "uesio/core.favicon"
+	}
+	return favicon
+}
+
 func (s *Site) GetCollection() CollectionableGroup {
 	return &SiteCollection{}
 }

--- a/apps/platform/pkg/preload/mergetypes.go
+++ b/apps/platform/pkg/preload/mergetypes.go
@@ -59,7 +59,7 @@ type SiteMergeData struct {
 	Title          string                      `json:"title"`
 	EnableSEO      bool                        `json:"-"`
 	Dependencies   meta.BundleDefDependencyMap `json:"dependencies"`
-	FaviconVersion string                      `json:"faviconVersion"`
+	FaviconVersion string                      `json:"-"`
 }
 
 type WorkspaceMergeData struct {

--- a/apps/platform/pkg/preload/mergetypes.go
+++ b/apps/platform/pkg/preload/mergetypes.go
@@ -50,15 +50,16 @@ type UserMergeData struct {
 }
 
 type SiteMergeData struct {
-	Name         string                      `json:"name"`
-	App          string                      `json:"app"`
-	Version      string                      `json:"version"`
-	Domain       string                      `json:"domain"`
-	Subdomain    string                      `json:"subdomain"`
-	Scheme       string                      `json:"scheme"`
-	Title        string                      `json:"title"`
-	EnableSEO    bool                        `json:"-"`
-	Dependencies meta.BundleDefDependencyMap `json:"dependencies"`
+	Name           string                      `json:"name"`
+	App            string                      `json:"app"`
+	Version        string                      `json:"version"`
+	Domain         string                      `json:"domain"`
+	Subdomain      string                      `json:"subdomain"`
+	Scheme         string                      `json:"scheme"`
+	Title          string                      `json:"title"`
+	EnableSEO      bool                        `json:"-"`
+	Dependencies   meta.BundleDefDependencyMap `json:"dependencies"`
+	FaviconVersion string                      `json:"faviconVersion"`
 }
 
 type WorkspaceMergeData struct {

--- a/apps/platform/platform/index.gohtml
+++ b/apps/platform/platform/index.gohtml
@@ -31,6 +31,7 @@
             {{- end -}}
         {{- end }}
         <script src="{{ .StaticAssetsHost }}/static{{ .StaticAssetsPath }}/ui/uesio.js" type="module" crossorigin="true"></script>
+        <link rel="icon" href="/favicon.ico{{if .Site.FaviconVersion}}?v={{ .Site.FaviconVersion }}{{end}}" sizes="any">
     </head>
 <body>
     <div id="root" class="h-screen overflow-auto"></div>


### PR DESCRIPTION
# What does this PR do?

Enables http caching for favicon.

Note - This only addresses the ability to support http caching for favicon.  See #4674 (which has been updated to account for the changes in this PR) for other issues related to favicon.

@humandad - When reviewing, please pay particular attention to https://github.com/ues-io/uesio/pull/4996/files#diff-dee56ef84e65aee0654893201db7dae31624d048d65c98e014031ee14fa1d7b9R15.  Previously, the code would `GetContextAppBundle` and `Favicon` from there, however this PR changes to always just use the current site (via `session.GetSite()`).  I believe the net result should be the same but would like to verify.

# Testing

Tested manually and proper favicon url with `v=###` syntax is generated and cache headers set as expected.
