### PR TITLE
chore: add missing http status asserts on integration tests

### DIFF
--- a/apps/platform-integration-tests/hurl_seeds/create_app_and_workspace.hurl
+++ b/apps/platform-integration-tests/hurl_seeds/create_app_and_workspace.hurl
@@ -2,7 +2,6 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "uesio"
 }
-
 # Extract the sessionid from set-cookie header
 HTTP 200
 [Captures]

--- a/apps/platform-integration-tests/hurl_seeds/site_domain_bundle.hurl
+++ b/apps/platform-integration-tests/hurl_seeds/site_domain_bundle.hurl
@@ -2,6 +2,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "uesio"
 }
+HTTP 200
 
 # Retrieve the tests app id
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/wires/load

--- a/apps/platform-integration-tests/hurl_specs/aftersave_bot.hurl
+++ b/apps/platform-integration-tests/hurl_specs/aftersave_bot.hurl
@@ -7,6 +7,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "uesio"
 }
+HTTP 200
 
 # Try to insert a zebra
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/uesio/tests/dev/wires/save

--- a/apps/platform-integration-tests/hurl_specs/allmetadata.hurl
+++ b/apps/platform-integration-tests/hurl_specs/allmetadata.hurl
@@ -7,6 +7,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "uesio"
 }
+HTTP 200
 
 # Get a list of all fields available to our workspace for the animal collection
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/wires/load
@@ -598,6 +599,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "ben"
 }
+HTTP 200
 
 #Site admin all metadata in studio context
 #make sure we can read data as the siteadmin for the studio site

--- a/apps/platform-integration-tests/hurl_specs/app_publish_flow.hurl
+++ b/apps/platform-integration-tests/hurl_specs/app_publish_flow.hurl
@@ -130,6 +130,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "abel"
 }
+HTTP 200
 
 #Site admin 
 # 4 step Start the review

--- a/apps/platform-integration-tests/hurl_specs/autonumber_insert.hurl
+++ b/apps/platform-integration-tests/hurl_specs/autonumber_insert.hurl
@@ -7,6 +7,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "uesio"
 }
+HTTP 200
 
 # Test a simple insert for the default autonumber
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/uesio/tests/dev/wires/save

--- a/apps/platform-integration-tests/hurl_specs/bedrock_integration_actions.hurl
+++ b/apps/platform-integration-tests/hurl_specs/bedrock_integration_actions.hurl
@@ -7,6 +7,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "uesio"
 }
+HTTP 200
 
 # Invoke the test model -- sanity test
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/uesio/tests/dev/integrationactions/run/uesio/aikit/bedrock?action=invokemodel

--- a/apps/platform-integration-tests/hurl_specs/beforesave_bot.hurl
+++ b/apps/platform-integration-tests/hurl_specs/beforesave_bot.hurl
@@ -7,6 +7,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "uesio"
 }
+HTTP 200
 
 # Try to insert a Lowland streaked tenrec and check if the aftersave bot increased the population to 10
 # and the before save decrease in 6

--- a/apps/platform-integration-tests/hurl_specs/builder_dependencies.hurl
+++ b/apps/platform-integration-tests/hurl_specs/builder_dependencies.hurl
@@ -8,7 +8,6 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "uesio"
 }
-
 # Extract the sessionid from set-cookie header
 HTTP 200
 [Captures]

--- a/apps/platform-integration-tests/hurl_specs/collection_fields_lifecycle.hurl
+++ b/apps/platform-integration-tests/hurl_specs/collection_fields_lifecycle.hurl
@@ -7,6 +7,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "uesio"
 }
+HTTP 200
 
 # Get the dev workspace id so we can test saving collections/fields
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/wires/load

--- a/apps/platform-integration-tests/hurl_specs/component_dependencies.hurl
+++ b/apps/platform-integration-tests/hurl_specs/component_dependencies.hurl
@@ -8,7 +8,6 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "uesio"
 }
