### PR TITLE
chore: ensure all integration tests pass in isolation

### DIFF
--- a/apps/platform-integration-tests/hurl_specs/app_publish_flow.hurl
+++ b/apps/platform-integration-tests/hurl_specs/app_publish_flow.hurl
@@ -295,3 +295,15 @@ Accept: application/json
 HTTP 200
 [Asserts]
 jsonpath "$.wires[0].errors" == null
+
+# Get published versions for the tests/app bundle
+GET {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/bundles/v1/versions/uesio/tests/list
+Accept: application/json
+HTTP 200
+[Asserts]
+jsonpath "$" count >= 1
+jsonpath "$" count <= 5
+jsonpath "$[*].version" exists
+jsonpath "$[*].description" exists
+jsonpath "$[0].description" == "test bundle"
+jsonpath "$[0].version" == "v0.0.1"

--- a/apps/platform-integration-tests/hurl_specs/bundle_store_apis.hurl
+++ b/apps/platform-integration-tests/hurl_specs/bundle_store_apis.hurl
@@ -14,15 +14,3 @@ jsonpath "$[*].app" exists
 jsonpath "$[*].icon" exists
 jsonpath "$[*].description" exists
 jsonpath "$[*].color" exists
-
-# Get published versions for the tests/app bundle
-GET {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/bundles/v1/versions/uesio/tests/list
-Accept: application/json
-HTTP 200
-[Asserts]
-jsonpath "$" count >= 1
-jsonpath "$" count <= 5
-jsonpath "$[*].version" exists
-jsonpath "$[*].description" exists
-jsonpath "$[0].description" == "test bundle"
-jsonpath "$[0].version" == "v0.0.1"

--- a/apps/platform-integration-tests/hurl_specs/metadata_list_workspace_context.hurl
+++ b/apps/platform-integration-tests/hurl_specs/metadata_list_workspace_context.hurl
@@ -30,7 +30,7 @@ HTTP 200
 # TODO: Unclear why this assert exists as its fragile and likely does not help in any way since underlying
 # data can change across the test suite.  Evaluate this tests purpose and adjust the assert to be
 # explicit/more meaningful or remove.
-jsonpath "$[*]" count == 30
+jsonpath "$[*]" count >= 29
 # Spot check a uesio/tests collection
 jsonpath "$['uesio/tests.animal'].key" == "uesio/tests.animal"
 jsonpath "$['uesio/tests.animal'].namespace" == "uesio/tests"
@@ -48,7 +48,7 @@ HTTP 200
 # TODO: Unclear why this assert exists as its fragile and likely does not help in any way since underlying
 # data can change across the test suite.  Evaluate this tests purpose and adjust the assert to be
 # explicit/more meaningful or remove.
-jsonpath "$[*]" count == 12
+jsonpath "$[*]" count >= 11
 # Spot check a uesio/tests collection
 jsonpath "$['uesio/tests.animal'].key" == "uesio/tests.animal"
 jsonpath "$['uesio/tests.animal'].namespace" == "uesio/tests"


### PR DESCRIPTION
# What does this PR do?

Fixes integration tests to ensure each individual test file passes when run in isolation - meaning `npm run tests-init` and then `npx nx run platform-integration-tests:integration <path_to_file>` succeeds.

This is the next step towards being able to run integration tests in parallel.  There is still more work to be done since a lot of tests are written to rely on previous files (via alphanumeric sort of name) having "done something". 

Note - The integration tests still need a lot of improvement across the board to ensure that each of them is meaningful and providing value/benefit.  Additionally, more coverage of scenarios currently not tested is required.  These two items are separate from being able to baseline and run all current tests in parallel however.

# Testing

Confirmed that each of the 98 hurl files when run in isolation now pass.
