### PR TITLE
refactor use form detail component for labels and translations

### DIFF
--- a/libs/apps/uesio/appkit/bundle/components/form_detail.yaml
+++ b/libs/apps/uesio/appkit/bundle/components/form_detail.yaml
@@ -148,6 +148,7 @@ definition:
         - uesio/appkit.section_audit_info:
         - uesio/appkit.section_delete:
             confirm: $Prop{deleteconfirm}
+            confirmMessage: $Prop{deleteconfirmmessage}
             signals: $Prop{deletesignals}
 title: Detail Form Component
 discoverable: true

--- a/libs/apps/uesio/core/bundle/bots/generator/agent/bot.yaml
+++ b/libs/apps/uesio/core/bundle/bots/generator/agent/bot.yaml
@@ -4,7 +4,7 @@ label: Agent
 type: GENERATOR
 params:
   - name: name
-    prompt: Bot Name
+    prompt: Agent Name
     type: METADATANAME
     required: true
   - name: label

--- a/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/field/list.tsx
+++ b/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/field/list.tsx
@@ -44,7 +44,7 @@ const ListField: definition.UtilityComponent<ListFieldUtilityProps> = (
   const {
     context,
     fieldId,
-    mode,
+    mode = props.context.getFieldMode(),
     options = {} as ListFieldOptions,
     path,
     variant,

--- a/libs/apps/uesio/studio/bundle/collections/label.yaml
+++ b/libs/apps/uesio/studio/bundle/collections/label.yaml
@@ -5,5 +5,5 @@ uniqueKey:
 nameField: uesio/studio.name
 access: protected
 accessField: uesio/studio.workspace
-label: label
-pluralLabel: labels
+label: Label
+pluralLabel: Labels

--- a/libs/apps/uesio/studio/bundle/collections/translation.yaml
+++ b/libs/apps/uesio/studio/bundle/collections/translation.yaml
@@ -5,5 +5,5 @@ uniqueKey:
 nameField: uesio/studio.language
 access: protected
 accessField: uesio/studio.workspace
-label: translation
-pluralLabel: translations
+label: Translation
+pluralLabel: Translations

--- a/libs/apps/uesio/studio/bundle/componentpacks/main/src/components/translations/translationitem.tsx
+++ b/libs/apps/uesio/studio/bundle/componentpacks/main/src/components/translations/translationitem.tsx
@@ -64,7 +64,6 @@ const TranslationItem: definition.UtilityComponent<Props> = (props) => {
         }}
         value={translations}
         setValue={setTranslations}
-        mode={"EDIT"}
         context={context}
       />
     </>

--- a/libs/apps/uesio/studio/bundle/views/label.yaml
+++ b/libs/apps/uesio/studio/bundle/views/label.yaml
@@ -41,68 +41,17 @@ definition:
         content:
           - uesio/appkit.layout_detail_split:
               main:
-                - uesio/io.list:
-                    uesio.id: labelsList
+                - uesio/appkit.form_detail:
                     wire: labels
-                    mode: READ
-                    components:
-                      - uesio/io.titlebar:
-                          uesio.variant: uesio/appkit.main
-                          title: ${uesio/studio.name}
-                          subtitle: Label
-                          avatar:
-                            - uesio/io.text:
-                                uesio.variant: uesio/io.icon
-                                text: ${uesio/studio.appicon}
-                                color: ${uesio/studio.appcolor}
-                          actions:
-                            - uesio/io.group:
-                                components:
-                                  - uesio/io.button:
-                                      uesio.variant: uesio/appkit.secondary
-                                      text: $Label{uesio/io.edit}
-                                      uesio.display:
-                                        - type: fieldMode
-                                          mode: READ
-                                        - type: paramValue
-                                          param: app
-                                          operator: EQUALS
-                                          value: $Param{namespace}
-                                      signals:
-                                        - signal: component/CALL
-                                          component: uesio/io.list
-                                          componentsignal: TOGGLE_MODE
-                                          targettype: specific
-                                          componentid: labelsList
-                                  - uesio/io.button:
-                                      uesio.variant: uesio/appkit.primary
-                                      text: $Label{uesio/io.save}
-                                      uesio.display:
-                                        - type: wireHasChanges
-                                          wire: labels
-                                      signals:
-                                        - signal: wire/SAVE
-                                          wires:
-                                            - labels
-                                        - signal: component/CALL
-                                          component: uesio/io.list
-                                          componentsignal: TOGGLE_MODE
-                                          targettype: specific
-                                          componentid: labelsList
-                                  - uesio/io.button:
-                                      uesio.variant: uesio/appkit.secondary
-                                      text: $Label{uesio/io.cancel}
-                                      uesio.display:
-                                        - type: fieldMode
-                                          mode: EDIT
-                                      signals:
-                                        - signal: wire/CANCEL
-                                          wire: labels
-                                        - signal: component/CALL
-                                          component: uesio/io.list
-                                          componentsignal: TOGGLE_MODE
-                                          targettype: specific
-                                          componentid: labelsList
+                    avataricon: ${uesio/studio.appicon}
+                    avatariconcolor: ${uesio/studio.appcolor}
+                    deleteconfirm: true
+                    deletesignals:
+                      - signal: wire/MARK_FOR_DELETE
+                      - signal: wire/SAVE
+                      - signal: route/NAVIGATE
+                        path: app/$Param{app}/workspace/$Param{workspacename}/labels
+                    content:
                       - uesio/io.box:
                           uesio.variant: uesio/appkit.primarysection
                           components:
@@ -113,11 +62,3 @@ definition:
                                       fieldId: uesio/studio.name
                                   - uesio/io.field:
                                       fieldId: uesio/studio.value
-                      - uesio/appkit.section_audit_info:
-                      - uesio/appkit.section_delete:
-                          confirm: true
-                          signals:
-                            - signal: wire/MARK_FOR_DELETE
-                            - signal: wire/SAVE
-                            - signal: route/NAVIGATE
-                              path: app/$Param{app}/workspace/$Param{workspacename}/labels

--- a/libs/apps/uesio/studio/bundle/views/translation.yaml
+++ b/libs/apps/uesio/studio/bundle/views/translation.yaml
@@ -58,44 +58,19 @@ definition:
         content:
           - uesio/appkit.layout_detail_split:
               main:
-                - uesio/io.list:
-                    uesio.id: translationsDeck
+                - uesio/appkit.form_detail:
                     wire: translations
-                    mode: READ
-                    components:
-                      - uesio/io.titlebar:
-                          uesio.variant: uesio/appkit.main
-                          title: $SelectList{uesio/studio.language}
-                          subtitle: Translation
-                          avatar:
-                            - uesio/io.text:
-                                uesio.variant: uesio/io.icon
-                                text: translate
-                                color: ${uesio/studio.appcolor}
-                          actions:
-                            - uesio/io.group:
-                                components:
-                                  - uesio/io.button:
-                                      uesio.variant: uesio/io.primary
-                                      text: $Label{uesio/io.save}
-                                      hotkey: "meta+s"
-                                      uesio.display:
-                                        - type: wireHasChanges
-                                          wire: translations
-                                      signals:
-                                        - signal: wire/SAVE
-                                          wires:
-                                            - translations
-                                  - uesio/io.button:
-                                      uesio.variant: uesio/io.secondary
-                                      text: $Label{uesio/io.cancel}
-                                      hotkey: "meta+shift+."
-                                      uesio.display:
-                                        - type: wireHasChanges
-                                          wire: translations
-                                      signals:
-                                        - signal: wire/CANCEL
-                                          wire: translations
+                    title: $SelectList{uesio/studio.language}
+                    avataricon: translate
+                    avatariconcolor: ${uesio/studio.appcolor}
+                    deleteconfirm: true
+                    deleteconfirmmessage: The $Collection{label} $SelectList{uesio/studio.language} will be deleted. This action cannot be undone.
+                    deletesignals:
+                      - signal: wire/MARK_FOR_DELETE
+                      - signal: wire/SAVE
+                      - signal: route/NAVIGATE
+                        path: app/$Param{app}/workspace/$Param{workspacename}/translations
+                    content:
                       - uesio/io.box:
                           uesio.variant: uesio/appkit.primarysection
                           components:
@@ -111,13 +86,3 @@ definition:
                                 labelsWire: labels
                                 translationsWire: translations
                                 labelsFieldId: uesio/studio.labels
-                      - uesio/appkit.section_audit_info:
-                      - uesio/appkit.section_delete:
-                          editModeOnly: false
-                          confirm: true
-                          confirmMessage: The $Collection{label} $SelectList{uesio/studio.language} will be deleted. This action cannot be undone.
-                          signals:
-                            - signal: wire/MARK_FOR_DELETE
-                            - signal: wire/SAVE
-                            - signal: route/NAVIGATE
-                              path: app/$Param{app}/workspace/$Param{workspacename}/translations


### PR DESCRIPTION
# What does this PR do?

1. For better consistency in detail pages, use the `uesio/appkit.form_detail` component.
2. Make list field respect field mode context.
3. Fixes some labels

# Testing

View a translation and label detail page for a workspace.
