### PR TITLE
fix: add missing system bundle names to client code

### DIFF
--- a/apps/platform/pkg/bundlestore/bundlestore.go
+++ b/apps/platform/pkg/bundlestore/bundlestore.go
@@ -17,6 +17,8 @@ import (
 
 var bundleStoreMap = map[string]BundleStore{}
 
+// NOTE - This should be kept in sync with the systemBundles list in platform.ts
+// https://github.com/ues-io/uesio/blob/693e6914ca3e2c58f4f57bdf368e062a39360244/libs/ui/src/platform/platform.ts#L188
 var systemBundles = map[string]bool{
 	"uesio/core":    true,
 	"uesio/studio":  true,

--- a/libs/ui/src/platform/platform.ts
+++ b/libs/ui/src/platform/platform.ts
@@ -186,10 +186,15 @@ export const getPrefix = (context: Context) => {
 }
 
 const systemBundles = [
+  // NOTE - This should be kept in sync with the systemBundles list in bundlestore.go
+  // https://github.com/ues-io/uesio/blob/693e6914ca3e2c58f4f57bdf368e062a39360244/apps/platform/pkg/bundlestore/bundlestore.go#L20
   "uesio/io",
   "uesio/builder",
   "uesio/studio",
   "uesio/core",
+	"uesio/sitekit",
+	"uesio/appkit",
+	"uesio/aikit",  
 ]
 
 export const isSystemBundle = (namespace: string) =>

--- a/libs/ui/src/platform/platform.ts
+++ b/libs/ui/src/platform/platform.ts
@@ -192,9 +192,9 @@ const systemBundles = [
   "uesio/builder",
   "uesio/studio",
   "uesio/core",
-	"uesio/sitekit",
-	"uesio/appkit",
-	"uesio/aikit",  
+  "uesio/sitekit",
+  "uesio/appkit",
+  "uesio/aikit",
 ]
 
 export const isSystemBundle = (namespace: string) =>


### PR DESCRIPTION
# What does this PR do?

Synchronize server and client system bundle lists for IsSystemBundle checks.

# Testing

ci & e2e will cover.