-
 # Extract the sessionid from set-cookie header
 HTTP 200
 [Captures]

--- a/apps/platform-integration-tests/hurl_specs/component_dependencies_theme.hurl
+++ b/apps/platform-integration-tests/hurl_specs/component_dependencies_theme.hurl
@@ -6,6 +6,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "uesio"
 }
+HTTP 200
 
 # Route with a theme
 GET {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/uesio/tests/dev/routes/path/uesio/tests/dependencies_theme

--- a/apps/platform-integration-tests/hurl_specs/componentpack_download.hurl
+++ b/apps/platform-integration-tests/hurl_specs/componentpack_download.hurl
@@ -20,4 +20,4 @@ HTTP 404
 
 # Verify 404 for workspace file that does not exist
 GET {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/uesio/tests/dev/componentpacks/uesio/tests/1742316697/fakecomponentpack/runtime.js
-HTTP 200
+HTTP 404

--- a/apps/platform-integration-tests/hurl_specs/componentpack_download.hurl
+++ b/apps/platform-integration-tests/hurl_specs/componentpack_download.hurl
@@ -20,6 +20,4 @@ HTTP 404
 
 # Verify 404 for workspace file that does not exist
 GET {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/uesio/tests/dev/componentpacks/uesio/tests/1742316697/fakecomponentpack/runtime.js
-
-
-
+HTTP 200

--- a/apps/platform-integration-tests/hurl_specs/create_bundle_security.hurl
+++ b/apps/platform-integration-tests/hurl_specs/create_bundle_security.hurl
@@ -137,6 +137,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "abel"
 }
+HTTP 200
 
 # now Abel should be able to create a bundle
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/bots/call/uesio/studio/createbundle

--- a/apps/platform-integration-tests/hurl_specs/delete_attachments.hurl
+++ b/apps/platform-integration-tests/hurl_specs/delete_attachments.hurl
@@ -7,6 +7,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "uesio"
 }
+HTTP 200
 
 # Get the workspace id
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/wires/load

--- a/apps/platform-integration-tests/hurl_specs/enforce_max_domains_per_user_limit.hurl
+++ b/apps/platform-integration-tests/hurl_specs/enforce_max_domains_per_user_limit.hurl
@@ -6,7 +6,6 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "uesio"
 }
-
 # Extract the sessionid from set-cookie header
 HTTP 200
 [Captures]
@@ -18,6 +17,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "ben"
 }
+HTTP 200
 
 # Set a limit of 1 domain per user
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/siteadmin/uesio/studio/prod/wires/save
@@ -44,6 +44,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "uesio"
 }
+HTTP 200
 
 # Delete the test site domain if it already exists. This should succeed even though our domain limit is very low.
 # This ensures that we are ONLY enforcing the limit on new domains, not existing ones.
@@ -111,6 +112,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "ben"
 }
+HTTP 200
 
 # Bump up the limit
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/siteadmin/uesio/studio/prod/wires/save
@@ -137,6 +139,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "uesio"
 }
+HTTP 200
 
 # Create a new domain - should succeed now
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/wires/save

--- a/apps/platform-integration-tests/hurl_specs/impersonation.hurl
+++ b/apps/platform-integration-tests/hurl_specs/impersonation.hurl
@@ -3,6 +3,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "uesio"
 }
+HTTP 200
 
 # Get the workspace id
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/wires/load
@@ -54,6 +55,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "ben"
 }
+HTTP 200
 
 # Add an impersonation record to use the rep profile
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/bots/call/uesio/studio/setworkspaceuser

--- a/apps/platform-integration-tests/hurl_specs/integration_actions.hurl
+++ b/apps/platform-integration-tests/hurl_specs/integration_actions.hurl
@@ -7,6 +7,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "uesio"
 }
