### PR TITLE
chore: do not create browser sessions for public user

### DIFF
--- a/apps/platform-integration-tests/hurl_specs/redirect_to_login_if_workspace_session_invalid.hurl
+++ b/apps/platform-integration-tests/hurl_specs/redirect_to_login_if_workspace_session_invalid.hurl
@@ -13,6 +13,7 @@ HTTP 200
 session_id: cookie "sessid"
 [Asserts]
 cookie "sessid" exists
+cookie "sessid" != ""
 
 # Logout
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/site/auth/logout
@@ -22,6 +23,7 @@ HTTP 200
 session_id_public: cookie "sessid"
 [Asserts]
 cookie "sessid" exists
+cookie "sessid" == ""
 
 # Access a workspace route with an invalid session, requesting HTML
 # @cookie_storage_clear
@@ -61,9 +63,7 @@ Accept: application/json
 HTTP 200
 
 [Asserts]
-cookie "sessid" exists
-cookie "sessid" not contains "{{session_id}}"
-cookie "sessid" not contains "{{session_id_public}}"
+cookie "sessid" not exists
 
 # Attempt to navigate to a public route with a bad session id
 # @cookie_storage_clear

--- a/apps/platform/pkg/middleware/authenticate.go
+++ b/apps/platform/pkg/middleware/authenticate.go
@@ -207,22 +207,7 @@ func createSessionFromBrowserSession(r *http.Request, site *meta.Site) (*sess.Se
 	browserUserID := auth.BrowserSessionManager.GetString(ctx, auth.UserIDKey)
 
 	if browserSiteID == "" && browserUserID == "" {
-		_, err := r.Cookie(auth.BrowserSessionCookieName)
-		if err == http.ErrNoCookie {
-			return auth.HandlePriviledgeChange(ctx, nil, site)
-		}
-		if err != nil {
-			return nil, err
-		}
-		// We have a cookie at this point, however it may be empty or non-empty but we treat them the same. We will create
-		// a uesio session but without a browser session backing it.
-		// IMPORTANT: Passing "" is INTENTIONAL here, we do not want a browser session in this situation in order to
-		// avoid passing a new sessid to client on response.
-		publicUser, err := auth.GetPublicUser(site, nil)
-		if err != nil {
-			return nil, fmt.Errorf("failed to retrieve public user: %w", err)
-		}
-		return auth.GetSessionFromUser(publicUser, site, "")
+		return auth.CreateSessionForPublicUser(site)
 	}
 
 	if browserSiteID != site.ID {


### PR DESCRIPTION
# What does this PR do?

Eliminates creating a browser session for public users.

Previously, we would create a browser session for public users which included storing the siteid along with the public userid in the session cache. However, there are several downsides to this:

1) Every request must go to the cache to get the public user information
2) Every request must retrieve the user from the user cache

This happens on every request (page, js, css, font, etc.) and has no value because all we are doing is storing the information that we know anyway via `GetPublicUser`.

By eliminating creating a browser session for public user, we avoid all the unnecessary session cache operations which will improve performance of the site for public users as well as reduce utilization/cost of the session store (e.g., redis).

# Testing

Tested manually and confirmed no sessions are created as expected. ci & e2e will cover basics.
