### PR TITLE
chore: ensure session always has a context

### DIFF
--- a/apps/platform/pkg/auth/site.go
+++ b/apps/platform/pkg/auth/site.go
@@ -57,12 +57,12 @@ func GetPublicUser(site *meta.Site, connection wire.Connection) (*meta.User, err
 	return GetUserByKey(meta.PublicUsername, sess.GetAnonSession(context.Background(), site), connection)
 }
 
-func GetPublicSession(site *meta.Site, connection wire.Connection) (*sess.Session, error) {
+func GetPublicSession(ctx context.Context, site *meta.Site, connection wire.Connection) (*sess.Session, error) {
 	publicUser, err := GetPublicUser(site, connection)
 	if err != nil {
 		return nil, err
 	}
-	return GetSessionFromUser(publicUser, site, "")
+	return GetSessionFromUser(ctx, publicUser, site, "")
 }
 
 func GetSystemUser(site *meta.Site, connection wire.Connection) (*meta.User, error) {
@@ -79,8 +79,7 @@ func GetSystemSession(ctx context.Context, site *meta.Site, connection wire.Conn
 	}
 
 	user.Permissions = meta.GetAdminPermissionSet()
-	session := sess.New(user, site)
-	session.SetGoContext(ctx)
+	session := sess.New(ctx, user, site)
 	return session, nil
 }
 

--- a/apps/platform/pkg/bot/jsdialect/bothttpapi_test.go
+++ b/apps/platform/pkg/bot/jsdialect/bothttpapi_test.go
@@ -23,17 +23,18 @@ import (
 )
 
 func getIntegrationConnection(authType string, credentials *wire.Credentials) *wire.IntegrationConnection {
-	s := (&sess.Session{}).SetSiteSession(sess.NewSiteSession(&meta.Site{
+	site := &meta.Site{
 		Name: "prod",
 		App: &meta.App{
 			BuiltIn:  meta.BuiltIn{UniqueKey: "luigi/foo"},
 			FullName: "luigi/foo",
 			Name:     "foo",
 		},
-	}, &meta.User{
+	}
+	user := &meta.User{
 		BuiltIn: meta.BuiltIn{ID: "user123"},
-	}))
-	s.SetGoContext(context.Background())
+	}
+	s := sess.New(context.Background(), user, site)
 	return wire.NewIntegrationConnection(
 		&meta.Integration{
 			BundleableBase: meta.BundleableBase{

--- a/apps/platform/pkg/bot/systemdialect/systembot_load_external.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_load_external.go
@@ -178,12 +178,10 @@ func getLoadOp(op *wire.LoadOp, collectionMetadata *wire.CollectionMetadata) (*w
 
 func sameHostLoad(op *wire.LoadOp, connection wire.Connection, site *meta.Site, session *sess.Session) error {
 	// Now get a public session
-	publicSession, err := auth.GetPublicSession(site, connection)
+	publicSession, err := auth.GetPublicSession(session.Context(), site, connection)
 	if err != nil {
 		return err
 	}
-
-	publicSession.SetGoContext(session.Context())
 
 	collectionMetadata, err := op.GetCollectionMetadata()
 	if err != nil {

--- a/apps/platform/pkg/bundlestore/workspacebundlestore/workspacebundlecacheutils.go
+++ b/apps/platform/pkg/bundlestore/workspacebundlestore/workspacebundlecacheutils.go
@@ -66,7 +66,7 @@ func getMinimumViableSession() *sess.Session {
 		FullName: "uesio/core",
 		Name:     "core",
 	}
-	s := sess.New(&meta.User{
+	s := sess.New(context.Background(), &meta.User{
 		BuiltIn: meta.BuiltIn{
 			UniqueKey: meta.SystemUsername,
 		},
@@ -86,7 +86,6 @@ func getMinimumViableSession() *sess.Session {
 		},
 		App: coreApp,
 	})
-	s.SetGoContext(context.Background())
 	return s
 }
 

--- a/apps/platform/pkg/controller/logout.go
+++ b/apps/platform/pkg/controller/logout.go
@@ -56,6 +56,5 @@ func ensurePublicSession(ctx context.Context) (*sess.Session, error) {
 	// controller, etc.) that are all, at some level, "controller" methods given current implementation. Once
 	// things are refactored, context passed throughout the system independently and sess.Sess where applicable,
 	// this can likely go completely away anyway.
-	session.SetGoContext(ctx)
 	return session, nil
 }

--- a/apps/platform/pkg/datasource/siteadmincontext_test.go
+++ b/apps/platform/pkg/datasource/siteadmincontext_test.go
@@ -1,6 +1,7 @@
 package datasource
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -27,14 +28,14 @@ func TestGetSiteAdminSession(t *testing.T) {
 			UniqueKey: "luigi/foo:prod",
 		},
 	}
-	sessWithWorkspaceContext := sess.New(originalUser, originalSite).SetWorkspaceSession(sess.NewWorkspaceSession(
+	sessWithWorkspaceContext := sess.New(context.Background(), originalUser, originalSite).SetWorkspaceSession(sess.NewWorkspaceSession(
 		&ws,
 		originalUser,
 		"uesio/some.profile",
 		&meta.PermissionSet{},
 	))
-	sessWithSiteAdminContext := sess.New(originalUser, originalSite).SetSiteAdminSession(sess.NewSiteSession(otherSite, originalUser))
-	plainSession := sess.New(originalUser, originalSite)
+	sessWithSiteAdminContext := sess.New(context.Background(), originalUser, originalSite).SetSiteAdminSession(sess.NewSiteSession(otherSite, originalUser))
+	plainSession := sess.New(context.Background(), originalUser, originalSite)
 	tests := []struct {
 		name       string
 		input      *sess.Session

--- a/apps/platform/pkg/datasource/workspacecontext_test.go
+++ b/apps/platform/pkg/datasource/workspacecontext_test.go
@@ -1,6 +1,7 @@
 package datasource
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -15,7 +16,7 @@ import (
 )
 
 func sessWithPerms(site *meta.Site, perms *meta.PermissionSet) *sess.Session {
-	return sess.New(&meta.User{
+	return sess.New(context.Background(), &meta.User{
 		Username:    "luigi",
 		Permissions: perms,
 	}, site)

--- a/apps/platform/pkg/merge/merge_test.go
+++ b/apps/platform/pkg/merge/merge_test.go
@@ -1,6 +1,7 @@
 package merge
 
 import (
+	"context"
 	"errors"
 	"reflect"
 	"regexp"
@@ -85,8 +86,8 @@ var studioSiteWithoutSubdomain = &meta.Site{
 	App:    studioApp,
 }
 
-var studioSession = sess.New(studioUser, studioSite)
-var studioSessionWithoutSubdomain = sess.New(studioUser, studioSiteWithoutSubdomain)
+var studioSession = sess.New(context.Background(), studioUser, studioSite)
+var studioSessionWithoutSubdomain = sess.New(context.Background(), studioUser, studioSiteWithoutSubdomain)
 
 func Test_serverMergeFuncs(t *testing.T) {
 

--- a/apps/platform/pkg/middleware/authenticate.go
+++ b/apps/platform/pkg/middleware/authenticate.go
@@ -54,7 +54,7 @@ func Authenticate(next http.Handler) http.Handler {
 				return
 			}
 
-			s, err := auth.GetSessionFromUser(user, site, "")
+			s, err := auth.GetSessionFromUser(ctx, user, site, "")
 			if err != nil {
 				HandleError(ctx, w, fmt.Errorf("failed to create session: %w", err))
 				return
@@ -166,7 +166,7 @@ func createSessionFromBrowserSession(r *http.Request, site *meta.Site) (*sess.Se
 	browserUserID := auth.BrowserSessionManager.GetString(ctx, auth.UserIDKey)
 
 	if browserSiteID == "" && browserUserID == "" {
-		return auth.CreateSessionForPublicUser(site)
+		return auth.CreateSessionForPublicUser(ctx, site)
 	}
 
 	if browserSiteID != site.ID {
@@ -179,7 +179,7 @@ func createSessionFromBrowserSession(r *http.Request, site *meta.Site) (*sess.Se
 
 	user, err := auth.GetCachedUserByID(browserUserID, site)
 	if err == nil {
-		return auth.GetSessionFromUser(user, site, auth.BrowserSessionManager.Token(ctx))
+		return auth.GetSessionFromUser(ctx, user, site, auth.BrowserSessionManager.Token(ctx))
 	}
 
 	if exceptions.IsType[*exceptions.NotFoundException](err) {

--- a/apps/platform/pkg/middleware/context.go
+++ b/apps/platform/pkg/middleware/context.go
@@ -32,12 +32,6 @@ func SetError(c context.Context, err error) {
 
 func setSession(ctx context.Context, s *sess.Session) {
 	setLogSession(ctx, s)
-	// attach the Go context to the session so that we can access the request context from basically anywhere.
-	// This was done because it was deemed less invasive than refactoring all of our code to pass a context around,
-	// since we already have a Session basically everywhere.
-	// Ideally, we would have a context.Context in virtually all of our Go method calls,
-	// but I leave that for another day, since it would be very time-consuming to refactor all of our Go method calls.
-	s.SetGoContext(ctx)
 }
 
 // Sets session data on logData for the current context that can be accessed by middleware

--- a/apps/platform/pkg/oauth2/authorizationcode_test.go
+++ b/apps/platform/pkg/oauth2/authorizationcode_test.go
@@ -42,8 +42,7 @@ func TestAuthorizationCodeFlow(t *testing.T) {
 	var requestAsserts func(t *testing.T, request *http.Request)
 
 	integrationName := "luigi/foo.bar"
-	session := &sess.Session{}
-	session.SetGoContext(context.Background())
+	session := sess.New(context.Background(), nil, nil)
 
 	// set up a mock server to handle our test requests
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/apps/platform/pkg/oauth2/state_test.go
+++ b/apps/platform/pkg/oauth2/state_test.go
@@ -1,6 +1,7 @@
 package oauth2
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -40,14 +41,14 @@ func TestStateMarshaling(t *testing.T) {
 		},
 		Name: "prod",
 	}
-	sessWithWorkspaceContext := sess.New(user, site).SetWorkspaceSession(sess.NewWorkspaceSession(
+	sessWithWorkspaceContext := sess.New(context.Background(), user, site).SetWorkspaceSession(sess.NewWorkspaceSession(
 		&ws,
 		user,
 		"",
 		nil,
 	))
-	sessWithSiteAdminContext := sess.New(user, site).SetSiteAdminSession(sess.NewSiteSession(otherSite, user))
-	plainSession := sess.New(user, site)
+	sessWithSiteAdminContext := sess.New(context.Background(), user, site).SetSiteAdminSession(sess.NewSiteSession(otherSite, user))
+	plainSession := sess.New(context.Background(), user, site)
 
 	stateWithWorkspace := (&State{
 		Nonce:           "123",

--- a/apps/platform/pkg/sess/anon.go
+++ b/apps/platform/pkg/sess/anon.go
@@ -7,7 +7,7 @@ import (
 )
 
 func GetAnonSession(ctx context.Context, site *meta.Site) *Session {
-	s := New(&meta.User{
+	s := New(ctx, &meta.User{
 		BuiltIn: meta.BuiltIn{
 			UniqueKey: meta.BootUsername,
 		},
@@ -16,7 +16,6 @@ func GetAnonSession(ctx context.Context, site *meta.Site) *Session {
 		LastName:    "User",
 		Permissions: meta.GetAdminPermissionSet(),
 	}, site)
-	s.SetGoContext(ctx)
 	return s
 }
 


### PR DESCRIPTION
# What does this PR do?

Ensures that session always has a context.

Previously, while a session normally had a non-nil context set via `SetGoContext`, it did not always have a context.  The context property was added to Session in [this commit](https://github.com/ues-io/uesio/pull/3619/files#diff-b50d36d253129bd263753674a60b24374b3b91b19cd0b492aa4c0d700bf1c885R28). As the comment in that commit indicates, it was added as an alternative to changing all the APIs to accept a context.  

The approach taken, while understandable, has led to the code morphing and having a couple of significant shortcomings:

1. Session doesn't always have a context
2. Session passed around during request processing can change (e.g., ensurePublicSession) which could result, mainly unintentionally, in multiple contexts involved in the processing of a request
3. Connection also has an embedded context and often session and connection are passed to the same function - so which one to use?  While they, in theory, should be the same, there's no way to guarantee this so again, multiple contexts can be involved in request processing
4. PlatformBundleStore maintains a singleton connection which has a background context. This causes issues because any code that uses connection.context from it will be using a different context than the session context which came from the request context - again, multiple contexts involved in processing a request

In short, the APIs need to change and explicitly receive a context that should be used so that an entire request flow is using the original context (or background context if a non-HTTP request).

This PR is the first step of several to get to a refactored API by starting with ensuring that every Session has a context which should be the first choice downstream when available.

# Testing

e2e and ci will cover.