+HTTP 200
 
 # Request metadata for a core integration action with input parameters defined
 GET {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/uesio/tests/dev/integrationactions/describe/uesio/aikit/bedrock?action=uesio/aikit.invokemodel

--- a/apps/platform-integration-tests/hurl_specs/labels_translations.hurl
+++ b/apps/platform-integration-tests/hurl_specs/labels_translations.hurl
@@ -3,6 +3,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "uesio"
 }
+HTTP 200
 
 # Try to navigate to the workspace home route and make sure that the labels from core and io are there
 GET {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/routes/path/uesio/studio/app/uesio/tests/workspace/dev

--- a/apps/platform-integration-tests/hurl_specs/listener_bot.hurl
+++ b/apps/platform-integration-tests/hurl_specs/listener_bot.hurl
@@ -7,6 +7,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "uesio"
 }
+HTTP 200
 
 # Invoke with all required parameters
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/uesio/tests/dev/bots/call/uesio/tests/add_numbers

--- a/apps/platform-integration-tests/hurl_specs/listener_bot_call_crud.hurl
+++ b/apps/platform-integration-tests/hurl_specs/listener_bot_call_crud.hurl
@@ -7,6 +7,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "uesio"
 }
+HTTP 200
 
 # Invoke with all required parameters
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/uesio/tests/dev/bots/call/uesio/tests/call_crud

--- a/apps/platform-integration-tests/hurl_specs/listener_bot_custom_integration_action.hurl
+++ b/apps/platform-integration-tests/hurl_specs/listener_bot_custom_integration_action.hurl
@@ -7,6 +7,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "uesio"
 }
+HTTP 200
 
 # Invoke with all required parameters
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/uesio/tests/dev/bots/call/uesio/tests/call_custom_run_action

--- a/apps/platform-integration-tests/hurl_specs/listener_bot_from_bundle.hurl
+++ b/apps/platform-integration-tests/hurl_specs/listener_bot_from_bundle.hurl
@@ -7,6 +7,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "uesio"
 }
+HTTP 200
 
 # Invoke with all required parameters
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/uesio/tests/quickstart/bots/call/uesio/tests/add_numbers

--- a/apps/platform-integration-tests/hurl_specs/listener_bot_http_post_api.hurl
+++ b/apps/platform-integration-tests/hurl_specs/listener_bot_http_post_api.hurl
@@ -7,6 +7,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "uesio"
 }
+HTTP 200
 
 # Invoke with all required parameters
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/uesio/tests/dev/bots/call/uesio/tests/call_http_api

--- a/apps/platform-integration-tests/hurl_specs/listener_bot_list_view_generator.hurl
+++ b/apps/platform-integration-tests/hurl_specs/listener_bot_list_view_generator.hurl
@@ -7,6 +7,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "uesio"
 }
+HTTP 200
 
 # Invoke with all required parameters this will work and create a new view with the name test_list_view_generator
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/uesio/tests/dev/metadata/generate/uesio/core/view

--- a/apps/platform-integration-tests/hurl_specs/metadata_list_core_collections.hurl
+++ b/apps/platform-integration-tests/hurl_specs/metadata_list_core_collections.hurl
@@ -7,6 +7,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "uesio"
 }
+HTTP 200
 
 # Test a wire load with no conditions
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/wires/load

--- a/apps/platform-integration-tests/hurl_specs/metadata_list_siteadmin_context.hurl
+++ b/apps/platform-integration-tests/hurl_specs/metadata_list_siteadmin_context.hurl
@@ -7,6 +7,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "uesio"
 }
+HTTP 200
 
 # Get a list of all available namespaces from a siteadmin context
 GET {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/siteadmin/uesio/tests/testsite/metadata/namespaces

--- a/apps/platform-integration-tests/hurl_specs/metadata_list_version_context.hurl
+++ b/apps/platform-integration-tests/hurl_specs/metadata_list_version_context.hurl
@@ -7,6 +7,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "uesio"
 }
