### PR TITLE
chore: consistent use of sessionID in go code

### DIFF
--- a/apps/cli/pkg/auth/login.go
+++ b/apps/cli/pkg/auth/login.go
@@ -291,7 +291,7 @@ func Login() (*UserMergeData, error) {
 		return nil, err
 	}
 
-	err = config.SetSessionID(token.SessionId)
+	err = config.SetSessionID(token.SessionID)
 	if err != nil {
 		return nil, err
 	}

--- a/apps/cli/pkg/auth/logout.go
+++ b/apps/cli/pkg/auth/logout.go
@@ -9,15 +9,15 @@ import (
 
 func Logout() (*UserMergeData, error) {
 
-	sessionId, err := config.GetSessionID()
+	sessionID, err := config.GetSessionID()
 	if err != nil {
 		return nil, err
 	}
 	// If there is no current session id, there's no need to make a logout call
-	if sessionId == "" {
+	if sessionID == "" {
 		return nil, nil
 	}
-	resp, err := call.Post("site/auth/logout", nil, sessionId, nil)
+	resp, err := call.Post("site/auth/logout", nil, sessionID, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/apps/cli/pkg/call/call.go
+++ b/apps/cli/pkg/call/call.go
@@ -18,7 +18,7 @@ import (
 type RequestSpec struct {
 	Method            string
 	Url               string
-	SessionId         string
+	SessionID         string
 	AppContext        *context.AppContext
 	Body              io.Reader
 	AdditionalHeaders map[string]string
@@ -44,8 +44,8 @@ func Request(r *RequestSpec) (*http.Response, error) {
 		return nil, err
 	}
 
-	if r.SessionId != "" {
-		req.Header.Set("Cookie", "sessid="+r.SessionId)
+	if r.SessionID != "" {
+		req.Header.Set("Cookie", "sessid="+r.SessionID)
 	}
 	if r.AppContext != nil {
 		r.AppContext.AddHeadersToRequest(req)
@@ -105,11 +105,11 @@ func RequestResult[K any](req *RequestSpec, read ResultReader[K]) (K, error) {
 	return result, nil
 }
 
-func GetJSON(url, sessionId string, response any) error {
+func GetJSON(url, sessionID string, response any) error {
 	_, err := RequestResult(&RequestSpec{
 		Method:    http.MethodGet,
 		Url:       url,
-		SessionId: sessionId,
+		SessionID: sessionID,
 	}, JSONResultReader(response))
 	if err != nil {
 		return err
@@ -117,11 +117,11 @@ func GetJSON(url, sessionId string, response any) error {
 	return nil
 }
 
-func Delete(url, sessionId string, appContext *context.AppContext) (int, error) {
+func Delete(url, sessionID string, appContext *context.AppContext) (int, error) {
 	resp, err := Request(&RequestSpec{
 		Method:     http.MethodDelete,
 		Url:        url,
-		SessionId:  sessionId,
+		SessionID:  sessionID,
 		AppContext: appContext,
 	})
 	if err != nil {
@@ -131,22 +131,22 @@ func Delete(url, sessionId string, appContext *context.AppContext) (int, error) 
 	return resp.StatusCode, nil
 }
 
-func Post(url string, payload io.Reader, sessionId string, appContext *context.AppContext) (*http.Response, error) {
+func Post(url string, payload io.Reader, sessionID string, appContext *context.AppContext) (*http.Response, error) {
 	return Request(&RequestSpec{
 		Method:     http.MethodPost,
 		Url:        url,
 		Body:       payload,
-		SessionId:  sessionId,
+		SessionID:  sessionID,
 		AppContext: appContext,
 	})
 }
 
-func PostForm(url string, payload io.Reader, sessionId string, appContext *context.AppContext) (*http.Response, error) {
+func PostForm(url string, payload io.Reader, sessionID string, appContext *context.AppContext) (*http.Response, error) {
 	return Request(&RequestSpec{
 		Method:     http.MethodPost,
 		Url:        url,
 		Body:       payload,
-		SessionId:  sessionId,
+		SessionID:  sessionID,
 		AppContext: appContext,
 		AdditionalHeaders: map[string]string{
 			"Content-Type": "application/x-www-form-urlencoded",
@@ -154,7 +154,7 @@ func PostForm(url string, payload io.Reader, sessionId string, appContext *conte
 	})
 }
 
-func PostJSON(url, sessionId string, request, response any, appContext *context.AppContext) error {
+func PostJSON(url, sessionID string, request, response any, appContext *context.AppContext) error {
 
 	payloadBytes := &bytes.Buffer{}
 
@@ -166,7 +166,7 @@ func PostJSON(url, sessionId string, request, response any, appContext *context.
 		Method:     http.MethodPost,
 		Url:        url,
 		Body:       payloadBytes,
-		SessionId:  sessionId,
+		SessionID:  sessionID,
 		AppContext: appContext,
 	}, JSONResultReader(response))
 
@@ -176,12 +176,12 @@ func PostJSON(url, sessionId string, request, response any, appContext *context.
 	return nil
 }
 
-func PostBytes(url string, payload io.Reader, sessionId string, appContext *context.AppContext) ([]byte, error) {
+func PostBytes(url string, payload io.Reader, sessionID string, appContext *context.AppContext) ([]byte, error) {
 	return RequestResult(&RequestSpec{
 		Method:     http.MethodPost,
 		Url:        url,
 		Body:       payload,
-		SessionId:  sessionId,
+		SessionID:  sessionID,
 		AppContext: appContext,
 	}, ByteResultReader)
 }

--- a/apps/cli/pkg/cmd/generate.go
+++ b/apps/cli/pkg/cmd/generate.go
@@ -50,9 +50,9 @@ func promptForGenerator() string {
 		// attempt to log in
 		userMergeData, err = auth.Login()
 	}
-	var sessionId string
+	var sessionID string
 	if err == nil && userMergeData != nil {
-		sessionId, err = config.GetSessionID()
+		sessionID, err = config.GetSessionID()
 	}
 	if err != nil {
 		return ""
@@ -67,7 +67,7 @@ func promptForGenerator() string {
 		MetadataType: "BOT",
 		Grouping:     "GENERATOR",
 		Required:     true,
-	}, "uesio/core", "0.0.1", sessionId, answers); err != nil {
+	}, "uesio/core", "0.0.1", sessionID, answers); err != nil {
 		return ""
 	}
 	if generatorNameString, isString := answers["generator"].(string); isString {

--- a/apps/cli/pkg/command/app/clone.go
+++ b/apps/cli/pkg/command/app/clone.go
@@ -64,12 +64,12 @@ func AppClone(targetDir string) error {
 		return err
 	}
 
-	sessionId, err := config.GetSessionID()
+	sessionID, err := config.GetSessionID()
 	if err != nil {
 		return err
 	}
 
-	app, err := askUserToSelectApp(sessionId)
+	app, err := askUserToSelectApp(sessionID)
 	if err != nil {
 		return err
 	}
@@ -93,7 +93,7 @@ func AppClone(targetDir string) error {
 	if err != nil {
 		return err
 	}
-	resp, err := call.PostBytes(generateURL, payloadBytes, sessionId, nil)
+	resp, err := call.PostBytes(generateURL, payloadBytes, sessionID, nil)
 	if err != nil {
 		return err
 	}

--- a/apps/cli/pkg/command/app/delete.go
+++ b/apps/cli/pkg/command/app/delete.go
@@ -15,13 +15,13 @@ func Delete(appFullName string) error {
 		return err
 	}
 
-	sessionId, err := config.GetSessionID()
+	sessionID, err := config.GetSessionID()
 	if err != nil {
 		return err
 	}
 
 	if appFullName == "" {
-		app, err := askUserToSelectApp(sessionId)
+		app, err := askUserToSelectApp(sessionID)
 		if err != nil {
 			return err
 		}

--- a/apps/cli/pkg/command/bundle/create.go
+++ b/apps/cli/pkg/command/bundle/create.go
@@ -27,7 +27,7 @@ func CreateBundle(releaseType, majorVersion, minorVersion, patchVersion, bundleD
 		return err
 	}
 
-	sessionId, err := config.GetSessionID()
+	sessionID, err := config.GetSessionID()
 	if err != nil {
 		return err
 	}
@@ -64,7 +64,7 @@ func CreateBundle(releaseType, majorVersion, minorVersion, patchVersion, bundleD
 
 	botResponse := &CallBotResponse{}
 
-	err = call.PostJSON(createBundleURL, sessionId, botInputs, botResponse, nil)
+	err = call.PostJSON(createBundleURL, sessionID, botInputs, botResponse, nil)
 	if err != nil {
 		return err
 	}

--- a/apps/cli/pkg/command/generate.go
+++ b/apps/cli/pkg/command/generate.go
@@ -50,7 +50,7 @@ func Generate(key string) error {
 		return err
 	}
 
-	sessionId, err := config.GetSessionID()
+	sessionID, err := config.GetSessionID()
 	if err != nil {
 		return err
 	}
@@ -58,11 +58,11 @@ func Generate(key string) error {
 	paramsURL := fmt.Sprintf("version/%s/%s/bots/params/generator/%s/%s", namespace, version, namespace, name)
 
 	botParams := &meta.BotParamsResponse{}
-	if err = call.GetJSON(paramsURL, sessionId, botParams); err != nil {
+	if err = call.GetJSON(paramsURL, sessionID, botParams); err != nil {
 		return fmt.Errorf("unable to retrieve metadata for generator '%s': %w", key, err)
 	}
 
-	answers, err := param.AskMany(botParams, app, version, sessionId)
+	answers, err := param.AskMany(botParams, app, version, sessionID)
 	if err != nil {
 		return err
 	}
@@ -77,7 +77,7 @@ func Generate(key string) error {
 	if resp, err := call.RequestResult(&call.RequestSpec{
 		Method:     http.MethodPost,
 		Url:        generateURL,
-		SessionId:  sessionId,
+		SessionID:  sessionID,
 		AppContext: appContext,
 		Body:       payloadBytes,
 		AdditionalHeaders: map[string]string{
@@ -91,7 +91,7 @@ func Generate(key string) error {
 		}
 	}
 	fmt.Println("Generator completed successfully. Rebuilding type definitions for app...")
-	if err = GenerateAppTypeDefinitions(app, workspace, sessionId, appContext); err != nil {
+	if err = GenerateAppTypeDefinitions(app, workspace, sessionID, appContext); err != nil {
 		return err
 	}
 	fmt.Println("Type definitions successfully updated.")
@@ -100,12 +100,12 @@ func Generate(key string) error {
 
 // GenerateAppTypeDefinitions refetches app-specific type definitions from the server,
 // and writes them to disk in the "generated" folder
-func GenerateAppTypeDefinitions(app, workspace, sessionId string, appContext *context.AppContext) error {
+func GenerateAppTypeDefinitions(app, workspace, sessionID string, appContext *context.AppContext) error {
 	typeDefinitionsUrl := fmt.Sprintf("workspace/%s/%s/retrieve/types", app, workspace)
 	resp, err := call.Request(&call.RequestSpec{
 		Method:     http.MethodGet,
 		Url:        typeDefinitionsUrl,
-		SessionId:  sessionId,
+		SessionID:  sessionID,
 		AppContext: appContext,
 	})
 	if err != nil {

--- a/apps/cli/pkg/command/upsert.go
+++ b/apps/cli/pkg/command/upsert.go
@@ -27,11 +27,11 @@ func getUrlPrefix(tenantType, app, tenant string) string {
 	return fmt.Sprintf("%s/%s/%s", tenantType, app, tenant)
 }
 
-func createJob(prefix, sessionId string, spec *meta.JobSpecRequest) (*bulk.JobResponse, error) {
+func createJob(prefix, sessionID string, spec *meta.JobSpecRequest) (*bulk.JobResponse, error) {
 	url := fmt.Sprintf("%s/bulk/job", prefix)
 	jobResponse := &bulk.JobResponse{}
 
-	err := call.PostJSON(url, sessionId, spec, jobResponse, nil)
+	err := call.PostJSON(url, sessionID, spec, jobResponse, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -50,7 +50,7 @@ func getImportPayload(jobType, dataFile string) (io.Reader, error) {
 	return nil, fmt.Errorf("invalid job type: %s", jobType)
 }
 
-func runBatch(prefix, sessionId, dataFile, jobID string, spec *meta.JobSpecRequest) (*bulk.BatchResponse, error) {
+func runBatch(prefix, sessionID, dataFile, jobID string, spec *meta.JobSpecRequest) (*bulk.BatchResponse, error) {
 	payload, err := getImportPayload(spec.JobType, dataFile)
 	if err != nil {
 		return nil, err
@@ -60,7 +60,7 @@ func runBatch(prefix, sessionId, dataFile, jobID string, spec *meta.JobSpecReque
 
 	url := fmt.Sprintf("%s/bulk/job/%s/batch", prefix, jobID)
 
-	resp, err := call.Post(url, payload, sessionId, nil)
+	resp, err := call.Post(url, payload, sessionID, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/apps/cli/pkg/command/workspace/retrieve.go
+++ b/apps/cli/pkg/command/workspace/retrieve.go
@@ -49,12 +49,12 @@ func Retrieve(options *RetrieveOptions) error {
 	if options.OnlyTypes {
 		appContext := context.NewWorkspaceContext(appName, workspace)
 
-		sessionId, err := config.GetSessionID()
+		sessionID, err := config.GetSessionID()
 		if err != nil {
 			return err
 		}
 
-		if err = command.GenerateAppTypeDefinitions(appName, workspace, sessionId, appContext); err != nil {
+		if err = command.GenerateAppTypeDefinitions(appName, workspace, sessionID, appContext); err != nil {
 			return err
 		}
 
@@ -86,7 +86,7 @@ func RetrieveBundleForAppWorkspace(appName, workspaceName, outputDir string) err
 	// TODO: Send hashes of all local files so we aren't deleting/retrieving unchanged files every time...
 	url := fmt.Sprintf("workspace/%s/%s/metadata/retrieve", appName, workspaceName)
 
-	sessionId, err := config.GetSessionID()
+	sessionID, err := config.GetSessionID()
 	if err != nil {
 		return err
 	}
@@ -94,7 +94,7 @@ func RetrieveBundleForAppWorkspace(appName, workspaceName, outputDir string) err
 	resp, err := call.RequestResult(&call.RequestSpec{
 		Method:     http.MethodGet,
 		Url:        url,
-		SessionId:  sessionId,
+		SessionID:  sessionID,
 		AppContext: context.NewWorkspaceContext(appName, workspaceName),
 	}, call.ByteResultReader)
 	if err != nil {

--- a/apps/cli/pkg/command/workspace/truncate.go
+++ b/apps/cli/pkg/command/workspace/truncate.go
@@ -32,14 +32,14 @@ func Truncate() error {
 		return errors.New("no active workspace is set -- use \"uesio work\" to set one")
 	}
 
-	sessionId, err := config.GetSessionID()
+	sessionID, err := config.GetSessionID()
 	if err != nil {
 		return err
 	}
 
 	url := fmt.Sprintf("workspace/%s/%s/data/truncate", app, workspace)
 
-	resp, err := call.Post(url, nil, sessionId, context.NewWorkspaceContext(app, workspace))
+	resp, err := call.Post(url, nil, sessionID, context.NewWorkspaceContext(app, workspace))
 	if err != nil {
 		return err
 	}

--- a/apps/cli/pkg/config/session.go
+++ b/apps/cli/pkg/config/session.go
@@ -1,15 +1,15 @@
 package config
 
-const sessionIdProp = "sessionId"
+const sessionIDProp = "sessionId"
 
 func GetSessionID() (string, error) {
-	return GetConfigValue(sessionIdProp)
+	return GetConfigValue(sessionIDProp)
 }
 
 func SetSessionID(id string) error {
-	return SetConfigValue(sessionIdProp, id)
+	return SetConfigValue(sessionIDProp, id)
 }
 
 func DeleteSessionID() error {
-	return DeleteConfigValue(sessionIdProp)
+	return DeleteConfigValue(sessionIDProp)
 }

--- a/apps/cli/pkg/wire/save.go
+++ b/apps/cli/pkg/wire/save.go
@@ -44,12 +44,12 @@ func Insert(collectionName string, changes []map[string]interface{}, appContext 
 }
 
 func DeleteOne(collectionName, idField, idValue string, appContext *context.AppContext) error {
-	sessionId, err := config.GetSessionID()
+	sessionID, err := config.GetSessionID()
 	if err != nil {
 		return err
 	}
 	deleteUri := fmt.Sprintf("site/api/v1/collection/%s?%s=eq.%s", strings.ReplaceAll(collectionName, ".", "/"), idField, idValue)
-	statusCode, err := call.Delete(deleteUri, sessionId, appContext)
+	statusCode, err := call.Delete(deleteUri, sessionID, appContext)
 	if err != nil {
 		return err
 	}
@@ -86,14 +86,14 @@ func Save(collectionName string, changes []map[string]interface{}, saveOptions S
 		},
 	}
 
-	sessionId, err := config.GetSessionID()
+	sessionID, err := config.GetSessionID()
 	if err != nil {
 		return nil, err
 	}
 
 	saveResponse := &SaveReqBatch{}
 
-	err = call.PostJSON("site/wires/save", sessionId, payload, saveResponse, appContext)
+	err = call.PostJSON("site/wires/save", sessionID, payload, saveResponse, appContext)
 	if err != nil {
 		return nil, err
 	}

--- a/apps/platform/pkg/auth/login.go
+++ b/apps/platform/pkg/auth/login.go
@@ -31,7 +31,7 @@ func GetResetPasswordRedirectResponse(w http.ResponseWriter, r *http.Request, us
 	return &preload.LoginResponse{
 		User:         preload.GetUserMergeData(session),
 		RedirectPath: redirectPath,
-		SessionId:    session.GetSessionId(),
+		SessionID:    session.GetSessionID(),
 	}, nil
 }
 
@@ -81,7 +81,7 @@ func GetLoginRedirectResponse(w http.ResponseWriter, r *http.Request, user *meta
 		RedirectRouteNamespace: redirectNamespace,
 		RedirectRouteName:      redirectRoute,
 		RedirectPath:           redirectPath,
-		SessionId:              session.GetSessionId(),
+		SessionID:              session.GetSessionID(),
 	}, nil
 }
 

--- a/apps/platform/pkg/bot/jsdialect/sessionapi.go
+++ b/apps/platform/pkg/bot/jsdialect/sessionapi.go
@@ -83,8 +83,8 @@ func NewSessionAPI(session *sess.Session) *SessionAPI {
 	}
 }
 
-func (s *SessionAPI) GetId() string {
-	return s.session.GetSessionId()
+func (s *SessionAPI) GetID() string {
+	return s.session.GetSessionID()
 }
 
 func (s *SessionAPI) InWorkspaceContext() bool {

--- a/apps/platform/pkg/bot/jsdialect/sessionapi.go
+++ b/apps/platform/pkg/bot/jsdialect/sessionapi.go
@@ -83,7 +83,9 @@ func NewSessionAPI(session *sess.Session) *SessionAPI {
 	}
 }
 
-func (s *SessionAPI) GetID() string {
+// NOTE: Intentionally lowercase Id since called from JS dialects
+// TODO: See if goja has a way to map this to getId from GetID so we can change the name and be consistent
+func (s *SessionAPI) GetId() string {
 	return s.session.GetSessionID()
 }
 

--- a/apps/platform/pkg/preload/mergetypes.go
+++ b/apps/platform/pkg/preload/mergetypes.go
@@ -18,7 +18,7 @@ type LoginResponse struct {
 	RedirectPath           string         `json:"redirectPath,omitempty"`
 	RedirectRouteName      string         `json:"redirectRouteName,omitempty"`
 	RedirectRouteNamespace string         `json:"redirectRouteNamespace,omitempty"`
-	SessionId              string         `json:"sessionId"`
+	SessionID              string         `json:"sessionId"`
 }
 
 type RouteMergeData struct {

--- a/apps/platform/pkg/sess/session.go
+++ b/apps/platform/pkg/sess/session.go
@@ -525,6 +525,6 @@ func (s *Session) GetContextSite() *meta.Site {
 	return s.GetSite()
 }
 
-func (s *Session) GetSessionId() string {
+func (s *Session) GetSessionID() string {
 	return s.ID
 }


### PR DESCRIPTION
# What does this PR do?

Standardize naming of `sessionID` in go (eliminate mix use of `sessionId` & `sessionID`).

# Testing

ci & e2e will cover.
