### PR TITLE
Enforce minimum width for detail split

### DIFF
--- a/libs/apps/uesio/appkit/bundle/components/layout_detail_split.yaml
+++ b/libs/apps/uesio/appkit/bundle/components/layout_detail_split.yaml
@@ -37,6 +37,7 @@ definition:
                 - sm:p-10
                 - pt-0
                 - empty:hidden
+                - lg:min-w-[320px]
             components:
               - $Slot{left}
 title: Detail Split Component


### PR DESCRIPTION
# What does this PR do?

In the `uesio.appkit/layout_detail_split` component, this enforces a minimum width for the sidebar. Otherwise, there are cases where you get a really skinny sidebar. (Which is not what we want)


# Testing

In a layout using the `layoud_detail_split` component, put a text component with text "foo" into the "left" section of the layout. It should take up a minimum of 320px, not collapse to the width of "foo"