### PR TITLE
feat: add has hover variant

### DIFF
--- a/libs/apps/uesio/appkit/bundle/componentvariants/uesio/io/button/itemaction.yaml
+++ b/libs/apps/uesio/appkit/bundle/componentvariants/uesio/io/button/itemaction.yaml
@@ -5,5 +5,5 @@ extends: uesio/appkit.navicon
 definition:
   uesio.styleTokens:
     root:
-      - invisible
+      - has-hover:invisible
       - group-hover:visible

--- a/libs/ui/src/styles/styles.ts
+++ b/libs/ui/src/styles/styles.ts
@@ -164,6 +164,7 @@ const setupStyles = (context: Context) => {
     {
       presets,
       hash: false,
+      variants: [["has-hover", "@media (hover: hover) and (pointer: fine)"]],
       theme: {
         extend: {
           colors: ({ theme }) => processThemeColors(theme, themeData),


### PR DESCRIPTION
# What does this PR do?

In order to support cases where you only want to apply a style if the browser supports hovering, this PR adds a new variant called `has-hover`. Style tokens used with this variant will only apply if the browser has hover support.

# Testing

1. Go to the files section of a workspace in the studio. Verify that the delete icon shows when you hover of a file tile.
2. Next turn on "responsive mode" in your browser's devtools. Verify that the delete icon always shows when viewing as a mobile device.