### PR TITLE
fix: server side redirect routes should merge route params

### DIFF
--- a/apps/platform-integration-tests/bundle/routes/redirect_test.yaml
+++ b/apps/platform-integration-tests/bundle/routes/redirect_test.yaml
@@ -1,4 +1,4 @@
 name: redirect_test
 type: redirect
 path: redirect_test
-redirect: https://www.ues.io
+redirect: https://www.ues.io?redirected_foo=$Param{foo}

--- a/apps/platform-integration-tests/hurl_specs/redirect_route_type.hurl
+++ b/apps/platform-integration-tests/hurl_specs/redirect_route_type.hurl
@@ -13,10 +13,10 @@ HTTP 200
 session_id: cookie "sessid"
 
 # Verify that previewing a redirect route executes a redirect
-GET {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/uesio/tests/dev/app/uesio/tests/redirect_test
+GET {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/uesio/tests/dev/app/uesio/tests/redirect_test?foo=bar
 Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7
 Cookie: sessid={{session_id}}
 HTTP 302
 
 [Asserts]
-header "Location" == "https://www.ues.io"
+header "Location" == "https://www.ues.io?redirected_foo=bar"

--- a/apps/platform/pkg/controller/route.go
+++ b/apps/platform/pkg/controller/route.go
@@ -352,7 +352,8 @@ func ServeRouteInternal(w http.ResponseWriter, r *http.Request, session *sess.Se
 		// Handle redirect routes
 		middleware.SetNoCache(w)
 		mergedRouteRedirect, err := MergeRouteData(route.Redirect, &merge.ServerMergeData{
-			Session: session,
+			Session:     session,
+			ParamValues: route.Params,
 		})
 		if err != nil {
 			HandleErrorRoute(w, r, session, path, route.Namespace, err, true)


### PR DESCRIPTION
# What does this PR do?

Ensures route params are available for server side redirected routes.

# Testing

Updated test case to include coverage for route params.