+HTTP 200
 
 # Get a list of all available namespaces from a version context
 GET {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/version/uesio/tests/v0.0.1/metadata/namespaces

--- a/apps/platform-integration-tests/hurl_specs/metadata_list_workspace_context.hurl
+++ b/apps/platform-integration-tests/hurl_specs/metadata_list_workspace_context.hurl
@@ -7,6 +7,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "uesio"
 }
+HTTP 200
 
 # Get a list of all available namespaces from a workspace context
 GET {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/uesio/tests/dev/metadata/namespaces

--- a/apps/platform-integration-tests/hurl_specs/multicollection.hurl
+++ b/apps/platform-integration-tests/hurl_specs/multicollection.hurl
@@ -12,6 +12,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "uesio"
 }
+HTTP 200
 
 # GET an account and contact uuid
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/uesio/tests/dev/wires/load

--- a/apps/platform-integration-tests/hurl_specs/not_found_routes.hurl
+++ b/apps/platform-integration-tests/hurl_specs/not_found_routes.hurl
@@ -7,6 +7,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "uesio"
 }
+HTTP 200
 
 # Test fetching a route as though we are a browser expecting HTML,
 # in which case we want to serve our "NotFound" error page

--- a/apps/platform-integration-tests/hurl_specs/prevent_querying_secret_store_values.hurl
+++ b/apps/platform-integration-tests/hurl_specs/prevent_querying_secret_store_values.hurl
@@ -7,6 +7,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "uesio"
 }
+HTTP 200
 
 # Set the value of the Resend key so that we can test it
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/uesio/tests/dev/wires/save

--- a/apps/platform-integration-tests/hurl_specs/record_token_refresh.hurl
+++ b/apps/platform-integration-tests/hurl_specs/record_token_refresh.hurl
@@ -95,6 +95,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "uesio"
 }
+HTTP 200
 
 # Put ben on the account team
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/uesio/tests/dev/wires/save
@@ -127,6 +128,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "ben"
 }
+HTTP 200
 
 # Now that ben is on the account team, he can see the evil corp.
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/uesio/tests/dev/wires/load

--- a/apps/platform-integration-tests/hurl_specs/record_tokens.hurl
+++ b/apps/platform-integration-tests/hurl_specs/record_tokens.hurl
@@ -3,6 +3,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "uesio"
 }
+HTTP 200
 
 # Workspace users can access everything
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/uesio/tests/dev/wires/load

--- a/apps/platform-integration-tests/hurl_specs/required_validation.hurl
+++ b/apps/platform-integration-tests/hurl_specs/required_validation.hurl
@@ -7,6 +7,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "uesio"
 }
+HTTP 200
 
 # Test try to INSERT missing a required field on changes
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/uesio/tests/dev/wires/save

--- a/apps/platform-integration-tests/hurl_specs/route_bot.hurl
+++ b/apps/platform-integration-tests/hurl_specs/route_bot.hurl
@@ -7,6 +7,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "uesio"
 }
+HTTP 200
 
 # Invoke with required parameters
 GET {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/uesio/tests/dev/app/uesio/tests/tools/by-brand/makita

--- a/apps/platform-integration-tests/hurl_specs/route_params.hurl
+++ b/apps/platform-integration-tests/hurl_specs/route_params.hurl
@@ -7,6 +7,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "uesio"
 }
+HTTP 200
 
 # Test fetching metadata for params of a Route that serves a View
 GET {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/uesio/tests/dev/routes/params/uesio/tests/animal_details

--- a/apps/platform-integration-tests/hurl_specs/runagent.hurl
+++ b/apps/platform-integration-tests/hurl_specs/runagent.hurl
@@ -7,6 +7,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "uesio"
 }
+HTTP 200
 
 # Invoke with missing agent parameter
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/uesio/tests/dev/bots/call/uesio/aikit/runagent

--- a/apps/platform-integration-tests/hurl_specs/site_admin_context.hurl
+++ b/apps/platform-integration-tests/hurl_specs/site_admin_context.hurl
@@ -3,6 +3,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "uesio"
 }
