### PR TITLE
fix: patch twind to remove container query hack

### DIFF
--- a/README.md
+++ b/README.md
@@ -626,3 +626,9 @@ For Go **package naming**, we follow this [guideline](https://blog.golang.org/pa
    - UPDATE 2025.07.03: https://github.com/web-infra-dev/modern.js/issues/6993 has been resolved and was released in [v2.68.0](https://github.com/web-infra-dev/modern.js/releases/tag/v2.68.0). Now waiting on https://github.com/module-federation/core/issues/3719.
 5. `tailwind-merge` v3.x requirese tailwind 4 so sticking with v2.x until the uesio styling system can be refactored and/or testing can be performed with how, if at all due to tailwind v4 base, the other tailwind dependencies interoperate with `tailwind-merge` v3.x.
 6. `@twind/*` packages have their `typescript` dependency overridden to our current `typescript` version due to [peer deps warning](https://github.com/tw-in-js/twind/issues/513). This package no longer appears to be maintained and, similar to `tailwind-merge`, an alternate solution should be researched including refactoring the uesio styling system as a whole.
+
+## Patches
+
+We're using `patch-package` to patch dependencies that are no longer maintained or if we need to make a quick patch to a package that has not yet released a fix.
+
+1. Patch for `@twind/core`: In order to make all of our breakpoint variants (sm|md|lg|xl|2xl) act as `@container` queries instead of `@media` queries, we've changed a line of code in the package. The diff can be viewed in `patches/@twind+core+1.1.3.patch`.

--- a/libs/ui/src/styles/styles.ts
+++ b/libs/ui/src/styles/styles.ts
@@ -64,16 +64,6 @@ const processThemeColors = (
     : {}
 }
 
-// This converts all our @media queries to @container queries
-const presetContainerQueries = (): Preset => ({
-  finalize: (rule) => {
-    if (rule.r && rule.r.length > 0 && rule.r[0].startsWith("@media")) {
-      rule.r[0] = rule.r[0].replace("@media", "@container")
-    }
-    return rule
-  },
-})
-
 // this adds a @scope prefix to any rule that needs a scope.
 // (Used for themes-within-themes)
 const presetAddThemeScope = (scope: string): Preset => {
@@ -150,16 +140,14 @@ const setupStyles = (context: Context) => {
 
   if (activeStyles) return themeClasses
 
-  const presets = [
-    presetAutoprefix(),
-    presetTailwind(),
-    presetContainerQueries(),
-  ]
+  const presets = [presetAutoprefix(), presetTailwind()]
 
   if (themeData.isScoped) {
     presets.push(presetAddThemeScope(themeClass))
   }
 
+  // NOTE: We've patched the twind library to turn all breakpoint queries (sm|md|lg|xl|2xl)
+  // from @media queries to @container queries. See the Patches section in README.md for more info.
   const stylesInstance = twind(
     {
       presets,

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "uesio",
       "version": "0.0.0",
+      "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {
         "@dagrejs/dagre": "^1.1.5",
@@ -70,6 +71,7 @@
         "monaco-editor": "0.50.0",
         "nx": "21.2.2",
         "papaparse": "^5.5.3",
+        "patch-package": "^8.0.0",
         "prettier": "^3.6.2",
         "react": "^19.1.0",
         "react-chartjs-2": "^5.3.0",
@@ -11916,6 +11918,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/find-yarn-workspace-root": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+      "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "micromatch": "^4.0.2"
+      }
+    },
     "node_modules/flat": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
@@ -14810,6 +14822,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stable-stringify": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
+      "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "isarray": "^2.0.5",
+        "jsonify": "^0.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -14894,6 +14926,16 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "dev": true,
+      "license": "Public Domain",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/jsprim": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-2.0.2.tgz",
@@ -14947,6 +14989,16 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.11"
       }
     },
     "node_modules/kleur": {
@@ -17121,6 +17173,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/ospath": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/ospath/-/ospath-1.2.2.tgz",
@@ -17366,6 +17428,107 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/patch-package": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.0.tgz",
+      "integrity": "sha512-da8BVIhzjtgScwDJ2TtKsfT5JFWz1hYoBl9rUQ1f38MC2HwnEIkK8VN3dKMKcP7P7bvvgzNDbfNHtx3MsQb5vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@yarnpkg/lockfile": "^1.1.0",
+        "chalk": "^4.1.2",
+        "ci-info": "^3.7.0",
+        "cross-spawn": "^7.0.3",
+        "find-yarn-workspace-root": "^2.0.0",
+        "fs-extra": "^9.0.0",
+        "json-stable-stringify": "^1.0.2",
+        "klaw-sync": "^6.0.0",
+        "minimist": "^1.2.6",
+        "open": "^7.4.2",
+        "rimraf": "^2.6.3",
+        "semver": "^7.5.3",
+        "slash": "^2.0.0",
+        "tmp": "^0.0.33",
+        "yaml": "^2.2.2"
+      },
+      "bin": {
+        "patch-package": "index.js"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">5"
+      }
+    },
+    "node_modules/patch-package/node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/patch-package/node_modules/open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/patch-package/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/patch-package/node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/patch-package/node_modules/tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "os-tmpdir": "~1.0.2"
+      },
+      "engines": {
+        "node": ">=0.6.0"
       }
     },
     "node_modules/path-exists": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "test": "nx run-many -t test",
     "watch-all": "npm run build-all && nx watch --all -- nx run-many -t build -p \\$NX_PROJECT_NAME",
     "watch-platform-deps": "nx run platform:watch-deps",
