### PR TITLE
chore: refactor login response types in CLI

### DIFF
--- a/apps/cli/pkg/auth/login.go
+++ b/apps/cli/pkg/auth/login.go
@@ -291,7 +291,7 @@ func Login() (*UserMergeData, error) {
 		return nil, err
 	}
 
-	err = config.SetSessionID(token.SessionID)
+	err = config.SetSessionID(token.SessionId)
 	if err != nil {
 		return nil, err
 	}

--- a/apps/cli/pkg/auth/loginresponse.go
+++ b/apps/cli/pkg/auth/loginresponse.go
@@ -1,18 +1,14 @@
 package auth
 
-// This mirrors preload.UserMergeData but only contains the properties needed for CLI
-type UserMergeData struct {
-	FirstName string `json:"firstname"`
-	LastName  string `json:"lastname"`
-	Profile   string `json:"profile"`
-	Site      string `json:"site"`
-	ID        string `json:"id"`
-	Username  string `json:"username"`
-	Language  string `json:"language"`
-}
+import "github.com/thecloudmasters/uesio/pkg/preload"
 
-// This mirrors preload.LoginResponse but only contains the properties needed for CLI
-type LoginResponse struct {
-	SessionID string         `json:"sessionId"`
-	User      *UserMergeData `json:"user"`
-}
+// TODO: All of the login paths return the full preload.LoginResponse & preload.UserMergeData. The previous version
+// of the CLI created its own LoginResponse & UserMergeData type that only contained the properties needed for the CLI.
+// However, this creates risk and additional maintenance overhead where the only tiny benefit is a little bit of
+// processing during unmarshalling since the server is sending the full LoginResponse/UserMergeData payload anyway.
+// Since we do not need a lot of the properties on LoginResponse/UserMergeData in the CLI, if/when the server side
+// methodsare refactored to have "base" info and "full" info and only use "full" where needed, this can be adjusted
+// to use the "base" info. For now, eliminating the maintenance/risks and just aliasing the preload types
+// that are actually being returned.
+type UserMergeData = preload.UserMergeData
+type LoginResponse = preload.LoginResponse

--- a/apps/platform/pkg/preload/mergetypes.go
+++ b/apps/platform/pkg/preload/mergetypes.go
@@ -10,7 +10,9 @@ import (
 	"github.com/thecloudmasters/uesio/pkg/sess"
 )
 
-// NOTE: There is a mirror of this in CLI auth.LoginResponse containing a subset of these properties that needs to be kept in sync.
+// TODO: The CLI uses a subset of the properties in these types but we currently return the full type payload. This
+// should be refactored to have a "base" and "full" version of these types and only use the "full" version where needed to
+// improve performance, reduce payload size and not expose information that isn't needed to the respective client.
 type LoginResponse struct {
 	User                   *UserMergeData `json:"user"`
 	RedirectPath           string         `json:"redirectPath,omitempty"`
@@ -37,7 +39,9 @@ type UserPictureMergeData struct {
 	UpdatedAt int64  `json:"updatedat"`
 }
 
-// NOTE: There is a mirror of this in CLI auth.UserMergeData containing a subset of these properties that needs to be kept in sync.
+// TODO: The CLI uses a subset of the properties in these types but we currently return the full type payload. This
+// should be refactored to have a "base" and "full" version of these types and only use the "full" version where needed to
+// improve performance, reduce payload size and not expose information that isn't needed to the respective client.
 type UserMergeData struct {
 	FirstName    string                `json:"firstname"`
 	LastName     string                `json:"lastname"`


### PR DESCRIPTION
# What does this PR do?

Eliminates the "custom" CLI types for login response since the full type was being sent to CLI anyway. See comments for details and TODOs.

In short, this eliminates the maintenance overhead which introduces uncessary risk when changes are made and provided nearly no benefit since the data was coming across the wire anyway.

# Testing

ci & e2e will cover.
