### PR TITLE
chore: improve cli login

### DIFF
--- a/apps/cli/pkg/auth/login.go
+++ b/apps/cli/pkg/auth/login.go
@@ -234,7 +234,7 @@ func processDirectLogin(method string, payload map[string]string) (*auth.TokenRe
 		return nil, err
 	}
 
-	url := fmt.Sprintf("site/auth/%s/%s/login", methodNamespace, methodName)
+	url := fmt.Sprintf("site/auth/cli/%s/%s/login", methodNamespace, methodName)
 
 	resp, err := call.Post(url, payloadBytes, "", nil)
 	if err != nil {
@@ -242,14 +242,14 @@ func processDirectLogin(method string, payload map[string]string) (*auth.TokenRe
 	}
 	defer resp.Body.Close()
 
-	var loginResponse auth.LoginResponse
+	var tokenResponse auth.TokenResponse
 
-	err = json.NewDecoder(resp.Body).Decode(&loginResponse)
+	err = json.NewDecoder(resp.Body).Decode(&tokenResponse)
 	if err != nil {
 		return nil, err
 	}
 
-	return auth.NewTokenResponse(loginResponse.User, loginResponse.Token), nil
+	return auth.NewTokenResponse(tokenResponse.User, tokenResponse.Token), nil
 }
 
 func getLoginHandler() (*LoginMethodHandler, error) {

--- a/apps/cli/pkg/call/call.go
+++ b/apps/cli/pkg/call/call.go
@@ -72,7 +72,12 @@ func Request(r *RequestSpec) (*http.Response, error) {
 		case http.StatusNotFound:
 			return nil, exceptions.NewNotFoundException("resource not found")
 		case http.StatusForbidden, http.StatusUnauthorized:
-			return nil, exceptions.NewForbiddenException("permission denied")
+			return nil, exceptions.NewForbiddenException(string(data))
+		case http.StatusBadRequest:
+			// intentionally not using NewBadRequestException here because the data already contains the text "bad request: ..." and using
+			// BadRequestException again would emit "bad request:" twice.
+			// TODO: Consider BadRequestException not prefixing the message with "bad request:"
+			return nil, errors.New(string(data))
 		default:
 			return nil, fmt.Errorf("request to %v failed with status code %v: '%v'", resp.Request.URL, resp.StatusCode, string(data))
 		}

--- a/apps/platform/pkg/auth/auth.go
+++ b/apps/platform/pkg/auth/auth.go
@@ -46,6 +46,7 @@ type AuthConnection interface {
 	// assertion to Assertion would fail but this ensures we only get Assertions from SP's that have validated
 	// them and not through any POST operation that might flow through /login.
 	LoginServiceProvider(*saml.Assertion) (*LoginResult, error)
+	LoginCLI(AuthRequest) (*LoginResult, error)
 	Signup(*meta.SignupMethod, map[string]any, string) error
 	ConfirmSignUp(*meta.SignupMethod, map[string]any) error
 	ResetPassword(map[string]any, bool) (*meta.LoginMethod, error)

--- a/apps/platform/pkg/auth/google/googleauth.go
+++ b/apps/platform/pkg/auth/google/googleauth.go
@@ -95,6 +95,10 @@ func (c *Connection) Login(loginRequest auth.AuthRequest) (*auth.LoginResult, er
 	}, nil
 }
 
+func (c *Connection) LoginCLI(loginRequest auth.AuthRequest) (*auth.LoginResult, error) {
+	return nil, exceptions.NewBadRequestException("google login: cli login is not supported, please use browser", nil)
+}
+
 func (c *Connection) DoLogin(payload map[string]any) (*meta.User, *meta.LoginMethod, error) {
 	validated, err := c.Validate(payload)
 	if err != nil {

--- a/apps/platform/pkg/auth/mock/mockauth.go
+++ b/apps/platform/pkg/auth/mock/mockauth.go
@@ -71,3 +71,6 @@ func (c *Connection) GetServiceProvider(r *http.Request) (*samlsp.Middleware, er
 func (c *Connection) LoginServiceProvider(assertion *saml.Assertion) (*auth.LoginResult, error) {
 	return nil, errors.New("saml auth login is not supported by this auth source type")
 }
+func (c *Connection) LoginCLI(loginRequest auth.AuthRequest) (*auth.LoginResult, error) {
+	return c.Login(loginRequest)
+}

--- a/apps/platform/pkg/auth/platform/platform.go
+++ b/apps/platform/pkg/auth/platform/platform.go
@@ -152,7 +152,7 @@ func (c *Connection) DoLogin(payload map[string]any) (*meta.User, *meta.LoginMet
 	}
 
 	if loginmethod.VerificationCode != "" {
-		return nil, nil, exceptions.NewUnauthorizedException("unable to login - your email address has not yet been verified")
+		return nil, nil, exceptions.NewUnauthorizedException("unable to login - your email address has not yet been verified, please check your email for a verification code")
 	}
 
 	err = bcrypt.CompareHashAndPassword([]byte(loginmethod.Hash), []byte(plainPassword))
@@ -453,4 +453,7 @@ func (c *Connection) GetServiceProvider(r *http.Request) (*samlsp.Middleware, er
 }
 func (c *Connection) LoginServiceProvider(assertion *saml.Assertion) (*auth.LoginResult, error) {
 	return nil, errors.New("saml auth login is not supported by this auth source type")
+}
+func (c *Connection) LoginCLI(loginRequest auth.AuthRequest) (*auth.LoginResult, error) {
+	return c.Login(loginRequest)
 }

--- a/apps/platform/pkg/auth/responses.go
+++ b/apps/platform/pkg/auth/responses.go
@@ -23,7 +23,7 @@ type TokenResponse struct {
 }
 
 type LoginResponse struct {
-	TokenResponse
+	UserResponse
 	RedirectPath string `json:"redirectPath,omitempty"`
 }
 
@@ -42,13 +42,10 @@ func NewTokenResponse(user *preload.UserMergeData, token string) *TokenResponse 
 	}
 }
 
-func NewLoginResponse(user *preload.UserMergeData, token string, redirectPath string) *LoginResponse {
+func NewLoginResponse(user *preload.UserMergeData, redirectPath string) *LoginResponse {
 	return &LoginResponse{
-		TokenResponse: TokenResponse{
-			UserResponse: UserResponse{
-				User: user,
-			},
-			Token: token,
+		UserResponse: UserResponse{
+			User: user,
 		},
 		RedirectPath: redirectPath,
 	}
@@ -61,7 +58,7 @@ func NewLoginResponseFromRoute(user *preload.UserMergeData, session *sess.Sessio
 	if err != nil {
 		return nil, err
 	}
-	return NewLoginResponse(user, session.GetAuthToken(), redirectPath), nil
+	return NewLoginResponse(user, redirectPath), nil
 }
 
 func getRouteUrlPrefix(route *meta.Route, session *sess.Session) []string {

--- a/apps/platform/pkg/auth/samlauth/samlauth.go
+++ b/apps/platform/pkg/auth/samlauth/samlauth.go
@@ -192,3 +192,6 @@ func (c *Connection) LoginServiceProvider(assertion *saml.Assertion) (*auth.Logi
 		PasswordReset: false,
 	}, nil
 }
+func (c *Connection) LoginCLI(loginRequest auth.AuthRequest) (*auth.LoginResult, error) {
+	return nil, exceptions.NewBadRequestException("SAML login: cli login is not supported, please use browser", nil)
+}

--- a/apps/platform/pkg/cmd/serve.go
+++ b/apps/platform/pkg/cmd/serve.go
@@ -350,6 +350,7 @@ func serve(cmd *cobra.Command, args []string) error {
 	//      become a studio specific route within studio itself associated to a studio bot.
 	sr.HandleFunc("/auth/cli/authorize", controller.CLIAuthorize).Methods("GET")
 	sr.HandleFunc("/auth/cli/token", controller.CLIToken).Methods("POST")
+	sr.HandleFunc("/auth/cli/"+itemParam+"/login", controller.CLILogin).Methods("POST")
 
 	// Experimental REST api route
 	sr.HandleFunc("/rest/"+itemParam, controller.Rest).Methods("GET")


### PR DESCRIPTION
# What does this PR do?

With the recent refactoring of auth flows, there is an opportunity to improve the CLI login for `mock/platform` logins to target the CLI specifically as the client.  Previously, these flows called the same endpoints as the web based login flows and therefore received responses as if they were a web client - but the CLI is not a web client :)  The refactoring provides the opportunity to orchestrate a different flow for the CLI.  One example of why this was needed is because the web based login returns an HTTP 200 with `redirectPath` when a users account requires a password reset.  The CLI doesn't expect a redirectPath and since the status was 200, didn't know what to do since there was no token returned.

This PR does three things:
1. Adds new a new `auth/cli/<provider>/login` route for CLI logins and returns proper results, including meaningful errors that can be evaluated by the CLI to surface to the user.
2. Removes the `token` property in the standard login response body for the web based login - including it in the body was never necessary other than for the CLI since it shared the exact same login orchestration.
3. Improves the output of error messages in the CLI when making http requests

# Testing

tested manually and confirmed error messages and successful login as expected. ci & e2e will cover rest.
