### PR TITLE
chore: all "uesio" sessions should have an id

### DIFF
--- a/apps/platform/pkg/auth/session.go
+++ b/apps/platform/pkg/auth/session.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/gofrs/uuid/v5"
 	"github.com/icza/session"
 	"golang.org/x/crypto/bcrypt"
 
@@ -48,6 +49,21 @@ func GetUserFromBrowserSession(browserSession session.Session, site *meta.Site) 
 		return nil, fmt.Errorf("sites mismatch for user: %s", browserSessionUser)
 	}
 	return GetCachedUserByID(browserSessionUser, site)
+}
+
+func CreateSessionFromUser(user *meta.User, site *meta.Site) (*sess.Session, error) {
+	// We are creating a Uesio Session (sess.Session) here, not a browser session (session.Session).
+	// but we still want to ensure we have a SessionID so we use a UUID to differentiate the session
+	// ID format from one that was created from a browser session. We use v4 for randomness since
+	// these don't need to be sorted or stored.
+	// TODO: Refactor code to be more explicit about a "UesioSession" vs. a "BrowserSession" since
+	// variables and function names all use "Session" which leads to a lot of confusion unless you
+	// pay vary close attention to the types.
+	sessionID, err := uuid.NewV4()
+	if err != nil {
+		return nil, err
+	}
+	return GetSessionFromUser(sessionID.String(), user, site)
 }
 
 func GetSessionFromUser(sessionID string, user *meta.User, site *meta.Site) (*sess.Session, error) {

--- a/apps/platform/pkg/auth/site.go
+++ b/apps/platform/pkg/auth/site.go
@@ -62,7 +62,7 @@ func GetPublicSession(site *meta.Site, connection wire.Connection) (*sess.Sessio
 	if err != nil {
 		return nil, err
 	}
-	return GetSessionFromUser("", publicUser, site)
+	return CreateSessionFromUser(publicUser, site)
 }
 
 func GetSystemUser(site *meta.Site, connection wire.Connection) (*meta.User, error) {

--- a/apps/platform/pkg/middleware/authenticate.go
+++ b/apps/platform/pkg/middleware/authenticate.go
@@ -50,7 +50,7 @@ func Authenticate(next http.Handler) http.Handler {
 				return
 			}
 
-			s, err := auth.GetSessionFromUser("", user, site)
+			s, err := auth.CreateSessionFromUser(user, site)
 			if err != nil {
 				HandleError(ctx, w, fmt.Errorf("failed to create session: %w", err))
 				return


### PR DESCRIPTION
# What does this PR do?

Ensures that everywhere we "create" a Uesio session, regardless of whether its for a browser based session or a "system" type of session, the session has an ID.

Previously, these types of sessions would not have an ID (it would be empty string) so anything downstream which may be expecting an ID wouldn't have one.  This could lead to several issues including limited traceability, output, etc.

NOTE: This does not address the underlying concern that a "sess.Session" (aka. a Uesio session) and a session.Session (aka. a Browser session) are both considers a "Session" currently in the code but it could be one or the other type of session and a uesio session may or may not have a browser session backing it.  The code should be refactored in to more clear typings so that its esaier to discern, when you see a variable "session" what "type" of session it is.

# Testing

ci & e2e will cover.
