### PR TITLE
chore: eliminate profile check for legacy cli login methods

### DIFF
--- a/apps/cli/pkg/auth/login.go
+++ b/apps/cli/pkg/auth/login.go
@@ -291,7 +291,7 @@ func Login() (*UserMergeData, error) {
 		return nil, err
 	}
 
-	err = config.SetSessionID(token.SessionId)
+	err = config.SetSessionID(token.SessionID)
 	if err != nil {
 		return nil, err
 	}

--- a/apps/cli/pkg/auth/login.go
+++ b/apps/cli/pkg/auth/login.go
@@ -275,12 +275,9 @@ func getLoginHandler() (*LoginMethodHandler, error) {
 func Login() (*UserMergeData, error) {
 
 	// First check to see if you're already logged in
-	currentUser, err := Check()
-	if err != nil {
+	if currentUser, err := Check(); err != nil {
 		return nil, err
-	}
-
-	if currentUser != nil && (currentUser.Profile == "uesio/studio.standard" || currentUser.Profile == "uesio/studio.admin") {
+	} else if currentUser != nil {
 		return currentUser, nil
 	}
 
@@ -294,7 +291,7 @@ func Login() (*UserMergeData, error) {
 		return nil, err
 	}
 
-	err = config.SetSessionID(token.SessionID)
+	err = config.SetSessionID(token.SessionId)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# What does this PR do?

Eliminates profile check during login in legacy CLI login methods (platform & mock).

This unifies behavior between all supported CLI login process (browser, platform, mock).  In short, either the user logs in successfully or doesn't but its irrespective of their "permissions" to perform certain actions.  If they are unable to perform a CLI command, they will receive the corresponding permission failure messages at that time.

# Testing

Manually tested and confirmed.
