### PR TITLE
fix: bundle versions list api improvements

### DIFF
--- a/apps/platform/pkg/controller/bundleversionslist.go
+++ b/apps/platform/pkg/controller/bundleversionslist.go
@@ -88,7 +88,7 @@ func BundleVersionsList(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var responses []BundleVersionsListResponse
+	responses := make([]BundleVersionsListResponse, 0, bundles.Len())
 	if err := bundles.Loop(func(item meta.Item, index string) error {
 		description, err := item.GetField("uesio/studio.description")
 		if err != nil {


### PR DESCRIPTION
# What does this PR do?

1. Always return an array even when no items (instead of previous `null` response)
2. Perf improvement to avoid re-allocations when building response slice

# Testing

Manually confirmed expected outcome, ci & e2e will cover rest.
