### PR TITLE
chore: explicit auth token on uesio session

### DIFF
--- a/apps/cli/pkg/auth/check.go
+++ b/apps/cli/pkg/auth/check.go
@@ -9,19 +9,19 @@ import (
 
 func Check() (*preload.UserMergeData, error) {
 
-	sessid, err := config.GetSessionID()
+	token, err := config.GetToken()
 	if err != nil {
 		return nil, err
 	}
 
 	// If there's no current session id stored, no need to make check call
-	if sessid == "" {
+	if token == "" {
 		return nil, nil
 	}
 
 	var userResponse auth.UserResponse
 
-	err = call.GetJSON("site/auth/check", sessid, &userResponse)
+	err = call.GetJSON("site/auth/check", token, &userResponse)
 	if err != nil {
 		return nil, err
 	}

--- a/apps/cli/pkg/auth/login.go
+++ b/apps/cli/pkg/auth/login.go
@@ -249,7 +249,7 @@ func processDirectLogin(method string, payload map[string]string) (*auth.TokenRe
 		return nil, err
 	}
 
-	return auth.NewTokenResponse(loginResponse.User, loginResponse.SessionID), nil
+	return auth.NewTokenResponse(loginResponse.User, loginResponse.Token), nil
 }
 
 func getLoginHandler() (*LoginMethodHandler, error) {
@@ -287,17 +287,17 @@ func Login() (*preload.UserMergeData, error) {
 		return nil, err
 	}
 
-	token, err := handler.Login()
+	result, err := handler.Login()
 	if err != nil {
 		return nil, err
 	}
 
-	err = config.SetSessionID(token.SessionID)
+	err = config.SetToken(result.Token)
 	if err != nil {
 		return nil, err
 	}
 
-	return token.User, nil
+	return result.User, nil
 }
 
 func generateCodeVerifier() (string, error) {

--- a/apps/cli/pkg/auth/logout.go
+++ b/apps/cli/pkg/auth/logout.go
@@ -11,15 +11,15 @@ import (
 
 func Logout() (*preload.UserMergeData, error) {
 
-	sessionID, err := config.GetSessionID()
+	token, err := config.GetToken()
 	if err != nil {
 		return nil, err
 	}
 	// If there is no current session id, there's no need to make a logout call
-	if sessionID == "" {
+	if token == "" {
 		return nil, nil
 	}
-	resp, err := call.Post("site/auth/logout", nil, sessionID, nil)
+	resp, err := call.Post("site/auth/logout", nil, token, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -31,6 +31,6 @@ func Logout() (*preload.UserMergeData, error) {
 		return nil, err
 	}
 
-	return userResponse.User, config.DeleteSessionID()
+	return userResponse.User, config.DeleteToken()
 
 }

--- a/apps/cli/pkg/cmd/generate.go
+++ b/apps/cli/pkg/cmd/generate.go
@@ -50,9 +50,9 @@ func promptForGenerator() string {
 		// attempt to log in
 		userMergeData, err = auth.Login()
 	}
-	var sessionID string
+	var token string
 	if err == nil && userMergeData != nil {
-		sessionID, err = config.GetSessionID()
+		token, err = config.GetToken()
 	}
 	if err != nil {
 		return ""
@@ -67,7 +67,7 @@ func promptForGenerator() string {
 		MetadataType: "BOT",
 		Grouping:     "GENERATOR",
 		Required:     true,
-	}, "uesio/core", "0.0.1", sessionID, answers); err != nil {
+	}, "uesio/core", "0.0.1", token, answers); err != nil {
 		return ""
 	}
 	if generatorNameString, isString := answers["generator"].(string); isString {

--- a/apps/cli/pkg/command/app/clone.go
+++ b/apps/cli/pkg/command/app/clone.go
@@ -23,7 +23,7 @@ import (
 
 // Queries for all apps accessible to the user, prompts the user to select one,
 // and then returns the app object
-func askUserToSelectApp(sessid string) (*wire.App, error) {
+func askUserToSelectApp() (*wire.App, error) {
 
 	appsResult, err := wire.GetApps()
 	if err != nil {
@@ -64,12 +64,7 @@ func AppClone(targetDir string) error {
 		return err
 	}
 
-	sessionID, err := config.GetSessionID()
-	if err != nil {
-		return err
-	}
-
-	app, err := askUserToSelectApp(sessionID)
+	app, err := askUserToSelectApp()
 	if err != nil {
 		return err
 	}
@@ -93,7 +88,11 @@ func AppClone(targetDir string) error {
 	if err != nil {
 		return err
 	}
-	resp, err := call.PostBytes(generateURL, payloadBytes, sessionID, nil)
+	token, err := config.GetToken()
+	if err != nil {
+		return err
+	}
+	resp, err := call.PostBytes(generateURL, payloadBytes, token, nil)
 	if err != nil {
 		return err
 	}

--- a/apps/cli/pkg/command/app/delete.go
+++ b/apps/cli/pkg/command/app/delete.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/thecloudmasters/cli/pkg/auth"
-	"github.com/thecloudmasters/cli/pkg/config"
 	"github.com/thecloudmasters/cli/pkg/wire"
 )
 
@@ -15,13 +14,8 @@ func Delete(appFullName string) error {
 		return err
 	}
 
-	sessionID, err := config.GetSessionID()
-	if err != nil {
-		return err
-	}
-
 	if appFullName == "" {
-		app, err := askUserToSelectApp(sessionID)
+		app, err := askUserToSelectApp()
 		if err != nil {
 			return err
 		}

--- a/apps/cli/pkg/command/app/init.go
+++ b/apps/cli/pkg/command/app/init.go
@@ -20,7 +20,7 @@ import (
 	"github.com/thecloudmasters/uesio/pkg/meta"
 )
 
-func getAnswerInfo(sessid, existingAppName string) (map[string]interface{}, error) {
+func getAnswerInfo(token, existingAppName string) (map[string]interface{}, error) {
 	users, err := wire.GetAvailableUsernames()
 	if err != nil {
 		return nil, errors.New("unable to retrieve users from studio")
@@ -70,7 +70,7 @@ func getAnswerInfo(sessid, existingAppName string) (map[string]interface{}, erro
 		},
 	)
 
-	answers, err := param.AskMany(&botParams, "", "", sessid)
+	answers, err := param.AskMany(&botParams, "", "", token)
 	if err != nil {
 		return nil, err
 	}
@@ -83,8 +83,8 @@ func getAnswerInfo(sessid, existingAppName string) (map[string]interface{}, erro
 
 }
 
-func getAnswers(sessid, existingAppName string) (string, string, string, string, error) {
-	answers, err := getAnswerInfo(sessid, existingAppName)
+func getAnswers(token, existingAppName string) (string, string, string, string, error) {
+	answers, err := getAnswerInfo(token, existingAppName)
 	if err != nil {
 		return "", "", "", "", nil
 	}
@@ -104,7 +104,7 @@ func AppInit() error {
 		return err
 	}
 
-	sessid, err := config.GetSessionID()
+	token, err := config.GetToken()
 	if err != nil {
 		return err
 	}
@@ -134,7 +134,7 @@ func AppInit() error {
 		}
 		// Create an app
 		fmt.Println("Let's create a new app.")
-		username, appname, color, icon, err := getAnswers(sessid, existingAppName)
+		username, appname, color, icon, err := getAnswers(token, existingAppName)
 		if err != nil {
 			return err
 		}
@@ -157,7 +157,7 @@ func AppInit() error {
 	if err != nil {
 		return err
 	}
-	resp, err := call.PostBytes(generateURL, payloadBytes, sessid, nil)
+	resp, err := call.PostBytes(generateURL, payloadBytes, token, nil)
 	if err != nil {
 		return err
 	}

--- a/apps/cli/pkg/command/bundle/create.go
+++ b/apps/cli/pkg/command/bundle/create.go
@@ -27,7 +27,7 @@ func CreateBundle(releaseType, majorVersion, minorVersion, patchVersion, bundleD
 		return err
 	}
 
-	sessionID, err := config.GetSessionID()
+	token, err := config.GetToken()
 	if err != nil {
 		return err
 	}
@@ -64,7 +64,7 @@ func CreateBundle(releaseType, majorVersion, minorVersion, patchVersion, bundleD
 
 	botResponse := &CallBotResponse{}
 
-	err = call.PostJSON(createBundleURL, sessionID, botInputs, botResponse, nil)
+	err = call.PostJSON(createBundleURL, token, botInputs, botResponse, nil)
 	if err != nil {
 		return err
 	}

--- a/apps/cli/pkg/command/upsert.go
+++ b/apps/cli/pkg/command/upsert.go
@@ -171,7 +171,7 @@ func Upsert(prefix string, options *UpsertOptions) error {
 
 	fmt.Println("Running Upsert Command")
 
-	sessid, err := config.GetSessionID()
+	token, err := config.GetToken()
 	if err != nil {
 		return err
 	}
@@ -181,12 +181,12 @@ func Upsert(prefix string, options *UpsertOptions) error {
 		return err
 	}
 
-	jobResponse, err := createJob(prefix, sessid, spec)
+	jobResponse, err := createJob(prefix, token, spec)
 	if err != nil {
 		return err
 	}
 
-	batchResponse, err := runBatch(prefix, sessid, options.DataFile, jobResponse.ID, spec)
+	batchResponse, err := runBatch(prefix, token, options.DataFile, jobResponse.ID, spec)
 	if err != nil {
 		return err
 	}

--- a/apps/cli/pkg/command/workspace/deploy.go
+++ b/apps/cli/pkg/command/workspace/deploy.go
@@ -33,7 +33,7 @@ func Deploy() error {
 		return errors.New("no active workspace is set -- use \"uesio work\" to set one")
 	}
 
-	sessid, err := config.GetSessionID()
+	token, err := config.GetToken()
 	if err != nil {
 		return err
 	}
@@ -42,7 +42,7 @@ func Deploy() error {
 
 	url := fmt.Sprintf("workspace/%s/%s/metadata/deploy", app, workspace)
 
-	resp, err := call.Post(url, payload, sessid, context.NewWorkspaceContext(app, workspace))
+	resp, err := call.Post(url, payload, token, context.NewWorkspaceContext(app, workspace))
 	if err != nil {
 		return err
 	}

--- a/apps/cli/pkg/command/workspace/retrieve.go
+++ b/apps/cli/pkg/command/workspace/retrieve.go
@@ -49,12 +49,12 @@ func Retrieve(options *RetrieveOptions) error {
 	if options.OnlyTypes {
 		appContext := context.NewWorkspaceContext(appName, workspace)
 
-		sessionID, err := config.GetSessionID()
+		token, err := config.GetToken()
 		if err != nil {
 			return err
 		}
 
-		if err = command.GenerateAppTypeDefinitions(appName, workspace, sessionID, appContext); err != nil {
+		if err = command.GenerateAppTypeDefinitions(appName, workspace, token, appContext); err != nil {
 			return err
 		}
 
@@ -86,7 +86,7 @@ func RetrieveBundleForAppWorkspace(appName, workspaceName, outputDir string) err
 	// TODO: Send hashes of all local files so we aren't deleting/retrieving unchanged files every time...
 	url := fmt.Sprintf("workspace/%s/%s/metadata/retrieve", appName, workspaceName)
 
-	sessionID, err := config.GetSessionID()
+	token, err := config.GetToken()
 	if err != nil {
 		return err
 	}
@@ -94,7 +94,7 @@ func RetrieveBundleForAppWorkspace(appName, workspaceName, outputDir string) err
 	resp, err := call.RequestResult(&call.RequestSpec{
 		Method:     http.MethodGet,
 		Url:        url,
-		SessionID:  sessionID,
+		Token:      token,
 		AppContext: context.NewWorkspaceContext(appName, workspaceName),
 	}, call.ByteResultReader)
 	if err != nil {

--- a/apps/cli/pkg/command/workspace/truncate.go
+++ b/apps/cli/pkg/command/workspace/truncate.go
@@ -32,14 +32,14 @@ func Truncate() error {
 		return errors.New("no active workspace is set -- use \"uesio work\" to set one")
 	}
 
-	sessionID, err := config.GetSessionID()
+	token, err := config.GetToken()
 	if err != nil {
 		return err
 	}
 
 	url := fmt.Sprintf("workspace/%s/%s/data/truncate", app, workspace)
 
-	resp, err := call.Post(url, nil, sessionID, context.NewWorkspaceContext(app, workspace))
+	resp, err := call.Post(url, nil, token, context.NewWorkspaceContext(app, workspace))
 	if err != nil {
 		return err
 	}

--- a/apps/cli/pkg/config/session.go
+++ b/apps/cli/pkg/config/session.go
@@ -1,15 +1,15 @@
 package config
 
-const sessionIDProp = "sessionId"
+const tokenProp = "token"
 
-func GetSessionID() (string, error) {
-	return GetConfigValue(sessionIDProp)
+func GetToken() (string, error) {
+	return GetConfigValue(tokenProp)
 }
 
-func SetSessionID(id string) error {
-	return SetConfigValue(sessionIDProp, id)
+func SetToken(token string) error {
+	return SetConfigValue(tokenProp, token)
 }
 
-func DeleteSessionID() error {
-	return DeleteConfigValue(sessionIDProp)
+func DeleteToken() error {
+	return DeleteConfigValue(tokenProp)
 }

--- a/apps/cli/pkg/param/param.go
+++ b/apps/cli/pkg/param/param.go
@@ -25,7 +25,7 @@ import (
 	w "github.com/thecloudmasters/uesio/pkg/types/wire"
 )
 
-func getMetadataList(metadataType, sessid, grouping string) (labels []string, valuesByLabel map[string]string, err error) {
+func getMetadataList(metadataType, token, grouping string) (labels []string, valuesByLabel map[string]string, err error) {
 
 	if metadataType == "" {
 		return nil, nil, errors.New("no metadata type provided for prompt")
@@ -90,7 +90,7 @@ func getMetadataList(metadataType, sessid, grouping string) (labels []string, va
 		url := fmt.Sprintf("version/%s/%s/metadata/types/%s/namespace/%s/list%s", depNamespace, dep.Version, metadataType, depNamespace, groupingURL)
 
 		metadataList := map[string]ns.MetadataResponse{}
-		err = call.GetJSON(url, sessid, &metadataList)
+		err = call.GetJSON(url, token, &metadataList)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -141,10 +141,10 @@ func mergeParam(templateString string, answers map[string]interface{}) (string, 
 	return mergedValue, nil
 }
 
-func AskMany(params *meta.BotParamsResponse, app, version, sessid string) (map[string]interface{}, error) {
+func AskMany(params *meta.BotParamsResponse, app, version, token string) (map[string]interface{}, error) {
 	answers := map[string]interface{}{}
 	for _, parameter := range *params {
-		err := Ask(parameter, app, version, sessid, answers)
+		err := Ask(parameter, app, version, token, answers)
 		if err != nil {
 			return nil, err
 		}
@@ -152,7 +152,7 @@ func AskMany(params *meta.BotParamsResponse, app, version, sessid string) (map[s
 	return answers, nil
 }
 
-func Ask(param meta.BotParamResponse, app, version, sessid string, answers map[string]interface{}) error {
+func Ask(param meta.BotParamResponse, app, version, token string, answers map[string]interface{}) error {
 
 	// Ignore params which are not relevant due to conditions
 	if !meta.IsParamRelevant(param, answers) {
@@ -214,7 +214,7 @@ func Ask(param meta.BotParamResponse, app, version, sessid string, answers map[s
 		if err != nil {
 			return err
 		}
-		labels, valuesByLabel, err := getMetadataList(param.MetadataType, sessid, grouping)
+		labels, valuesByLabel, err := getMetadataList(param.MetadataType, token, grouping)
 		if err != nil {
 			return err
 		}
@@ -235,7 +235,7 @@ func Ask(param meta.BotParamResponse, app, version, sessid string, answers map[s
 		if err != nil {
 			return err
 		}
-		labels, valuesByLabel, err := getMetadataList(param.MetadataType, sessid, grouping)
+		labels, valuesByLabel, err := getMetadataList(param.MetadataType, token, grouping)
 		if err != nil {
 			return err
 		}

--- a/apps/cli/pkg/wire/load.go
+++ b/apps/cli/pkg/wire/load.go
@@ -67,14 +67,14 @@ func Load(collectionName string, options *LoadOptions) (wire.Collection, error) 
 		},
 	}
 
-	sessid, err := config.GetSessionID()
+	token, err := config.GetToken()
 	if err != nil {
 		return nil, err
 	}
 
 	loadResponse := &LoadResBatch{}
 
-	err = call.PostJSON("site/wires/load", sessid, payload, loadResponse, nil)
+	err = call.PostJSON("site/wires/load", token, payload, loadResponse, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/apps/cli/pkg/wire/save.go
+++ b/apps/cli/pkg/wire/save.go
@@ -44,12 +44,12 @@ func Insert(collectionName string, changes []map[string]interface{}, appContext 
 }
 
 func DeleteOne(collectionName, idField, idValue string, appContext *context.AppContext) error {
-	sessionID, err := config.GetSessionID()
+	token, err := config.GetToken()
 	if err != nil {
 		return err
 	}
 	deleteUri := fmt.Sprintf("site/api/v1/collection/%s?%s=eq.%s", strings.ReplaceAll(collectionName, ".", "/"), idField, idValue)
-	statusCode, err := call.Delete(deleteUri, sessionID, appContext)
+	statusCode, err := call.Delete(deleteUri, token, appContext)
 	if err != nil {
 		return err
 	}
@@ -86,14 +86,14 @@ func Save(collectionName string, changes []map[string]interface{}, saveOptions S
 		},
 	}
 
-	sessionID, err := config.GetSessionID()
+	token, err := config.GetToken()
 	if err != nil {
 		return nil, err
 	}
 
 	saveResponse := &SaveReqBatch{}
 
-	err = call.PostJSON("site/wires/save", sessionID, payload, saveResponse, appContext)
+	err = call.PostJSON("site/wires/save", token, payload, saveResponse, appContext)
 	if err != nil {
 		return nil, err
 	}

--- a/apps/platform-integration-tests/bundle/bots/listener/call_http_api/bot.ts
+++ b/apps/platform-integration-tests/bundle/bots/listener/call_http_api/bot.ts
@@ -20,7 +20,7 @@ export default function call_http_api(bot: ListenerBotApi) {
     }),
     headers: {
       "Content-Type": "application/json",
-      Cookie: "sessid=" + bot.getSession().getId(),
+      Cookie: "sessid=" + bot.getSession().getAuthToken(),
     },
   })
   const result = response.body as CallBotResponse

--- a/apps/platform-integration-tests/bundle/bots/load/load_weather_forecast/bot.ts
+++ b/apps/platform-integration-tests/bundle/bots/load/load_weather_forecast/bot.ts
@@ -29,7 +29,7 @@ export default function load_weather_forecast(bot: LoadBotApi) {
     body: {},
     headers: {
       "Content-Type": "application/json",
-      Cookie: "sessid=" + bot.getSession().getId(),
+      Cookie: "sessid=" + bot.getSession().getAuthToken(),
     },
   })
 

--- a/apps/platform-integration-tests/bundle/bots/runaction/get_weather_forecast/bot.ts
+++ b/apps/platform-integration-tests/bundle/bots/runaction/get_weather_forecast/bot.ts
@@ -29,7 +29,7 @@ export default function get_weather_forecast(bot: RunActionBotApi) {
   }
   const headers = {
     "Content-Type": "application/json",
-    Cookie: "sessid=" + bot.getSession().getId(),
+    Cookie: "sessid=" + bot.getSession().getAuthToken(),
   } as Record<string, string>
   const result = bot.http.request({
     method: "POST",

--- a/apps/platform-integration-tests/bundle/bots/save/save_weather_forecast/bot.ts
+++ b/apps/platform-integration-tests/bundle/bots/save/save_weather_forecast/bot.ts
@@ -27,7 +27,7 @@ export default function save_weather_forecast(bot: SaveBotApi) {
     body: {},
     headers: {
       "Content-Type": "application/json",
-      Cookie: "sessid=" + bot.getSession().getId(),
+      Cookie: "sessid=" + bot.getSession().getAuthToken(),
     },
   })
 

--- a/apps/platform-integration-tests/generated/@types/@uesio/index.d.ts
+++ b/apps/platform-integration-tests/generated/@types/@uesio/index.d.ts
@@ -88,7 +88,7 @@ interface DeletesApi {
   get: () => DeleteApi[]
 }
 interface SessionApi {
-  getId: () => string
+  getAuthToken: () => string
   // Returns true only if the Bot is being run in a Workspace context
   inWorkspaceContext: () => boolean
   // If in a Workspace context, returns a Workspace Api

--- a/apps/platform/pkg/auth/cli_token.go
+++ b/apps/platform/pkg/auth/cli_token.go
@@ -96,7 +96,7 @@ func CLIToken(w http.ResponseWriter, r *http.Request, requestingSession *sess.Se
 		return
 	}
 	browserSession := CreateBrowserSession(w, r, user, site)
-	cliSession, err := GetSessionFromUser(browserSession.ID(), user, site)
+	cliSession, err := GetSessionFromUser(user, site, browserSession.ID())
 	if err != nil {
 		ctlutil.HandleError(r.Context(), w, err)
 		return
@@ -104,7 +104,7 @@ func CLIToken(w http.ResponseWriter, r *http.Request, requestingSession *sess.Se
 
 	DelAuthorizationCode(authCode)
 
-	response := NewTokenResponse(preload.GetUserMergeData(cliSession), cliSession.ID)
+	response := NewTokenResponse(preload.GetUserMergeData(cliSession), cliSession.GetAuthToken())
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(response); err != nil {
 		ctlutil.HandleError(r.Context(), w, fmt.Errorf("failed to encode response: %w", err))

--- a/apps/platform/pkg/auth/login.go
+++ b/apps/platform/pkg/auth/login.go
@@ -28,7 +28,7 @@ func GetResetPasswordRedirectResponse(w http.ResponseWriter, r *http.Request, us
 
 	redirectPath := redirect + "?code=" + code + "&username=" + username
 
-	return NewLoginResponse(preload.GetUserMergeData(session), session.GetSessionID(), redirectPath), nil
+	return NewLoginResponse(preload.GetUserMergeData(session), session.GetAuthToken(), redirectPath), nil
 }
 
 func GetLoginRedirectResponse(w http.ResponseWriter, r *http.Request, user *meta.User, session *sess.Session) (*LoginResponse, error) {
@@ -61,7 +61,7 @@ func GetLoginRedirectResponse(w http.ResponseWriter, r *http.Request, user *meta
 		}
 	}
 
-	return NewLoginResponse(preload.GetUserMergeData(session), session.GetSessionID(), redirectPath), nil
+	return NewLoginResponse(preload.GetUserMergeData(session), session.GetAuthToken(), redirectPath), nil
 }
 
 func LoginRedirectResponse(w http.ResponseWriter, r *http.Request, user *meta.User, session *sess.Session) {

--- a/apps/platform/pkg/auth/responses.go
+++ b/apps/platform/pkg/auth/responses.go
@@ -13,7 +13,7 @@ type UserResponse struct {
 
 type TokenResponse struct {
 	UserResponse
-	SessionID string `json:"sessionId"`
+	Token string `json:"token,omitempty"`
 }
 
 type LoginResponse struct {
@@ -27,22 +27,22 @@ func NewUserResponse(user *preload.UserMergeData) *UserResponse {
 	}
 }
 
-func NewTokenResponse(user *preload.UserMergeData, sessionID string) *TokenResponse {
+func NewTokenResponse(user *preload.UserMergeData, token string) *TokenResponse {
 	return &TokenResponse{
 		UserResponse: UserResponse{
 			User: user,
 		},
-		SessionID: sessionID,
+		Token: token,
 	}
 }
 
-func NewLoginResponse(user *preload.UserMergeData, sessionID string, redirectPath string) *LoginResponse {
+func NewLoginResponse(user *preload.UserMergeData, token string, redirectPath string) *LoginResponse {
 	return &LoginResponse{
 		TokenResponse: TokenResponse{
 			UserResponse: UserResponse{
 				User: user,
 			},
-			SessionID: sessionID,
+			Token: token,
 		},
 		RedirectPath: redirectPath,
 	}

--- a/apps/platform/pkg/auth/site.go
+++ b/apps/platform/pkg/auth/site.go
@@ -62,7 +62,7 @@ func GetPublicSession(site *meta.Site, connection wire.Connection) (*sess.Sessio
 	if err != nil {
 		return nil, err
 	}
-	return CreateSessionFromUser(publicUser, site)
+	return GetSessionFromUser(publicUser, site, "")
 }
 
 func GetSystemUser(site *meta.Site, connection wire.Connection) (*meta.User, error) {
@@ -79,7 +79,7 @@ func GetSystemSession(ctx context.Context, site *meta.Site, connection wire.Conn
 	}
 
 	user.Permissions = meta.GetAdminPermissionSet()
-	session := sess.New("", user, site)
+	session := sess.New(user, site)
 	session.SetGoContext(ctx)
 	return session, nil
 }

--- a/apps/platform/pkg/bot/jsdialect/sessionapi.go
+++ b/apps/platform/pkg/bot/jsdialect/sessionapi.go
@@ -83,10 +83,8 @@ func NewSessionAPI(session *sess.Session) *SessionAPI {
 	}
 }
 
-// NOTE: Intentionally lowercase Id since called from JS dialects
-// TODO: See if goja has a way to map this to getId from GetID so we can change the name and be consistent
-func (s *SessionAPI) GetId() string {
-	return s.session.GetSessionID()
+func (s *SessionAPI) GetAuthToken() string {
+	return s.session.GetAuthToken()
 }
 
 func (s *SessionAPI) InWorkspaceContext() bool {

--- a/apps/platform/pkg/bundlestore/workspacebundlestore/workspacebundlecacheutils.go
+++ b/apps/platform/pkg/bundlestore/workspacebundlestore/workspacebundlecacheutils.go
@@ -66,7 +66,7 @@ func getMinimumViableSession() *sess.Session {
 		FullName: "uesio/core",
 		Name:     "core",
 	}
-	s := sess.New("wsbundlecache", &meta.User{
+	s := sess.New(&meta.User{
 		BuiltIn: meta.BuiltIn{
 			UniqueKey: meta.SystemUsername,
 		},

--- a/apps/platform/pkg/datasource/siteadmincontext_test.go
+++ b/apps/platform/pkg/datasource/siteadmincontext_test.go
@@ -27,14 +27,14 @@ func TestGetSiteAdminSession(t *testing.T) {
 			UniqueKey: "luigi/foo:prod",
 		},
 	}
-	sessWithWorkspaceContext := sess.New("", originalUser, originalSite).SetWorkspaceSession(sess.NewWorkspaceSession(
+	sessWithWorkspaceContext := sess.New(originalUser, originalSite).SetWorkspaceSession(sess.NewWorkspaceSession(
 		&ws,
 		originalUser,
 		"uesio/some.profile",
 		&meta.PermissionSet{},
 	))
-	sessWithSiteAdminContext := sess.New("", originalUser, originalSite).SetSiteAdminSession(sess.NewSiteSession(otherSite, originalUser))
-	plainSession := sess.New("", originalUser, originalSite)
+	sessWithSiteAdminContext := sess.New(originalUser, originalSite).SetSiteAdminSession(sess.NewSiteSession(otherSite, originalUser))
+	plainSession := sess.New(originalUser, originalSite)
 	tests := []struct {
 		name       string
 		input      *sess.Session

--- a/apps/platform/pkg/datasource/workspacecontext_test.go
+++ b/apps/platform/pkg/datasource/workspacecontext_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func sessWithPerms(site *meta.Site, perms *meta.PermissionSet) *sess.Session {
-	return sess.New("", &meta.User{
+	return sess.New(&meta.User{
 		Username:    "luigi",
 		Permissions: perms,
 	}, site)

--- a/apps/platform/pkg/merge/merge_test.go
+++ b/apps/platform/pkg/merge/merge_test.go
@@ -85,8 +85,8 @@ var studioSiteWithoutSubdomain = &meta.Site{
 	App:    studioApp,
 }
 
-var studioSession = sess.New("", studioUser, studioSite)
-var studioSessionWithoutSubdomain = sess.New("", studioUser, studioSiteWithoutSubdomain)
+var studioSession = sess.New(studioUser, studioSite)
+var studioSessionWithoutSubdomain = sess.New(studioUser, studioSiteWithoutSubdomain)
 
 func Test_serverMergeFuncs(t *testing.T) {
 

--- a/apps/platform/pkg/oauth2/state_test.go
+++ b/apps/platform/pkg/oauth2/state_test.go
@@ -40,14 +40,14 @@ func TestStateMarshaling(t *testing.T) {
 		},
 		Name: "prod",
 	}
-	sessWithWorkspaceContext := sess.New("", user, site).SetWorkspaceSession(sess.NewWorkspaceSession(
+	sessWithWorkspaceContext := sess.New(user, site).SetWorkspaceSession(sess.NewWorkspaceSession(
 		&ws,
 		user,
 		"",
 		nil,
 	))
-	sessWithSiteAdminContext := sess.New("", user, site).SetSiteAdminSession(sess.NewSiteSession(otherSite, user))
-	plainSession := sess.New("", user, site)
+	sessWithSiteAdminContext := sess.New(user, site).SetSiteAdminSession(sess.NewSiteSession(otherSite, user))
+	plainSession := sess.New(user, site)
 
 	stateWithWorkspace := (&State{
 		Nonce:           "123",

--- a/apps/platform/pkg/sess/anon.go
+++ b/apps/platform/pkg/sess/anon.go
@@ -7,7 +7,7 @@ import (
 )
 
 func GetAnonSession(ctx context.Context, site *meta.Site) *Session {
-	s := New("", &meta.User{
+	s := New(&meta.User{
 		BuiltIn: meta.BuiltIn{
 			UniqueKey: meta.BootUsername,
 		},

--- a/apps/platform/pkg/sess/session.go
+++ b/apps/platform/pkg/sess/session.go
@@ -7,9 +7,13 @@ import (
 	"github.com/thecloudmasters/uesio/pkg/meta"
 )
 
-func New(ID string, user *meta.User, site *meta.Site) *Session {
+func New(user *meta.User, site *meta.Site) *Session {
+	return NewWithAuthToken(user, site, "")
+}
+
+func NewWithAuthToken(user *meta.User, site *meta.Site, authToken string) *Session {
 	return &Session{
-		ID:          ID,
+		authToken:   authToken,
 		siteSession: NewSiteSession(site, user),
 	}
 }
@@ -118,7 +122,7 @@ func NewVersionSession(
 }
 
 type Session struct {
-	ID               string
+	authToken        string
 	siteSession      *SiteSession
 	workspaceSession *WorkspaceSession
 	siteAdminSession *SiteSession
@@ -474,6 +478,12 @@ func (s *Session) GetContextSite() *meta.Site {
 	return s.GetSite()
 }
 
-func (s *Session) GetSessionID() string {
-	return s.ID
+// This is only required because we allow bots to use it to make calls to the APIs. Based on
+// discussion with @humandad, it was largely added in order to support testing more than a real-world
+// use case. Providing bots the ability to do this comes with pros/cons but there is something to be
+// said for eliminating this completely until a real-world use case arises and a solution fully vetted
+// and designed. For now, leaving this in for backwards compatibility.
+// TODO: Per above, evaluate if this should even exist and if so, if it should be implemented differently.
+func (s *Session) GetAuthToken() string {
+	return s.authToken
 }

--- a/libs/ui/src/public_types/server/index.d.ts
+++ b/libs/ui/src/public_types/server/index.d.ts
@@ -87,7 +87,7 @@ interface DeletesApi {
   get: () => DeleteApi[]
 }
 interface SessionApi {
-  getId: () => string
+  getAuthToken: () => string
   // Returns true only if the Bot is being run in a Workspace context
   inWorkspaceContext: () => boolean
   // If in a Workspace context, returns a Workspace Api


### PR DESCRIPTION
> [!WARNING]
> __BREAKING CHANGE__: The `Session API` function `getId` has been renamed to `getAuthToken`. Any bot related code that utilized `getId` will need to be updated to `getAuthToken`.

# What does this PR do?

Eliminates the "uesio session" `ID` property and adds an `token` property for authentication token.

Previously, the [uesio session](https://github.com/ues-io/uesio/blob/main/apps/platform/pkg/sess/session.go) overloaded the meaning of its `Id` property. Sometimes it was blank, sometimes it was a name (e.g., `wsbundlecache`), sometimes it was a guid and most times, it was an authentication token. What was true all the time is that it was confusing, difficult to discern when to use what and most importantly, put security at risk (e.g., someone could unknowingly log the `ID` thinking it was just an `ID` when really it was an auth token - I did this myself!).

This PR eliminates the `ID` completely primarily because there really is no value in having an `ID` for each session currently. It would be helpful for logging purposes possibly but the current code structure doesn't lend itself to traceability rendering an `ID` pretty much useless in logs. There is the recently added `traceID` in request context now and that should really become the way to trace all requests through their lifecycle (user initiated or background). Work on traceability will be forthcoming but as it stands, session `ID` isn't needed for anything other than logging and traceid should be used instead so `ID` is now gone.

For the situations where `ID` represented an authentication token, a new `GetAuthToken()` function has been added to `Session`. In the cases where `ID` was an auth token, `GetAuthToken()` should be used instead and its intent and meaning is now very clear within the code base.  Along that line, there is something to be said for session not even needing to carry the auth token at all. Based on discussions with @humandad, the main reason it was added was largely to support writing tests so that a test could call an API on the same site avoiding any need of internet connectivity.  That said, there are real world scenarios for allowing bots to call APIs but to my knowledge there are no current use cases for this. For now, leaving the functionality for backwards compat but the inclusion of this should be evaluated and removed if no valid use cases or if there are some, the implementation revisited to ensure it meet the business requirements and does so with security in mind.

# Testing

ci & e2e will cover.