+HTTP 200
 
 # Try to administer the tests site as the owner of the app
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/siteadmin/uesio/tests/testsite/wires/load
@@ -29,6 +30,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "ben"
 }
+HTTP 200
 
 # Try to administer the tests site as a team member of the app
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/siteadmin/uesio/tests/testsite/wires/load
@@ -55,6 +57,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "abel"
 }
+HTTP 200
 
 # Try (and fail) to administer the tests site as an outsider (sorry abel)
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/siteadmin/uesio/tests/testsite/wires/load

--- a/apps/platform-integration-tests/hurl_specs/site_admin_context_guest_system_users.hurl
+++ b/apps/platform-integration-tests/hurl_specs/site_admin_context_guest_system_users.hurl
@@ -3,6 +3,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "uesio"
 }
+HTTP 200
 
 # Create a new user that will be deleted later
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/siteadmin/uesio/tests/testsite/wires/save

--- a/apps/platform-integration-tests/hurl_specs/uniquekey.hurl
+++ b/apps/platform-integration-tests/hurl_specs/uniquekey.hurl
@@ -7,6 +7,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "ben"
 }
+HTTP 200
 
 # Test a simple insert into the bundle collection
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/wires/save

--- a/apps/platform-integration-tests/hurl_specs/usage.hurl
+++ b/apps/platform-integration-tests/hurl_specs/usage.hurl
@@ -7,7 +7,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "ben"
 }
-
+HTTP 200
 
 # Run the usage job so that we're sure to have usage data available
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/worker/usage

--- a/apps/platform-integration-tests/hurl_specs/user_tokens.hurl
+++ b/apps/platform-integration-tests/hurl_specs/user_tokens.hurl
@@ -3,7 +3,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "uesio"
 }
-
+HTTP 200
 
 # Test a wire load with no conditions
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/wires/load

--- a/apps/platform-integration-tests/hurl_specs/view_definition_validation.hurl
+++ b/apps/platform-integration-tests/hurl_specs/view_definition_validation.hurl
@@ -7,6 +7,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "uesio"
 }
+HTTP 200
 
 # Get the dev workspace id so we can test saving a view in a workspace
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/wires/load

--- a/apps/platform-integration-tests/hurl_specs/viewparams.hurl
+++ b/apps/platform-integration-tests/hurl_specs/viewparams.hurl
@@ -7,6 +7,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "uesio"
 }
+HTTP 200
 
 # Test fetching metadata for the view's params
 GET {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/uesio/tests/dev/views/params/uesio/tests/view_params

--- a/apps/platform-integration-tests/hurl_specs/wire_aggregate_load.hurl
+++ b/apps/platform-integration-tests/hurl_specs/wire_aggregate_load.hurl
@@ -7,7 +7,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "uesio"
 }
-
+HTTP 200
 
 # Test an aggregate wire load with no conditions
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/uesio/tests/dev/wires/load

--- a/apps/platform-integration-tests/hurl_specs/wire_collection_dependencies.hurl
+++ b/apps/platform-integration-tests/hurl_specs/wire_collection_dependencies.hurl
@@ -8,6 +8,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "uesio"
 }
+HTTP 200
 
 # Test that wire collection field dependencies are accumulated into a union of all fields
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/uesio/tests/dev/wires/load

--- a/apps/platform-integration-tests/hurl_specs/wire_load.hurl
+++ b/apps/platform-integration-tests/hurl_specs/wire_load.hurl
@@ -7,7 +7,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "uesio"
 }
-
+HTTP 200
 
 # Test a wire load with no conditions
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/uesio/tests/dev/wires/load

--- a/apps/platform-integration-tests/hurl_specs/wire_load_external_integration_collection.hurl
+++ b/apps/platform-integration-tests/hurl_specs/wire_load_external_integration_collection.hurl
@@ -7,6 +7,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "uesio"
 }
