### PR TITLE
refactor: add attachments to record manager

### DIFF
--- a/libs/apps/uesio/appkit/bundle/views/file_attachments.yaml
+++ b/libs/apps/uesio/appkit/bundle/views/file_attachments.yaml
@@ -56,6 +56,11 @@ definition:
               reference:
                 components:
                   - uesio/appkit.tile_file:
+                      # TODO: Ideally we could just add a REFERENCEGROUP condition
+                      # to the wire in context and we would be able to remove this
+                      # somewhat hacky display condition. That way the caller of
+                      # this view could decide whether or not to show attachments
+                      # that are from FILE fields.
                       uesio.display:
                         - type: hasNoValue
                           value: ${uesio/core.fieldid}

--- a/libs/apps/uesio/appkit/bundle/views/file_attachments.yaml
+++ b/libs/apps/uesio/appkit/bundle/views/file_attachments.yaml
@@ -56,4 +56,7 @@ definition:
               reference:
                 components:
                   - uesio/appkit.tile_file:
+                      uesio.display:
+                        - type: hasNoValue
+                          value: ${uesio/core.fieldid}
                       allowDelete: $Param{allowDelete}

--- a/libs/apps/uesio/studio/bundle/componentpacks/main/src/components/recorddatamanager/recorddatamanager.tsx
+++ b/libs/apps/uesio/studio/bundle/componentpacks/main/src/components/recorddatamanager/recorddatamanager.tsx
@@ -8,6 +8,7 @@ const {
   OWNER_FIELD,
   UPDATED_AT_FIELD,
   UPDATED_BY_FIELD,
+  ATTACHMENTS_FIELD,
 } = collection
 
 type DataManagerDefinition = {
@@ -27,7 +28,22 @@ const getWireDefinition = (
   const createMode = !recordID
   return {
     collection,
-    fields: Object.fromEntries(collectionFields.map((f) => [f.getId(), {}])),
+    fields: Object.fromEntries(
+      collectionFields.map((f) => {
+        const fieldId = f.getId()
+        const subFields =
+          fieldId === ATTACHMENTS_FIELD
+            ? {
+                fields: {
+                  "uesio/core.mimetype": {},
+                  "uesio/core.contentlength": {},
+                  "uesio/core.path": {},
+                },
+              }
+            : {}
+        return [fieldId, subFields]
+      }),
+    ),
     conditions: createMode
       ? undefined
       : [
@@ -52,7 +68,10 @@ const getLoadableFields = (
   return (
     collectionMetadata
       .getFields()
-      .filter((f) => f.getType() !== "REFERENCEGROUP")
+      .filter(
+        (f) =>
+          f.getType() !== "REFERENCEGROUP" || f.getId() === ATTACHMENTS_FIELD,
+      )
       .filter((f) =>
         isNewRecord
           ? f.getCreateable()
@@ -69,6 +88,7 @@ const COMMON_FIELDS = [
   CREATED_BY_FIELD,
   UPDATED_AT_FIELD,
   UPDATED_BY_FIELD,
+  ATTACHMENTS_FIELD,
 ]
 
 const getGridFromFieldDefs = (fieldDefs: collection.Field[]) => ({
@@ -106,6 +126,12 @@ const getComponents = (
   if (!createMode) {
     grids.push({
       "uesio/appkit.section_audit_info": {},
+    })
+    grids.push({
+      "uesio/appkit.section_attachments": {
+        allowDelete: true,
+        allowCreate: true,
+      },
     })
   }
   return grids

--- a/libs/apps/uesio/studio/bundle/componentpacks/main/src/components/recorddatamanager/recorddatamanager.tsx
+++ b/libs/apps/uesio/studio/bundle/componentpacks/main/src/components/recorddatamanager/recorddatamanager.tsx
@@ -38,6 +38,7 @@ const getWireDefinition = (
                   "uesio/core.mimetype": {},
                   "uesio/core.contentlength": {},
                   "uesio/core.path": {},
+                  "uesio/core.fieldid": {},
                 },
               }
             : {}

--- a/libs/apps/uesio/studio/bundle/components/recorddatamanager.yaml
+++ b/libs/apps/uesio/studio/bundle/components/recorddatamanager.yaml
@@ -10,3 +10,4 @@ components:
   - uesio/io.grid
   - uesio/io.list
   - uesio/appkit.section_audit_info
+  - uesio/appkit.section_attachments

--- a/libs/apps/uesio/studio/bundle/views/recorddata.yaml
+++ b/libs/apps/uesio/studio/bundle/views/recorddata.yaml
@@ -42,70 +42,86 @@ definition:
                 itemName: $Param{collectionname}
                 itemNameSpace: $Param{namespace}
         content:
-          - uesio/io.list:
-              uesio.id: collectionsDeck
-              wire: collections
-              mode: READ
-              components:
-                - uesio/io.titlebar:
-                    uesio.variant: uesio/appkit.main
-                    title: ${uesio/studio.label}
-                    subtitle: $Param{recordid}
-                    actions:
-                      - uesio/io.group:
-                          components:
-                            - uesio/io.button:
-                                uesio.context:
-                                  workspace:
-                                    name: $Param{workspacename}
-                                    app: $Param{app}
-                                uesio.variant: uesio/io.primary
-                                uesio.display:
-                                  - type: wireHasChanges
-                                    wire: recordData
-                                text: $Label{uesio/io.save}
-                                hotkey: "meta+s"
-                                signals:
-                                  - signal: wire/SAVE
-                                    wires:
-                                      - recordData
-                            - uesio/io.button:
-                                uesio.variant: uesio/io.secondary
-                                text: $Label{uesio/io.cancel}
-                                uesio.display:
-                                  - type: wireHasChanges
-                                    wire: recordData
-                                signals:
-                                  - signal: wire/CANCEL
-                                    wire: recordData
-                            - uesio/io.button:
-                                uesio.variant: uesio/io.secondary
-                                text: Manage Data
-                                signals:
-                                  - signal: route/NAVIGATE
-                                    path: app/$Param{app}/workspace/$Param{workspacename}/data/$Param{namespace}/$Param{collectionname}
-                - uesio/io.box:
-                    uesio.context:
-                      workspace:
-                        name: $Param{workspacename}
-                        app: $Param{app}
-                    components:
-                      - uesio/studio.recorddatamanager:
-                          collectionId: $Param{namespace}.$Param{collectionname}
-                          wireId: recordData
-                          listId: recordDataList
-                          recordID: $Param{recordid}
-                - uesio/io.box:
-                    uesio.variant: uesio/appkit.section
+          - uesio/appkit.layout_detail_split:
+              main:
+                - uesio/io.list:
+                    uesio.id: collectionsDeck
+                    wire: collections
+                    mode: READ
                     components:
                       - uesio/io.titlebar:
-                          uesio.variant: uesio/appkit.sub
-                          title: Record Access Tokens
-                      - uesio/io.table:
-                          uesio.id: recordtokenvalueTable
                           uesio.variant: uesio/appkit.main
-                          wire: recordtokenvalue
-                          mode: READ
-                          columns:
-                            - field: uesio/studio.tokentype
-                            - field: uesio/studio.relatedrecordid
+                          title: ${uesio/studio.label}
+                          subtitle: $Param{recordid}
+                          actions:
+                            - uesio/io.group:
+                                components:
+                                  - uesio/io.button:
+                                      uesio.context:
+                                        workspace:
+                                          name: $Param{workspacename}
+                                          app: $Param{app}
+                                      uesio.variant: uesio/appkit.primary
+                                      uesio.display:
+                                        - type: wireHasChanges
+                                          wire: recordData
+                                      text: $Label{uesio/io.save}
+                                      hotkey: "meta+s"
+                                      signals:
+                                        - signal: wire/SAVE
+                                          wires:
+                                            - recordData
+                                  - uesio/io.button:
+                                      uesio.variant: uesio/appkit.secondary
+                                      text: $Label{uesio/io.cancel}
+                                      uesio.display:
+                                        - type: wireHasChanges
+                                          wire: recordData
+                                      signals:
+                                        - signal: wire/CANCEL
+                                          wire: recordData
+                                  - uesio/io.button:
+                                      uesio.variant: uesio/appkit.secondary
+                                      text: Back to ${uesio/studio.plurallabel} List
+                                      icon: arrow_back
+                                      uesio.display:
+                                        - type: wireHasNoChanges
+                                          wire: recordData
+                                      signals:
+                                        - signal: route/NAVIGATE
+                                          path: app/$Param{app}/workspace/$Param{workspacename}/data/$Param{namespace}/$Param{collectionname}
+                      - uesio/io.box:
+                          uesio.context:
+                            workspace:
+                              name: $Param{workspacename}
+                              app: $Param{app}
+                          components:
+                            - uesio/studio.recorddatamanager:
+                                collectionId: $Param{namespace}.$Param{collectionname}
+                                wireId: recordData
+                                listId: recordDataList
+                                recordID: $Param{recordid}
+                      - uesio/io.box:
+                          uesio.variant: uesio/appkit.section
+                          components:
+                            - uesio/io.titlebar:
+                                uesio.variant: uesio/appkit.sub
+                                title: Record Access Tokens
+                            - uesio/io.emptystate:
+                                title: No Record Access Tokens
+                                subtitle: Nobody has special access to this record.
+                                icon: token
+                                uesio.display:
+                                  - type: wireHasNoRecords
+                                    wire: recordtokenvalue
+                            - uesio/io.table:
+                                uesio.id: recordtokenvalueTable
+                                uesio.variant: uesio/appkit.main
+                                wire: recordtokenvalue
+                                mode: READ
+                                uesio.display:
+                                  - type: wireHasRecords
+                                    wire: recordtokenvalue
+                                columns:
+                                  - field: uesio/studio.tokentype
+                                  - field: uesio/studio.relatedrecordid

--- a/libs/ui/src/bands/collection/types.ts
+++ b/libs/ui/src/bands/collection/types.ts
@@ -25,6 +25,7 @@ const UPDATED_BY_FIELD = "uesio/core.updatedby"
 const CREATED_BY_FIELD = "uesio/core.createdby"
 const OWNER_FIELD = "uesio/core.owner"
 const COLLECTION_FIELD = "uesio/core.collection"
+const ATTACHMENTS_FIELD = "uesio/core.attachments"
 
 export {
   ID_FIELD,
@@ -35,4 +36,5 @@ export {
   CREATED_AT_FIELD,
   CREATED_BY_FIELD,
   COLLECTION_FIELD,
+  ATTACHMENTS_FIELD,
 }

--- a/libs/ui/src/collectionexports.ts
+++ b/libs/ui/src/collectionexports.ts
@@ -17,6 +17,7 @@ import {
   CREATED_AT_FIELD,
   CREATED_BY_FIELD,
   COLLECTION_FIELD,
+  ATTACHMENTS_FIELD,
 } from "./bands/collection/types"
 import { addBlankSelectOption } from "./bands/field/utils"
 import { SelectOption } from "./definition/selectlist"
@@ -42,4 +43,5 @@ export {
   CREATED_AT_FIELD,
   CREATED_BY_FIELD,
   COLLECTION_FIELD,
+  ATTACHMENTS_FIELD,
 }

--- a/libs/ui/src/metadata/types.ts
+++ b/libs/ui/src/metadata/types.ts
@@ -1,5 +1,6 @@
 // TODO: We need to load this from the server rather than hard-coding it here too!
 const METADATA = {
+  AGENT: "agents",
   AUTHSOURCE: "authsources",
   BOT: "bots",
   COLLECTION: "collections",


### PR DESCRIPTION
# What does this PR do?
<img width="1283" height="878" alt="Screenshot 2025-07-10 at 4 41 06 PM" src="https://github.com/user-attachments/assets/3f4dce7c-e143-4702-a7c1-812a99d4bfe4" />

1. Allows viewing, deleting, and creating attachments in the record data manager.
2. Improves the UX of the "Back to records list" button.
3. Adds and emptyState placeholder for record access tokens (instead of showing an empty table)

# Testing

1. Visit the record data manager. 
2. Create/Delete/View File attachments
3. Use and Enjoy the new Back button.

