### PR TITLE
fix: ensure browser session is removed on priviledge changes

### DIFF
--- a/apps/platform/pkg/auth/cli_token.go
+++ b/apps/platform/pkg/auth/cli_token.go
@@ -95,7 +95,7 @@ func CLIToken(w http.ResponseWriter, r *http.Request, requestingSession *sess.Se
 		ctlutil.HandleError(r.Context(), w, err)
 		return
 	}
-	browserSession := sess.CreateBrowserSession(w, user, site)
+	browserSession := sess.CreateBrowserSession(w, r, user, site)
 	cliSession, err := GetSessionFromUser(browserSession.ID(), user, site)
 	if err != nil {
 		ctlutil.HandleError(r.Context(), w, err)

--- a/apps/platform/pkg/auth/login.go
+++ b/apps/platform/pkg/auth/login.go
@@ -40,9 +40,7 @@ func GetLoginRedirectResponse(w http.ResponseWriter, r *http.Request, user *meta
 		return nil, err
 	}
 
-	// If we had an old session, remove it.
-	w.Header().Del("Set-Cookie")
-	session = sess.Login(w, user, site)
+	session = sess.Login(w, r, user, site)
 
 	// Check for redirect parameter on the referrer
 	referer, err := url.Parse(r.Referer())

--- a/apps/platform/pkg/cmd/serve.go
+++ b/apps/platform/pkg/cmd/serve.go
@@ -325,7 +325,7 @@ func serve(cmd *cobra.Command, args []string) error {
 	sr.HandleFunc("/auth/"+itemParam+"/createlogin", controller.CreateLogin).Methods("POST")
 	sa.HandleFunc("/auth/"+itemParam+"/createlogin", controller.CreateLogin).Methods("POST")
 	sr.HandleFunc("/auth/"+itemParam+"/login", controller.Login).Methods("POST")
-	wr.HandleFunc("/auth/"+itemParam+"/login", controller.Login).Methods("POST")
+	wr.HandleFunc("/auth/"+itemParam+"/login", controller.LoginWorkspace).Methods("POST")
 	sr.HandleFunc("/auth/"+itemParam+"/signup", controller.Signup).Methods("POST")
 	sa.HandleFunc("/auth/"+itemParam+"/resetpassword", controller.ResetPassword).Methods("POST")
 	sr.HandleFunc("/auth/"+itemParam+"/resetpassword", controller.ResetPassword).Methods("POST")
@@ -338,7 +338,7 @@ func serve(cmd *cobra.Command, args []string) error {
 	sr.HandleFunc("/auth/check", controller.AuthCheck).Methods("GET")
 
 	sr.HandleFunc("/auth/"+itemParam+"/requestlogin", controller.RequestLogin).Methods("GET")
-	wr.HandleFunc("/auth/"+itemParam+"/requestlogin", controller.RequestLogin).Methods("GET")
+	wr.HandleFunc("/auth/"+itemParam+"/requestlogin", controller.RequestLoginWorkspace).Methods("GET")
 
 	// These routes are studio specific and will return forbidden if not uesio/studio.  The way we handle cli auth
 	// and these routes in general can be improved in one of two ways:

--- a/apps/platform/pkg/controller/logout.go
+++ b/apps/platform/pkg/controller/logout.go
@@ -15,20 +15,12 @@ import (
 )
 
 func Logout(w http.ResponseWriter, r *http.Request) {
-
-	session := middleware.GetSession(r)
-	site := session.GetSite()
-	publicUser, err := auth.GetPublicUser(site, nil)
+	// See comments in ensurePublicSession for why we do this.
+	session, err := ensurePublicSession(w, r)
 	if err != nil {
 		ctlutil.HandleError(r.Context(), w, err)
 		return
 	}
-	err = auth.HydrateUserPermissions(publicUser, session)
-	if err != nil {
-		ctlutil.HandleError(r.Context(), w, err)
-		return
-	}
-	session = sess.Logout(w, r, publicUser, session)
 
 	route, err := routing.GetLoginRoute(session)
 	if err != nil {
@@ -41,4 +33,41 @@ func Logout(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	filejson.RespondJSON(w, r, auth.NewLoginResponse(preload.GetUserMergeData(session), "", redirectPath))
+}
+
+// Logs out any current user and logs in as the public user
+//
+// All auth related activities should occur as a public user. Since any route can be an auth related route, we cannot
+// reliably redirect away from the route if the user is currently logged in due to the way routing works. Instead,
+// we ensure that we always process auth related activities as a public user by logging out any current user (which
+// may or may not be the public user) and logging in as the public user before continuing.
+func ensurePublicSession(w http.ResponseWriter, r *http.Request) (*sess.Session, error) {
+	session := middleware.GetSession(r)
+	ctx := session.Context()
+	site := session.GetSite()
+
+	// TODO: This could be optimized to detect if current session is public user and avoid the logout/login
+	// and also skip hydrating permissions if permissions are already present. For now, being defensive and
+	// make sure we have a "clean" public session. As the code continues to be improved/refactored, this
+	// should be revisited.
+	publicUser, err := auth.GetPublicUser(site, nil)
+	if err != nil {
+		return nil, err
+	}
+	// TODO: See comment above regarding potential optimization
+	err = auth.HydrateUserPermissions(publicUser, session)
+	if err != nil {
+		return nil, err
+	}
+	// logout the current user (which may or may not be the public user) and log in as the public user
+	session = sess.Logout(w, r, publicUser, session)
+	// TODO: Think through whether or not we should be calling the equivalent of auth.setSession
+	// to modify the session information for the entire request. In theory, once we make it through
+	// middleware and controllers, we should only be passing around a context.Context & sess.Session and
+	// not the actualhttp request & responsewriter however we have several packages (auth, sess, middleware,
+	// controller, etc.) that are all, at some level, "controller" methods given current implementation. Once
+	// things are refactored, context passed throughout the system independently and sess.Sess where applicable,
+	// this can likely go completely away anyway.
+	session.SetGoContext(ctx)
+	return session, nil
 }

--- a/apps/platform/pkg/controller/resetpassword.go
+++ b/apps/platform/pkg/controller/resetpassword.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/thecloudmasters/uesio/pkg/auth"
 	"github.com/thecloudmasters/uesio/pkg/controller/ctlutil"
-	"github.com/thecloudmasters/uesio/pkg/middleware"
 	"github.com/thecloudmasters/uesio/pkg/types/exceptions"
 )
 
@@ -19,12 +18,16 @@ func getSignupMethodID(vars map[string]string) string {
 }
 
 func ResetPassword(w http.ResponseWriter, r *http.Request) {
-
-	session := middleware.GetSession(r)
+	// See comments in ensurePublicSession for why we do this.
+	session, err := ensurePublicSession(w, r)
+	if err != nil {
+		ctlutil.HandleError(r.Context(), w, err)
+		return
+	}
 	site := session.GetContextSite()
 
 	var payload map[string]any
-	err := json.NewDecoder(r.Body).Decode(&payload)
+	err = json.NewDecoder(r.Body).Decode(&payload)
 	if err != nil {
 		ctlutil.HandleError(r.Context(), w, exceptions.NewBadRequestException("invalid request body", err))
 		return
@@ -35,16 +38,19 @@ func ResetPassword(w http.ResponseWriter, r *http.Request) {
 		ctlutil.HandleError(r.Context(), w, err)
 		return
 	}
-
 }
 
 func ConfirmResetPassword(w http.ResponseWriter, r *http.Request) {
-
-	session := middleware.GetSession(r)
+	// See comments in ensurePublicSession for why we do this.
+	session, err := ensurePublicSession(w, r)
+	if err != nil {
+		ctlutil.HandleError(r.Context(), w, err)
+		return
+	}
 	site := session.GetSite()
 
 	var payload map[string]any
-	err := json.NewDecoder(r.Body).Decode(&payload)
+	err = json.NewDecoder(r.Body).Decode(&payload)
 	if err != nil {
 		ctlutil.HandleError(r.Context(), w, exceptions.NewBadRequestException("invalid request body", err))
 		return
@@ -57,5 +63,4 @@ func ConfirmResetPassword(w http.ResponseWriter, r *http.Request) {
 	}
 
 	auth.LoginRedirectResponse(w, r, user, session)
-
 }

--- a/apps/platform/pkg/middleware/authenticate.go
+++ b/apps/platform/pkg/middleware/authenticate.go
@@ -112,7 +112,7 @@ func Authenticate(next http.Handler) http.Handler {
 		}
 
 		if browserSession == nil {
-			browserSession = sess.CreateBrowserSession(w, user, site)
+			browserSession = sess.CreateBrowserSession(w, r, user, site)
 		}
 
 		s, err := auth.GetSessionFromUser(browserSession.ID(), user, site)


### PR DESCRIPTION
# What does this PR do?

1. Ensures that when a privilege change occurs (e.g., login, signup, etc.) that the previous browser session is removed. Previously, a new browser session with corresponding token was created, however the previous browser session was orphaned meaning it would stay and be available in cache for the remainder of its absolute lifetime of 12 hours
2. Ensures that whenever a "non-system specific" privilege change is occurring (e.g,, login, signup), it is performed as the Public User. Previously, the action was performed in the "current user" context, however since we allow "logged in users" to access login, signup, etc. (we can't reliably redirect away because any route could be a login/signup/etc. route), we were processing them as the current user. While this was largely protected from "leaking" and/or "using" the current user information in anyway, it's prone to (unintentional) mis-use and needs to be avoided.

As mentioned in recent PRs, there are several more coming related to improving and ultimately refactoring the auth flows.  This is just the next step of the process and should not be considered permanent state.

# Testing

Tested all scenarios manually and confirmed. e2e & ci will cover rest.