+HTTP 200
 
 # Test a wire load with no conditions
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/uesio/tests/dev/wires/load

--- a/apps/platform-integration-tests/hurl_specs/wire_load_external_self.hurl
+++ b/apps/platform-integration-tests/hurl_specs/wire_load_external_self.hurl
@@ -7,7 +7,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "uesio"
 }
-
+HTTP 200
 
 # Test a simple external load
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/uesio/tests/dev/wires/load

--- a/apps/platform-integration-tests/hurl_specs/wire_load_group_condition.hurl
+++ b/apps/platform-integration-tests/hurl_specs/wire_load_group_condition.hurl
@@ -7,6 +7,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "uesio"
 }
+HTTP 200
 
 # Test a wire load with a group condition (or)
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/uesio/tests/dev/wires/load

--- a/apps/platform-integration-tests/hurl_specs/wire_load_localized_fields.hurl
+++ b/apps/platform-integration-tests/hurl_specs/wire_load_localized_fields.hurl
@@ -7,6 +7,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "uesio"
 }
+HTTP 200
 
 # Test a wire load with a simple condition
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/uesio/tests/dev/wires/load

--- a/apps/platform-integration-tests/hurl_specs/wire_load_lookup_condition.hurl
+++ b/apps/platform-integration-tests/hurl_specs/wire_load_lookup_condition.hurl
@@ -7,7 +7,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "uesio"
 }
-
+HTTP 200
 
 # IN Operator with values
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/uesio/tests/dev/wires/load

--- a/apps/platform-integration-tests/hurl_specs/wire_load_novaluebehavior_condition.hurl
+++ b/apps/platform-integration-tests/hurl_specs/wire_load_novaluebehavior_condition.hurl
@@ -7,6 +7,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "uesio"
 }
+HTTP 200
 
 # Test a wire load with no novaluebehavor property on the condition
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/uesio/tests/dev/wires/load

--- a/apps/platform-integration-tests/hurl_specs/wire_load_reference_crossing_condition.hurl
+++ b/apps/platform-integration-tests/hurl_specs/wire_load_reference_crossing_condition.hurl
@@ -7,6 +7,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "uesio"
 }
+HTTP 200
 
 # Test a wire load with a single reference-crossing condition
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/uesio/tests/dev/wires/load

--- a/apps/platform-integration-tests/hurl_specs/wire_load_search_condition.hurl
+++ b/apps/platform-integration-tests/hurl_specs/wire_load_search_condition.hurl
@@ -7,6 +7,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "uesio"
 }
+HTTP 200
 
 # Test a wire load with a search condition
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/uesio/tests/dev/wires/load

--- a/apps/platform-integration-tests/hurl_specs/wire_load_studio_users.hurl
+++ b/apps/platform-integration-tests/hurl_specs/wire_load_studio_users.hurl
@@ -7,6 +7,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "ben"
 }
+HTTP 200
 
 # Delete the sample ORG user if it exists
 DELETE {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/api/v1/collection/uesio/core/user?uesio/core.username=eq.testorguser

--- a/apps/platform-integration-tests/hurl_specs/wire_load_subquery_condition.hurl
+++ b/apps/platform-integration-tests/hurl_specs/wire_load_subquery_condition.hurl
@@ -7,6 +7,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "uesio"
 }
+HTTP 200
 
 # Test a wire load with a single subquery condition
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/uesio/tests/dev/wires/load

--- a/apps/platform-integration-tests/hurl_specs/wire_load_userfile.hurl
+++ b/apps/platform-integration-tests/hurl_specs/wire_load_userfile.hurl
@@ -7,6 +7,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "uesio"
 }
+HTTP 200
 
 # Get the id of an animal record
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/uesio/tests/dev/wires/load

--- a/apps/platform-integration-tests/hurl_specs/wire_save.hurl
+++ b/apps/platform-integration-tests/hurl_specs/wire_save.hurl
@@ -7,6 +7,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "uesio"
 }
