### PR TITLE
chore: samesite should use the default of Lax

### DIFF
--- a/apps/platform/pkg/auth/session.go
+++ b/apps/platform/pkg/auth/session.go
@@ -62,7 +62,6 @@ func init() {
 	BrowserSessionManager.Store = store
 	BrowserSessionManager.Cookie.Name = BrowserSessionCookieName
 	BrowserSessionManager.Cookie.Secure = !allowInsecureCookies
-	BrowserSessionManager.Cookie.SameSite = 0
 	BrowserSessionManager.ErrorFunc = func(w http.ResponseWriter, r *http.Request, err error) {
 		ctlutil.HandleError(r.Context(), w, fmt.Errorf("browser session error: %w", err))
 	}


### PR DESCRIPTION
# What does this PR do?

Cookie SameSite setting should use the default of Lax. Forgot to remove testing code.

# Testing

Manually confirmed Lax is set for the cookie. ci & e2e will cover rest.
