### PR TITLE
refactor: cleanup generator form and buttons

### DIFF
--- a/libs/apps/uesio/core/bundle/bots/generator/agent/bot.js
+++ b/libs/apps/uesio/core/bundle/bots/generator/agent/bot.js
@@ -1,6 +1,7 @@
 function run(botapi) {
   const params = botapi.params.getAll()
   const { name, label, description, prompt } = params
+  const namespace = botapi.getAppName()
 
   const basePath = `agents/${name}`
 
@@ -11,4 +12,6 @@ function run(botapi) {
     { name, label, description },
     `templates/agent.yaml`,
   )
+
+  botapi.setRedirect(`/agents/${namespace}/${name}`)
 }

--- a/libs/apps/uesio/core/bundle/bots/generator/bot/bot.js
+++ b/libs/apps/uesio/core/bundle/bots/generator/bot/bot.js
@@ -3,6 +3,7 @@ function run(botapi) {
   const app = botapi.getAppName()
   const params = botapi.params.getAll()
   const { name, collection, content } = params
+  const namespace = botapi.getAppName()
   const botParams = params.params
   const type = (params.type || "LISTENER").toLowerCase()
   const dialect = (params.dialect || "TYPESCRIPT").toLowerCase()
@@ -63,4 +64,6 @@ function run(botapi) {
       `templates/${type}/bot.template.yaml`,
     )
   }
+
+  botapi.setRedirect(`/bots/${type}/${namespace}/${name}`)
 }

--- a/libs/apps/uesio/core/bundle/bots/generator/component/bot.js
+++ b/libs/apps/uesio/core/bundle/bots/generator/component/bot.js
@@ -3,6 +3,7 @@ function run(bot) {
   const name = bot.params.get("name")
   const type = bot.params.get("type")
   const definition = bot.params.get("definition")
+  const namespace = bot.getAppName()
   const componentName = `${name.charAt(0).toUpperCase() + name.slice(1)}`
   if (type === "DECLARATIVE") {
     if (definition) {
@@ -36,4 +37,6 @@ function run(bot) {
     },
     "templates/reactComponent.template.yaml",
   )
+
+  bot.setRedirect(`/components/${namespace}/${name}`)
 }

--- a/libs/apps/uesio/core/bundle/bots/generator/componentpack/bot.js
+++ b/libs/apps/uesio/core/bundle/bots/generator/componentpack/bot.js
@@ -1,5 +1,6 @@
 function run(bot) {
   const name = bot.params.get("name")
+  const namespace = bot.getAppName()
   bot.generateYamlFile(
     `componentpacks/${name}/pack.yaml`,
     {
@@ -7,4 +8,6 @@ function run(bot) {
     },
     "templates/pack.yaml",
   )
+
+  bot.setRedirect(`/componentpacks/${namespace}/${name}`)
 }

--- a/libs/apps/uesio/core/bundle/bots/generator/route/bot.js
+++ b/libs/apps/uesio/core/bundle/bots/generator/route/bot.js
@@ -1,11 +1,8 @@
 function run(bot) {
-  const contextApp = bot.getAppName()
+  const name = bot.params.get("name")
+  const namespace = bot.getAppName()
   const params = bot.params.getAll()
-  // Strip off the context app name from the bot key
-  // if it is the same as the current app
-  if (params.bot && params.bot.startsWith(contextApp)) {
-    params.bot = params.bot.slice(contextApp.length + 1)
-  }
+
   if (!params.params) {
     params.params = ""
   }
@@ -14,4 +11,6 @@ function run(bot) {
     params,
     `templates/route_${params.type || "view"}.template.yaml`,
   )
+
+  bot.setRedirect(`/routes/${namespace}/${name}`)
 }

--- a/libs/apps/uesio/core/bundle/bots/generator/signupmethod/bot.js
+++ b/libs/apps/uesio/core/bundle/bots/generator/signupmethod/bot.js
@@ -1,5 +1,6 @@
 function run(bot) {
   const name = bot.params.get("name")
+  const namespace = bot.getAppName()
   const authSource = bot.params.get("authSource") || ""
   const profile = bot.params.get("profile") || ""
   const usernameTemplate = bot.params.get("usernameTemplate") || ""
@@ -31,4 +32,6 @@ function run(bot) {
     },
     "templates/signupmethod.yaml",
   )
+
+  bot.setRedirect(`/signupmethods/${namespace}/${name}`)
 }

--- a/libs/apps/uesio/studio/bundle/componentpacks/main/src/components/generatorform/generatorform.tsx
+++ b/libs/apps/uesio/studio/bundle/componentpacks/main/src/components/generatorform/generatorform.tsx
@@ -109,4 +109,6 @@ GeneratorForm.signals = {
   RUN: runGenerator,
 }
 
+export { run }
+
 export default GeneratorForm

--- a/libs/apps/uesio/studio/bundle/views/bot.yaml
+++ b/libs/apps/uesio/studio/bundle/views/bot.yaml
@@ -79,14 +79,12 @@ definition:
                                     field: uesio/studio.type
                                     value: GENERATOR
                                 components:
-                                  - uesio/studio.generatorbutton:
-                                      uesio.context:
-                                        workspace:
-                                          name: $Param{workspacename}
-                                          app: $Param{app}
-                                      buttonVariant: uesio/appkit.secondary
-                                      label: Run this generator
-                                      generator: ${uesio/studio.namespace}.${uesio/studio.name}
+                                  - uesio/io.button:
+                                      uesio.variant: uesio/appkit.secondary
+                                      text: Run this generator
+                                      signals:
+                                        - signal: route/NAVIGATE
+                                          path: app/$Param{app}/workspace/$Param{workspacename}/generate/${namespace}/${name}
                             - uesio/io.group:
                                 uesio.display:
                                   - type: paramValue


### PR DESCRIPTION
# What does this PR do?

1. Whenever we use the `uesio/studio.generatorbutton` component, we now follow the generator's redirect instead of just refreshing the page.
2. Consolidate duplicated code between `uesio/studio.generatorbutton` and `uesio/studio.generatorform`
3. The "Run this generator" button on the generator bot detail page, now just redirects to the generator runner form, instead of displaying the form in a popup. (this simplifies the ux there and allows the redirects to be more intuitive.)

The main change with this PR is that when using the generatorbutton for creating the following metadata items:

agent
bot
component
componentpack
route
signupmethod

We now redirect to the item we just created instead of refreshing the list view.
