### PR TITLE
fix: always generate redirectpath on login events server-side

### DIFF
--- a/apps/cli/go.mod
+++ b/apps/cli/go.mod
@@ -19,15 +19,19 @@ require (
 	github.com/francoispqt/gojay v1.2.13 // indirect
 	github.com/go-chi/chi/v5 v5.2.2 // indirect
 	github.com/go-chi/httplog/v3 v3.2.2 // indirect
+	github.com/go-openapi/jsonpointer v0.21.1 // indirect
+	github.com/go-openapi/swag v0.23.1 // indirect
 	github.com/gofrs/uuid/v5 v5.3.2 // indirect
 	github.com/gomodule/redigo v1.9.2 // indirect
+	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/icza/session v1.3.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/pgx/v5 v5.7.5 // indirect
+	github.com/josharian/intern v1.0.0 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
-	github.com/kr/pretty v0.3.1 // indirect
+	github.com/mailru/easyjson v0.9.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d // indirect
@@ -39,6 +43,7 @@ require (
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
+	github.com/zachelrath/yaml-jsonpointer v0.2.0 // indirect
 	golang.org/x/crypto v0.40.0 // indirect
 	golang.org/x/sys v0.34.0 // indirect
 	golang.org/x/term v0.33.0 // indirect

--- a/apps/cli/go.sum
+++ b/apps/cli/go.sum
@@ -49,7 +49,6 @@ github.com/cli/browser v1.3.0/go.mod h1:HH8s+fOAxjhQoBUAsKuPCbqUuxZDhQ2/aD+SzsEf
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/coreos/go-systemd v0.0.0-20181012123002-c6f51f82210d/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
-github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.17 h1:QeVUsEDNrLBW4tMgZHvxy18sKtr6VI492kBhUfhDJNI=
 github.com/creack/pty v1.1.17/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -76,6 +75,10 @@ github.com/go-chi/chi/v5 v5.2.2/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hH
 github.com/go-chi/httplog/v3 v3.2.2 h1:G0oYv3YYcikNjijArHFUlqfR78cQNh9fGT43i6StqVc=
 github.com/go-chi/httplog/v3 v3.2.2/go.mod h1:N/J1l5l1fozUrqIVuT8Z/HzNeSy8TF2EFyokPLe6y2w=
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
+github.com/go-openapi/jsonpointer v0.21.1 h1:whnzv/pNXtK2FbX/W9yJfRmE2gsmkfahjMKB0fZvcic=
+github.com/go-openapi/jsonpointer v0.21.1/go.mod h1:50I1STOfbY1ycR8jGz8DaMeLCdXiI6aDteEdRNNzpdk=
+github.com/go-openapi/swag v0.23.1 h1:lpsStH0n2ittzTnbaSloVZLuB5+fvSY/+hnagBjSNZU=
+github.com/go-openapi/swag v0.23.1/go.mod h1:STZs8TbRvEQQKUA+JZNAm3EWlgaOBGpyFDqQnDHMef0=
 github.com/gofrs/uuid/v5 v5.3.2 h1:2jfO8j3XgSwlz/wHqemAEugfnTlikAYHhnqQ8Xh4fE0=
 github.com/gofrs/uuid/v5 v5.3.2/go.mod h1:CDOjlDMVAtN56jqyRUZh58JT31Tiw7/oQyEXZV+9bD8=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
@@ -106,6 +109,8 @@ github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OI
 github.com/googleapis/gax-go v2.0.0+incompatible/go.mod h1:SFVmujtThgffbyetf+mdk2eWhX2bMyUtNHzFKcPA9HY=
 github.com/googleapis/gax-go/v2 v2.0.3/go.mod h1:LLvjysVCY1JZeum8Z6l8qUty8fiNwE08qbEPm1M08qg=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
+github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
+github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/grpc-gateway v1.5.0/go.mod h1:RSKVYQBd5MCa4OVpNdGskqpgL2+G+NZTnrVHpWWfpdw=
@@ -127,6 +132,8 @@ github.com/jackc/pgx/v5 v5.7.5/go.mod h1:aruU7o91Tc2q2cFp5h4uP3f6ztExVpyVv88Xl/8
 github.com/jellevandenhooff/dkim v0.0.0-20150330215556-f50fe3d243e1/go.mod h1:E0B/fFc00Y+Rasa88328GlI/XbtyysCtTHZS8h7IrBU=
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
+github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
+github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/jrick/logrotate v1.0.0/go.mod h1:LNinyqDIJnpAur+b8yyulnQw/wDuN1+BYKlTRt3OuAQ=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
@@ -144,6 +151,8 @@ github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/lunixbochs/vtclean v1.0.0/go.mod h1:pHhQNgMf3btfWnGBVipUOjRYhoOsdGqdm/+2c2E2WMI=
 github.com/mailru/easyjson v0.0.0-20190312143242-1de009706dbe/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
+github.com/mailru/easyjson v0.9.0 h1:PrnmzHw7262yW8sTBwxi1PdJA3Iw/EKBa8psRf7d9a4=
+github.com/mailru/easyjson v0.9.0/go.mod h1:1+xMtQp2MRNVL/V1bOzuP3aP8VNwRW55fQUto+XFtTU=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=
 github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
@@ -171,7 +180,6 @@ github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1y
 github.com/openzipkin/zipkin-go v0.1.1/go.mod h1:NtoC/o8u3JlF1lSlyPNswIbeQH9bJTmOf0Erfk+hxe8=
 github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
 github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
-github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -181,7 +189,6 @@ github.com/prometheus/common v0.0.0-20180801064454-c7de2306084e/go.mod h1:daVV7q
 github.com/prometheus/procfs v0.0.0-20180725123919-05ee40e3a273/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/qdm12/reprint v0.0.0-20200326205758-722754a53494 h1:wSmWgpuccqS2IOfmYrbRiUgv+g37W5suLLLxwwniTSc=
 github.com/qdm12/reprint v0.0.0-20200326205758-722754a53494/go.mod h1:yipyliwI08eQ6XwDm1fEwKPdF/xdbkiHtrU+1Hg+vc4=
-github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
@@ -246,6 +253,8 @@ github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:
 github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17UxZ74=
 github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+github.com/zachelrath/yaml-jsonpointer v0.2.0 h1:z7sDYsRAJL/JrA48HrChReA+AMfIiss+X2ZMMR25H60=
+github.com/zachelrath/yaml-jsonpointer v0.2.0/go.mod h1:sWWbW+Nxgmm3Hp6+ffaCSDocIu3Me+68shpCQr3WfAw=
 go.opencensus.io v0.18.0/go.mod h1:vKdFvxhtzZ9onBp9VKHK8z/sRpBMnKAsufL7wlDrCOA=
 go4.org v0.0.0-20180809161055-417644f6feb5/go.mod h1:MkTOUMDaeVYJUOUsaDXIhWPZYa1yOyC1qaOBpL57BhE=
 golang.org/x/build v0.0.0-20190111050920-041ab4dc3f9d/go.mod h1:OWs+y06UdEOHN4y+MfF/py+xQ/tYqIWW03b70/CG9Rw=

--- a/apps/platform/pkg/auth/responses.go
+++ b/apps/platform/pkg/auth/responses.go
@@ -18,9 +18,7 @@ type TokenResponse struct {
 
 type LoginResponse struct {
 	TokenResponse
-	RedirectPath           string `json:"redirectPath,omitempty"`
-	RedirectRouteName      string `json:"redirectRouteName,omitempty"`
-	RedirectRouteNamespace string `json:"redirectRouteNamespace,omitempty"`
+	RedirectPath string `json:"redirectPath,omitempty"`
 }
 
 func NewUserResponse(user *preload.UserMergeData) *UserResponse {
@@ -38,7 +36,7 @@ func NewTokenResponse(user *preload.UserMergeData, sessionID string) *TokenRespo
 	}
 }
 
-func NewLoginResponse(user *preload.UserMergeData, sessionID string, redirectPath, redirectRouteNamespace string, redirectRouteName string) *LoginResponse {
+func NewLoginResponse(user *preload.UserMergeData, sessionID string, redirectPath string) *LoginResponse {
 	return &LoginResponse{
 		TokenResponse: TokenResponse{
 			UserResponse: UserResponse{
@@ -46,8 +44,6 @@ func NewLoginResponse(user *preload.UserMergeData, sessionID string, redirectPat
 			},
 			SessionID: sessionID,
 		},
-		RedirectPath:           redirectPath,
-		RedirectRouteName:      redirectRouteName,
-		RedirectRouteNamespace: redirectRouteNamespace,
+		RedirectPath: redirectPath,
 	}
 }

--- a/apps/platform/pkg/auth/samlauth/samlauth.go
+++ b/apps/platform/pkg/auth/samlauth/samlauth.go
@@ -209,13 +209,13 @@ func (c *Connection) Login(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	redirectPath := "/" + response.RedirectRouteName
-
-	if c.session.GetContextAppName() != response.RedirectRouteNamespace {
-		redirectPath = "/site/app/" + response.RedirectRouteNamespace + "/" + response.RedirectRouteName
-	}
-
-	http.Redirect(w, r, redirectPath, http.StatusSeeOther)
+	// NOTE - The previous version of this code would always ignore any `redirectPath` from GetLoginRedirectResponse
+	// and always use RedirectRouteNamespace & RedirectRouteName.  Additionally, it would check if the c.session.GetContextAppName()
+	// was different from the response.RedirectRouteNamespace and if so, build a redirectPath (see the git history for exact code
+	// that was used). The approach taken was specifically for a prototype of samlauth and was never intended to be production ready.
+	// TODO: If/When samlauth requires full production support, the entire flow needs to be reviweed, validated, adjusted and proper
+	// tests written.
+	http.Redirect(w, r, response.RedirectPath, http.StatusSeeOther)
 }
 
 func (c *Connection) Signup(signupMethod *meta.SignupMethod, payload map[string]any, username string) error {

--- a/apps/platform/pkg/controller/logout.go
+++ b/apps/platform/pkg/controller/logout.go
@@ -1,16 +1,15 @@
 package controller
 
 import (
-	"errors"
 	"net/http"
+	"net/url"
 
 	"github.com/thecloudmasters/uesio/pkg/controller/ctlutil"
 	"github.com/thecloudmasters/uesio/pkg/controller/filejson"
 	"github.com/thecloudmasters/uesio/pkg/preload"
-	"github.com/thecloudmasters/uesio/pkg/types/exceptions"
+	"github.com/thecloudmasters/uesio/pkg/routing"
 
 	"github.com/thecloudmasters/uesio/pkg/auth"
-	"github.com/thecloudmasters/uesio/pkg/meta"
 	"github.com/thecloudmasters/uesio/pkg/middleware"
 	"github.com/thecloudmasters/uesio/pkg/sess"
 )
@@ -24,18 +23,22 @@ func Logout(w http.ResponseWriter, r *http.Request) {
 		ctlutil.HandleError(r.Context(), w, err)
 		return
 	}
+	err = auth.HydrateUserPermissions(publicUser, session)
+	if err != nil {
+		ctlutil.HandleError(r.Context(), w, err)
+		return
+	}
 	session = sess.Logout(w, r, publicUser, session)
 
-	loginRoute := site.GetAppBundle().LoginRoute
-	if loginRoute == "" {
-		ctlutil.HandleError(r.Context(), w, errors.New("no Login route defined"))
-		return
-	}
-	redirectNamespace, redirectRoute, err := meta.ParseKey(loginRoute)
+	route, err := routing.GetLoginRoute(session)
 	if err != nil {
-		ctlutil.HandleError(r.Context(), w, exceptions.NewBadRequestException("invalid login route: "+loginRoute, nil))
+		ctlutil.HandleError(r.Context(), w, err)
 		return
 	}
-
-	filejson.RespondJSON(w, r, auth.NewLoginResponse(preload.GetUserMergeData(session), "", "", redirectNamespace, redirectRoute))
+	redirectPath, err := url.JoinPath("/", route.Path)
+	if err != nil {
+		ctlutil.HandleError(r.Context(), w, err)
+		return
+	}
+	filejson.RespondJSON(w, r, auth.NewLoginResponse(preload.GetUserMergeData(session), "", redirectPath))
 }

--- a/apps/platform/pkg/controller/signup.go
+++ b/apps/platform/pkg/controller/signup.go
@@ -4,12 +4,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/gorilla/mux"
 
 	"github.com/thecloudmasters/uesio/pkg/controller/ctlutil"
 	"github.com/thecloudmasters/uesio/pkg/controller/filejson"
-	"github.com/thecloudmasters/uesio/pkg/meta"
+	"github.com/thecloudmasters/uesio/pkg/routing"
 	"github.com/thecloudmasters/uesio/pkg/sess"
 	"github.com/thecloudmasters/uesio/pkg/types/exceptions"
 
@@ -52,13 +53,18 @@ func Signup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	redirectRouteNamespace, redirectRouteName, err := meta.ParseKey(signupMethod.LandingRoute)
+	route, err := routing.GetRouteFromKey(signupMethod.LandingRoute, systemSession)
+	if err != nil {
+		ctlutil.HandleError(r.Context(), w, err)
+		return
+	}
+	redirectPath, err := url.JoinPath("/", route.Path)
 	if err != nil {
 		ctlutil.HandleError(r.Context(), w, err)
 		return
 	}
 
-	filejson.RespondJSON(w, r, auth.NewLoginResponse(nil, "", "", redirectRouteNamespace, redirectRouteName))
+	filejson.RespondJSON(w, r, auth.NewLoginResponse(nil, "", redirectPath))
 
 }
 

--- a/apps/platform/pkg/routing/routing.go
+++ b/apps/platform/pkg/routing/routing.go
@@ -20,7 +20,7 @@ import (
 	"github.com/thecloudmasters/uesio/pkg/types/wire"
 )
 
-func getRouteFromKey(key string, session *sess.Session) (*meta.Route, error) {
+func GetRouteFromKey(key string, session *sess.Session) (*meta.Route, error) {
 	if key == "" {
 		return nil, nil
 	}
@@ -36,16 +36,28 @@ func getRouteFromKey(key string, session *sess.Session) (*meta.Route, error) {
 	return route, nil
 }
 
+func GetUserHomeRoute(user *meta.User, session *sess.Session) (*meta.Route, error) {
+	redirectKey := session.GetHomeRoute()
+	profile := user.ProfileRef
+	if profile.HomeRoute != "" {
+		redirectKey = profile.HomeRoute
+	}
+	if redirectKey == "" {
+		return nil, exceptions.NewNotFoundException("no home route found for user")
+	}
+	return GetRouteFromKey(redirectKey, session)
+}
+
 func GetHomeRoute(session *sess.Session) (*meta.Route, error) {
-	return getRouteFromKey(session.GetHomeRoute(), session)
+	return GetRouteFromKey(session.GetHomeRoute(), session)
 }
 
 func GetSignupRoute(session *sess.Session) (*meta.Route, error) {
-	return getRouteFromKey(session.GetSignupRoute(), session)
+	return GetRouteFromKey(session.GetSignupRoute(), session)
 }
 
 func GetLoginRoute(session *sess.Session) (*meta.Route, error) {
-	return getRouteFromKey(session.GetLoginRoute(), session)
+	return GetRouteFromKey(session.GetLoginRoute(), session)
 }
 
 func GetRouteFromPath(r *http.Request, namespace, path, prefix string, session *sess.Session, connection wire.Connection) (*meta.Route, error) {

--- a/libs/ui/src/bands/user/operations.ts
+++ b/libs/ui/src/bands/user/operations.ts
@@ -1,21 +1,17 @@
 import { Context } from "../../context/context"
 import { dispatch } from "../../store/store"
 import { set as setUser } from "."
-import { navigateToRoute, redirect } from "../../bands/route/operations"
+import { redirect } from "../../bands/route/operations"
 import { getErrorString } from "../utils"
 import { LoginResponse, platform } from "../../platform/platform"
 type Payload = Record<string, string> | undefined
 async function responseRedirect(response: LoginResponse, context: Context) {
-  return "redirectPath" in response
-    ? redirect(context, response.redirectPath)
-    : navigateToRoute(
-        // Always run the logout action in the base route context.
-        context.getRouteContext(),
-        {
-          route: `${response.redirectRouteNamespace}.${response.redirectRouteName}`,
-          params: {},
-        },
-      )
+  // All login responses will return a redirectPath barring any failure server side. If we don't
+  // have a redirectPath, there is nothing we can do here other than try to go to site root or
+  // take user to an error page as trying to query for the "home" route will result in the same
+  // as what login response should contain.
+  // TODO: Consider going to an error page here instead of site root
+  return redirect(context, response.redirectPath || "/")
 }
 
 const signup = async (

--- a/libs/ui/src/platform/platform.ts
+++ b/libs/ui/src/platform/platform.ts
@@ -160,17 +160,11 @@ type NamespaceInfo = {
   namespace: string
 }
 
-type LoginResponse = LoginResponsePath | LoginResponseRedirect
+type LoginResponse = LoginResponsePath
 
 type LoginResponsePath = {
   user: UserState
   redirectPath: string
-}
-
-type LoginResponseRedirect = {
-  user: UserState
-  redirectRouteNamespace: string
-  redirectRouteName: string
 }
 
 export const getPrefix = (context: Context) => {


### PR DESCRIPTION
# What does this PR do?

Modifies "login responses" to always contain a `redirectPath` eliminating the `routeNamespace/routeName` usage.

The reason for this change is a few-fold:

1. We always hit the server to process a "login related' event but then, unless an `r=<path>` was specified, would send the route namespace/name to the client who would then go back to the server to get the path and then `pushState`.  This 2nd call to get information we could already obtain impacts performance unnecessarily.
2. While we are processing the "login related event", we are changing the session (auth) token so any inflight requests from the browser may fail depending on when they get processed through middleware.  There is actually another bug (PR coming) where we don't "remove" the "old session" but assuming we were doing that as we should, the inflight request would now have an invalid token.  By transitioning to using `window.location=<path>` instead of `pushState`, we help mitigate this risk because the browser should cancel in-pending requests rather than try to complete them.  Note that there are still situations where an in-process request could have a token that is now expired (this seems to occur most commonly with source map requests when dev tools is open) but forcing a full page refresh minimizes all these risks
3. We want to ensure that the full page, all resources, etc. are loaded in the context of the "now current" user - a full page refresh is the only way to achieve this

NOTE: There are more PRs coming in/around the security of session management, etc. as mentioned above.  This is not final state but the next step.

# Testing

Tested manually and confirmed expected behavior.  e2e & ci will cover rest.
