### PR TITLE
chore: refactor location of auth related code

### DIFF
--- a/apps/platform/pkg/auth/auth.go
+++ b/apps/platform/pkg/auth/auth.go
@@ -6,10 +6,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
-	"os"
 	"strings"
-
-	"github.com/icza/session"
 
 	"github.com/thecloudmasters/uesio/pkg/bundle"
 	"github.com/thecloudmasters/uesio/pkg/configstore"
@@ -22,37 +19,6 @@ import (
 	"github.com/thecloudmasters/uesio/pkg/types/exceptions"
 	"github.com/thecloudmasters/uesio/pkg/types/wire"
 )
-
-const BrowserSessionCookieName = "sessid" // icza applied this name by default so we use the same one
-
-func init() {
-	session.Global.Close()
-	// The localhost check here is only necessary because hurl doesn't handle secure cookies against *.localhost by default like browsers, curl, etc.
-	// do. If/When they treat "localhost" as a secure connection the IsLocalHost condition can be removed.
-	// TODO: File an issue with hurl regarding this.  libcurl is returning the cookie to them, its in the response, but they are not carrying it
-	// forward to subsequent requests.
-	allowInsecureCookies := !tls.ServeAppWithTLS() && (env.IsLocalhost() || os.Getenv("UESIO_ALLOW_INSECURE_COOKIES") == "true")
-	storageType := os.Getenv("UESIO_SESSION_STORE")
-
-	var store session.Store
-	switch storageType {
-	case "filesystem":
-		store = NewFSSessionStore()
-	case "redis":
-		store = NewRedisSessionStore()
-	case "", "memory":
-		store = session.NewInMemStore()
-	default:
-		panic("UESIO_SESSION_STORE is an unrecognized value: " + storageType)
-	}
-
-	options := &session.CookieMngrOptions{
-		AllowHTTP:        allowInsecureCookies,
-		SessIDCookieName: BrowserSessionCookieName,
-	}
-
-	session.Global = session.NewCookieManagerOptions(store, options)
-}
 
 type AuthenticationType interface {
 	GetAuthConnection(*wire.Credentials, *meta.AuthSource, wire.Connection, *sess.Session) (AuthConnection, error)

--- a/apps/platform/pkg/auth/cli_token.go
+++ b/apps/platform/pkg/auth/cli_token.go
@@ -95,7 +95,7 @@ func CLIToken(w http.ResponseWriter, r *http.Request, requestingSession *sess.Se
 		ctlutil.HandleError(r.Context(), w, err)
 		return
 	}
-	browserSession := sess.CreateBrowserSession(w, r, user, site)
+	browserSession := CreateBrowserSession(w, r, user, site)
 	cliSession, err := GetSessionFromUser(browserSession.ID(), user, site)
 	if err != nil {
 		ctlutil.HandleError(r.Context(), w, err)

--- a/apps/platform/pkg/auth/login.go
+++ b/apps/platform/pkg/auth/login.go
@@ -40,7 +40,7 @@ func GetLoginRedirectResponse(w http.ResponseWriter, r *http.Request, user *meta
 		return nil, err
 	}
 
-	session = sess.Login(w, r, user, site)
+	session = ProcessLogin(w, r, user, site)
 
 	// Check for redirect parameter on the referrer
 	referer, err := url.Parse(r.Referer())

--- a/apps/platform/pkg/auth/redis-session-store.go
+++ b/apps/platform/pkg/auth/redis-session-store.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/icza/session"
 	"github.com/thecloudmasters/uesio/pkg/cache"
-	"github.com/thecloudmasters/uesio/pkg/sess"
 )
 
 type RedisSessionStore struct {
@@ -16,7 +15,7 @@ type RedisSessionStore struct {
 
 func NewRedisSessionStore() session.Store {
 	return &RedisSessionStore{
-		cache.NewRedisCache[session.Session]("session").WithExpiration(sess.SessionLifetime).WithInitializer(session.NewSession),
+		cache.NewRedisCache[session.Session]("session").WithExpiration(SessionLifetime).WithInitializer(session.NewSession),
 	}
 }
 

--- a/apps/platform/pkg/auth/session.go
+++ b/apps/platform/pkg/auth/session.go
@@ -4,17 +4,54 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
+	"os"
 	"strings"
+	"time"
 
 	"github.com/gofrs/uuid/v5"
 	"github.com/icza/session"
 	"golang.org/x/crypto/bcrypt"
 
 	"github.com/thecloudmasters/uesio/pkg/datasource"
+	"github.com/thecloudmasters/uesio/pkg/env"
 	"github.com/thecloudmasters/uesio/pkg/meta"
 	"github.com/thecloudmasters/uesio/pkg/sess"
+	"github.com/thecloudmasters/uesio/pkg/tls"
 	"github.com/thecloudmasters/uesio/pkg/types/exceptions"
 )
+
+const SessionLifetime = 12 * time.Hour
+const BrowserSessionCookieName = "sessid" // icza applied this name by default so we use the same one
+
+func init() {
+	session.Global.Close()
+	// The localhost check here is only necessary because hurl doesn't handle secure cookies against *.localhost by default like browsers, curl, etc.
+	// do. If/When they treat "localhost" as a secure connection the IsLocalHost condition can be removed.
+	// TODO: File an issue with hurl regarding this.  libcurl is returning the cookie to them, its in the response, but they are not carrying it
+	// forward to subsequent requests.
+	allowInsecureCookies := !tls.ServeAppWithTLS() && (env.IsLocalhost() || os.Getenv("UESIO_ALLOW_INSECURE_COOKIES") == "true")
+	storageType := os.Getenv("UESIO_SESSION_STORE")
+
+	var store session.Store
+	switch storageType {
+	case "filesystem":
+		store = NewFSSessionStore()
+	case "redis":
+		store = NewRedisSessionStore()
+	case "", "memory":
+		store = session.NewInMemStore()
+	default:
+		panic("UESIO_SESSION_STORE is an unrecognized value: " + storageType)
+	}
+
+	options := &session.CookieMngrOptions{
+		AllowHTTP:        allowInsecureCookies,
+		SessIDCookieName: BrowserSessionCookieName,
+	}
+
+	session.Global = session.NewCookieManagerOptions(store, options)
+}
 
 func GetUserFromAuthToken(token string, site *meta.Site) (*meta.User, error) {
 	// Split the token on the ":" character
@@ -36,19 +73,6 @@ func GetUserFromAuthToken(token string, site *meta.Site) (*meta.User, error) {
 	}
 
 	return GetUserByID(loginmethod.User.ID, adminSession, nil)
-}
-
-func GetUserFromBrowserSession(browserSession session.Session, site *meta.Site) (*meta.User, error) {
-	if browserSession == nil {
-		return GetPublicUser(site, nil)
-	}
-	browserSessionSite := sess.GetSessionAttribute(browserSession, "Site")
-	browserSessionUser := sess.GetSessionAttribute(browserSession, "UserID")
-	// Check to make sure our session site matches the site from our domain.
-	if browserSessionSite != site.GetFullName() {
-		return nil, fmt.Errorf("sites mismatch for user: %s", browserSessionUser)
-	}
-	return GetCachedUserByID(browserSessionUser, site)
 }
 
 func CreateSessionFromUser(user *meta.User, site *meta.Site) (*sess.Session, error) {
@@ -105,4 +129,36 @@ func GetCachedUserByID(userid string, site *meta.Site) (*meta.User, error) {
 		return nil, err
 	}
 	return user, nil
+}
+
+func CreateBrowserSession(w http.ResponseWriter, r *http.Request, user *meta.User, site *meta.Site) session.Session {
+	sess := session.NewSessionOptions(&session.SessOptions{
+		CAttrs: map[string]any{
+			"Site":   site.GetFullName(),
+			"UserID": user.ID,
+		},
+		// TODO: Make Session timeout configurable by App/Site
+		// https://github.com/TheCloudMasters/uesio/issues/2643
+		Timeout: SessionLifetime,
+	})
+	browserSession := session.Get(r)
+	if browserSession != nil {
+		session.Remove(browserSession, w)
+	}
+	// Remove any previous set-cookie headers
+	// icza updates existing to "" and then its Add method
+	// appends so we end up with two Set-Cookie headers. This ensures
+	// we only have one and it's the current one
+	w.Header().Del("Set-Cookie")
+	session.Add(sess, w)
+	return sess
+}
+
+func ProcessLogin(w http.ResponseWriter, r *http.Request, user *meta.User, site *meta.Site) *sess.Session {
+	return sess.New(CreateBrowserSession(w, r, user, site).ID(), user, site)
+}
+
+func ProcessLogout(w http.ResponseWriter, r *http.Request, publicUser *meta.User, s *sess.Session) *sess.Session {
+	// Login as the public user - Login will logout the current user
+	return ProcessLogin(w, r, publicUser, s.GetSiteSession().GetSite())
 }

--- a/apps/platform/pkg/controller/logout.go
+++ b/apps/platform/pkg/controller/logout.go
@@ -60,7 +60,7 @@ func ensurePublicSession(w http.ResponseWriter, r *http.Request) (*sess.Session,
 		return nil, err
 	}
 	// logout the current user (which may or may not be the public user) and log in as the public user
-	session = sess.Logout(w, r, publicUser, session)
+	session = auth.ProcessLogout(w, r, publicUser, session)
 	// TODO: Think through whether or not we should be calling the equivalent of auth.setSession
 	// to modify the session information for the entire request. In theory, once we make it through
 	// middleware and controllers, we should only be passing around a context.Context & sess.Session and

--- a/apps/platform/pkg/controller/signup.go
+++ b/apps/platform/pkg/controller/signup.go
@@ -11,7 +11,6 @@ import (
 	"github.com/thecloudmasters/uesio/pkg/controller/ctlutil"
 	"github.com/thecloudmasters/uesio/pkg/controller/filejson"
 	"github.com/thecloudmasters/uesio/pkg/routing"
-	"github.com/thecloudmasters/uesio/pkg/sess"
 	"github.com/thecloudmasters/uesio/pkg/types/exceptions"
 
 	"github.com/thecloudmasters/uesio/pkg/auth"
@@ -116,7 +115,7 @@ func ConfirmSignUp(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Log the user in
-	_ = sess.Login(w, r, user, site)
+	_ = auth.ProcessLogin(w, r, user, site)
 	// Redirect to studio home
 	http.Redirect(w, r, "/", http.StatusFound)
 }


### PR DESCRIPTION
# What does this PR do?

No functional changes of any kind.  Just refactoring the location of some of the auth related code as the next step (many more yet to come) of improving auth flows.  Focused on putting code in packages and files were it more appropriately fits than its prior location.

Major win here is decoupling sess package from its dependencies on icza and eliminating it from having "controller" functions. Also, eliminating some middleware only functions from auth package.

# Testing

ci & e2e will cover.