-    "watch-dev": "nx run platform:dev --watch"
+    "watch-dev": "nx run platform:dev --watch",
+    "postinstall": "patch-package"
   },
   "nx": {
     "includedScripts": [],
@@ -132,6 +133,7 @@
     "monaco-editor": "0.50.0",
     "nx": "21.2.2",
     "papaparse": "^5.5.3",
+    "patch-package": "^8.0.0",
     "prettier": "^3.6.2",
     "react": "^19.1.0",
     "react-chartjs-2": "^5.3.0",

--- a/patches/@twind+core+1.1.3.patch
+++ b/patches/@twind+core+1.1.3.patch
@@ -1,0 +1,26 @@
+diff --git a/node_modules/@twind/core/core.dev.js b/node_modules/@twind/core/core.dev.js
+index e7e1df8..1d69d98 100644
+--- a/node_modules/@twind/core/core.dev.js
++++ b/node_modules/@twind/core/core.dev.js
+@@ -31,7 +31,7 @@ function format(rules, seperator = ',') {
+  * @param screen
+  * @param prefix
+  * @returns
+- */ function mql(screen, prefix = '@media ') {
++ */ function mql(screen, prefix = '@container ') {
+     return prefix + asArray(screen).map((screen)=>{
+         return 'string' == typeof screen && (screen = {
+             min: screen
+diff --git a/node_modules/@twind/core/core.js b/node_modules/@twind/core/core.js
+index 26018b3..15145b6 100644
+--- a/node_modules/@twind/core/core.js
++++ b/node_modules/@twind/core/core.js
+@@ -31,7 +31,7 @@ function format(rules, seperator = ',') {
+  * @param screen
+  * @param prefix
+  * @returns
+- */ function mql(screen, prefix = '@media ') {
++ */ function mql(screen, prefix = '@container ') {
+     return prefix + asArray(screen).map((screen)=>{
+         return 'string' == typeof screen && (screen = {
+             min: screen


### PR DESCRIPTION
# What does this PR do?

This PR removes the container queries preset hack in favor of a more performant and less dangerous hack. Instead of adding a finalize rule as a preset, we're changing the default prefix that twind uses when creating breakpoint variants.

# Testing

1. Visit the Files section of a workspace in the studio. Resize your browser to a variety of sizes. Verify that the file tiles respond correctly to the resizing, and there are no instances of overflowing text.
