### PR TITLE
fix: eliminate auth middleware redirect to login logic

### DIFF
--- a/apps/platform/pkg/middleware/authenticate.go
+++ b/apps/platform/pkg/middleware/authenticate.go
@@ -65,17 +65,50 @@ func Authenticate(next http.Handler) http.Handler {
 
 		user, err := auth.GetUserFromBrowserSession(browserSession, site)
 		if err != nil {
+			// TODO: We failed to get the user but this could be for any number of reasons, for example
+			// a database or redis issue.  Should we permanently remove the session here? If we don't
+			// we could run in to infite loop so we must do something but.....possibly keep track of
+			// attempts?  We could use Attrs on the session but we haven't implemented it 100% correctly
+			// so changes to Attrs don't write back to the backing store currently.
+			// NOTE: There are several reasons we could fail to GetUserFromBrowserSession, some are due to invalid
+			// cookies which we can't recover from and some infra/system related (e.g., db failure) that we could
+			// recover from. The approach below mirrors the previous approach where we treat any error as unrecoverable,
+			// remove the session we had and create a new public one.  The only difference from prior approach is that
+			// we no longer redirect to login and instead pass through middleware as a public session. We can't redirect
+			// in middleware for a number of reasons (e.g., we don't know if the route is public/priviate, we don't know
+			// if there's even a login route, etc.).
+			// TODO: This can be improved to treat different types of errors from GetUserFromBrowserSession differently
+			// but we need to be able to break a potential infinite loop. To do that, we need to actually "save" the current
+			// session in the store so that we can track a counter or something. For now, leaving prior approach but this
+			// should be revisited once "saving" a session is implemented (which may correspond with refactoring middleware,
+			// auth and session management as well).
 			if browserSession != nil {
 				session.Remove(browserSession, w)
+				browserSession = nil
 			}
-			publicSession, err := auth.GetPublicSession(site, nil)
+			user, err = auth.GetPublicUser(site, nil)
 			if err != nil {
-				HandleError(ctx, w, fmt.Errorf("failed to create public session: %w", err))
+				HandleError(ctx, w, fmt.Errorf("failed to retrieve public user: %w", err))
 				return
 			}
+		}
 
-			auth.RedirectToLoginRoute(w, r, publicSession, auth.NotFound)
-			return
+		// NOTE: This is just a sanity check as the session stores should be expiring sessions based on timeout configured, however we do this for two reasons:
+		// 1. the filestore does not expire/delete file based sessions currently
+		// 2. Defensive check just in case
+		// Also note that the current implementation does update the session when it is accessed so the timeout set upon creation is an absolute timeout and not
+		// a rolling timeout.
+		// TODO:
+		// 1. Implement a background cleaner for the filestore that will remove expired sessions
+		// 2. Implement a rolling timeout for the session stores so that the timeout is based on accessed and not created time
+		if browserSession != nil && sess.IsExpired(browserSession) {
+			session.Remove(browserSession, w)
+			browserSession = nil
+			user, err = auth.GetPublicUser(site, nil)
+			if err != nil {
+				HandleError(ctx, w, fmt.Errorf("failed to retrieve public user: %w", err))
+				return
+			}
 		}
 
 		if browserSession == nil {
@@ -85,13 +118,6 @@ func Authenticate(next http.Handler) http.Handler {
 		s, err := auth.GetSessionFromUser(browserSession.ID(), user, site)
 		if err != nil {
 			HandleError(ctx, w, fmt.Errorf("failed to create session: %w", err))
-			return
-		}
-		// If the session is expired, and it's not for a public user
-		if s != nil && sess.IsExpired(browserSession) && !s.IsPublicUser() {
-			session.Remove(browserSession, w)
-			setSession(ctx, s)
-			auth.RedirectToLoginRoute(w, r.WithContext(ctx), s, auth.Expired)
 			return
 		}
 


### PR DESCRIPTION
# What does this PR do?

Eliminates "redirect to login logic" in authentication middleware in the two places that it existed.

This PR is the next of several PRs focused on addressing some underlying issues with middleware, authentication and session management.  This PR is the most substantial of the changes being made and is focused on one of the core underlying issues with the way middleware was working previously.

In short, redirecting to login in middleware is prone to several different issues:

1. We don't know if the route being requested is public or protected as that's the responsibility of the controller - the middlware should simply be establishing a valid session for the request
2. We don't know if the site even has a login page - while we could determine this in middleware, issue 1 still applies

The net effect of the previous approach resulted in situations such as the following:

1) When calling `/auth/check` route, if you had a sessionid but your session had expired, you would be redirected to login instead of actually returning a "User" (could be guest or a real user) from check which is the purpose of check
2) When calling `/auth/logout` same thing would happen

The adjusted logic in this PR modifies the behavior in two situations where a redirect would happen to remove the existing session, establish a session for PublicUser and continue.  This behavior is no different than if the user visited the site for the first time and would get a PublicUser session that would simply pass through to the controller.

NOTE: This behavior is still less than optimal as we could be much more intelligent about detecting different types of errors that could result in not being able to hydrate a session for one that is actually valid.  However, those situations are rare and so that effort will be left for another day.  Right now, we need not make assumptions in middleware about login and let the controllers be responsible (which they already are for public sessions anyway).


# Testing

Tested locally with force expirations, failures, etc. and all works as expected. ci & e2e will cover basics.
