### PR TITLE
fix: cli auth check during login

### DIFF
--- a/apps/cli/pkg/auth/logout.go
+++ b/apps/cli/pkg/auth/logout.go
@@ -1,36 +1,33 @@
 package auth
 
 import (
-	"encoding/json"
-
 	"github.com/thecloudmasters/cli/pkg/call"
 	"github.com/thecloudmasters/cli/pkg/config"
-	"github.com/thecloudmasters/uesio/pkg/auth"
-	"github.com/thecloudmasters/uesio/pkg/preload"
 )
 
-func Logout() (*preload.UserMergeData, error) {
+func Logout() error {
 
 	token, err := config.GetToken()
 	if err != nil {
-		return nil, err
+		return err
 	}
+	err = logoutToken(token)
+	if err != nil {
+		return err
+	}
+	return config.DeleteToken()
+}
+
+func logoutToken(token string) error {
 	// If there is no current session id, there's no need to make a logout call
 	if token == "" {
-		return nil, nil
+		return nil
 	}
 	resp, err := call.Post("site/auth/logout", nil, token, nil)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	defer resp.Body.Close()
-
-	var userResponse auth.LoginResponse
-
-	if err = json.NewDecoder(resp.Body).Decode(&userResponse); err != nil {
-		return nil, err
-	}
-
-	return userResponse.User, config.DeleteToken()
-
+	// intentionally ignoring
+	_ = resp.Body.Close()
+	return nil
 }

--- a/apps/cli/pkg/auth/server.go
+++ b/apps/cli/pkg/auth/server.go
@@ -231,6 +231,9 @@ func setupLocalServer(cfg *callbackHandlerConfig) (*http.Server, error) {
 				} else {
 					statusCode = http.StatusOK
 				}
+				// TODO: The "login as a different user" flow needs to be improved. One way to do this would be to have the "Authorization Result" page live on the actual site so the localhost page
+				// just redirects to a success/failure page but since it's on the site itself, the standard login/logout mechanisms become more obvious to the user. For now, the HTML emitted provides
+				// instructions that the user must visit the site, logout and then run login from the CLI again. This flow is not ideal and should be improved.
 				data.SiteURL = cfg.siteURL
 				buf := bytes.Buffer{}
 				err = t.Execute(&buf, data)

--- a/apps/cli/pkg/auth/server.go
+++ b/apps/cli/pkg/auth/server.go
@@ -72,7 +72,11 @@ const htmlTemplate = `
 			{{ end }}
 		</p>
 		<p>
-			To login to the CLI as a different user, visit <a href="{{ .SiteURL }}">{{ .SiteURL }}</a>, logout and then login again from the CLI.
+			{{ if .Error }}
+				If you are having trouble logging in, visit <a href="{{ .SiteURL }}">{{ .SiteURL }}</a>, logout and then login again from the CLI.
+			{{ else }}
+				To login to the CLI as a different user, visit <a href="{{ .SiteURL }}">{{ .SiteURL }}</a>, logout and then login again from the CLI.
+			{{ end }}
 		</p>
 	</div>
 </body>

--- a/apps/cli/pkg/auth/server.go
+++ b/apps/cli/pkg/auth/server.go
@@ -73,7 +73,7 @@ const htmlTemplate = `
 		</p>
 		<p>
 			{{ if .Error }}
-				If you are having trouble logging in, visit <a href="{{ .SiteURL }}">{{ .SiteURL }}</a>, logout and then login again from the CLI.
+				If you are having trouble logging in, visit <a href="{{ .SiteURL }}">{{ .SiteURL }}</a>, ensure that you are logged out and then login again from the CLI.
 			{{ else }}
 				To login to the CLI as a different user, visit <a href="{{ .SiteURL }}">{{ .SiteURL }}</a>, logout and then login again from the CLI.
 			{{ end }}

--- a/apps/cli/pkg/command/logout.go
+++ b/apps/cli/pkg/command/logout.go
@@ -8,15 +8,11 @@ import (
 
 func Logout() error {
 
-	user, err := auth.Logout()
+	err := auth.Logout()
 	if err != nil {
 		return err
 	}
 
-	if user == nil {
-		fmt.Println("no current session found")
-		return nil
-	}
 	fmt.Println("successfully logged out user")
 	return nil
 }


### PR DESCRIPTION
# What does this PR do?

In #5033, a "profile" check was removed from the start of login flow and instead, if we had a current user, we just no-op'd the login. However, this created an issue whereby if there is a `token` in config but that token is no longer valid (e.g., it expired), the auth check API returns a "Guest" user. The change in logic meant that we would always get a user back (barring any unforseen failure) and never proceed with login.  The only way to login was to ensure that the local config did not have a 'token' value.

This PR resolves that issue by eliminating the "check" completely.  It's really unnecessary as the user is asking us to login so we should do as they ask - this is the way the majority of CLI login processes work. The alternative is to ask them to logout first if we have an existing token but that seems cumbersome for the user - just proceed with login and if they successfully log in, replace the token in config with the new one (and logout the old token ignoring any failure in doing so).

In addition to solving this issue, the "Authorization Result" HTML was updated to include instructions for users on how to log in as a different user.  If the user is already logged in via their browser, the current flow will go straight through to successful login and update the local token with a token for CLI so there is no way for the user to "choose" who they want to login as. To solve this for now, text was added to the HTML output to inform the user that they should visit the site, logout and then login again via the CLI. This flow is less than ideal but at least provides the user the information needed. This flow should be improved.

# Testing

Tested manually and confirmed all expected behaviors. ci & e2e will cover basics.