+HTTP 200
 
 # Get a record
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/uesio/tests/dev/wires/load

--- a/apps/platform-integration-tests/hurl_specs/wire_save_external_integration_collection.hurl
+++ b/apps/platform-integration-tests/hurl_specs/wire_save_external_integration_collection.hurl
@@ -7,6 +7,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "uesio"
 }
+HTTP 200
 
 # Test inserting, updating, and deleting dummy records
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/uesio/tests/dev/wires/save

--- a/apps/platform-integration-tests/hurl_specs/wire_save_reference.hurl
+++ b/apps/platform-integration-tests/hurl_specs/wire_save_reference.hurl
@@ -7,7 +7,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "uesio"
 }
-
+HTTP 200
 
 # GET an account and contact uuid
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/uesio/tests/dev/wires/load

--- a/apps/platform-integration-tests/hurl_specs/wire_save_userfile.hurl
+++ b/apps/platform-integration-tests/hurl_specs/wire_save_userfile.hurl
@@ -7,6 +7,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "uesio"
 }
+HTTP 200
 
 # Get the id of an animal record
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/uesio/tests/dev/wires/load

--- a/apps/platform-integration-tests/hurl_specs/workspace_bundle_store_cache_invalidation.hurl
+++ b/apps/platform-integration-tests/hurl_specs/workspace_bundle_store_cache_invalidation.hurl
@@ -5,6 +5,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "uesio"
 }
+HTTP 200
 
 # Access the deps route for previewing this route,
 # which should have been seeded in the workspace bundle store cache via lines 227-232 of app_and_workspace.hurl,

--- a/apps/platform-integration-tests/hurl_specs/workspace_context.hurl
+++ b/apps/platform-integration-tests/hurl_specs/workspace_context.hurl
@@ -3,6 +3,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "uesio"
 }
+HTTP 200
 
 # Try to navigate to the workspace home route
 GET {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/routes/path/uesio/studio/app/uesio/tests/workspace/dev
@@ -43,6 +44,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "ben"
 }
+HTTP 200
 
 # Try to navigate to the workspace home route
 GET {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/routes/path/uesio/studio/app/uesio/tests/workspace/dev
@@ -83,6 +85,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "abel"
 }
+HTTP 200
 
 # Try to navigate to the workspace home route
 GET {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/routes/path/uesio/studio/app/uesio/tests/workspace/dev

--- a/apps/platform-integration-tests/hurl_specs/workspace_static_file_load_dependencies.hurl
+++ b/apps/platform-integration-tests/hurl_specs/workspace_static_file_load_dependencies.hurl
@@ -7,7 +7,6 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "uesio"
 }
-
 # Extract the sessionid from set-cookie header
 HTTP 200
 [Captures]

--- a/apps/platform-integration-tests/hurl_specs_single_run/perf_stats.hurl
+++ b/apps/platform-integration-tests/hurl_specs_single_run/perf_stats.hurl
@@ -7,6 +7,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "uesio"
 }
+HTTP 200
 
 # Run the perf stats job
 GET {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/perf/stats

--- a/apps/platform-integration-tests/hurl_specs_single_run/truncate_tenant_data_cli.hurl
+++ b/apps/platform-integration-tests/hurl_specs_single_run/truncate_tenant_data_cli.hurl
@@ -7,6 +7,7 @@ POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/ue
 {
     "token": "uesio"
 }
+HTTP 200
 
 # Test a wire load with no conditions
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/uesio/tests/dev/wires/load


### PR DESCRIPTION
# What does this PR do?

1. Adds missing http status code assertion to platform-integration-tests that did not assert codes previously
2. Fixes delete_app.hurl assertion that was incorrectly asserting `http 200` instead of `http *` even though it had a further matches assertion to ensure a `204|404`

# Testing

All works manually, ci will cover.
