### PR TITLE
chore: give rep profile perms to home & login routes & views

### DIFF
--- a/apps/platform-integration-tests/bundle/permissionsets/rep.yaml
+++ b/apps/platform-integration-tests/bundle/permissionsets/rep.yaml
@@ -1,6 +1,8 @@
 name: rep
 named: {}
-views: {}
+views:
+  uesio/tests.customhome: true
+  uesio/tests.customlogin: true
 collections:
   uesio/core.user:
     read: true
@@ -50,7 +52,9 @@ collections:
     modifyall: true
     viewall: false
     fields: {}
-routes: {}
+routes:
+  uesio/tests.customhome: true
+  uesio/tests.customlogin: true
 files: {}
 bots: {}
 integrationActions: {}


### PR DESCRIPTION
# What does this PR do?

Missed assigning home/login views & routes to "rep" permissionset in #5055 

# Testing

ci & e2e will cover.
