### PR TITLE
chore: add traceid to background contexts

### DIFF
--- a/apps/cli/go.mod
+++ b/apps/cli/go.mod
@@ -25,9 +25,11 @@ require (
 	github.com/francoispqt/gojay v1.2.13 // indirect
 	github.com/go-chi/chi/v5 v5.2.2 // indirect
 	github.com/go-chi/httplog/v3 v3.2.2 // indirect
+	github.com/go-chi/traceid v0.3.0 // indirect
 	github.com/gofrs/uuid/v5 v5.3.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
 	github.com/gomodule/redigo v1.9.2 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect

--- a/apps/cli/go.sum
+++ b/apps/cli/go.sum
@@ -87,6 +87,8 @@ github.com/go-chi/chi/v5 v5.2.2 h1:CMwsvRVTbXVytCk1Wd72Zy1LAsAh9GxMmSNWLHCG618=
 github.com/go-chi/chi/v5 v5.2.2/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=
 github.com/go-chi/httplog/v3 v3.2.2 h1:G0oYv3YYcikNjijArHFUlqfR78cQNh9fGT43i6StqVc=
 github.com/go-chi/httplog/v3 v3.2.2/go.mod h1:N/J1l5l1fozUrqIVuT8Z/HzNeSy8TF2EFyokPLe6y2w=
+github.com/go-chi/traceid v0.3.0 h1:BYITxMnIeQasU7/U7+InZWANWxVZeCUBGTAqWleQOeg=
+github.com/go-chi/traceid v0.3.0/go.mod h1:XFfEEYZjqgML4ySh+wYBU29eqJkc2um7oEzgIc63e74=
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
 github.com/gofrs/uuid/v5 v5.3.2 h1:2jfO8j3XgSwlz/wHqemAEugfnTlikAYHhnqQ8Xh4fE0=
 github.com/gofrs/uuid/v5 v5.3.2/go.mod h1:CDOjlDMVAtN56jqyRUZh58JT31Tiw7/oQyEXZV+9bD8=
@@ -120,6 +122,8 @@ github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+u
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go v2.0.0+incompatible/go.mod h1:SFVmujtThgffbyetf+mdk2eWhX2bMyUtNHzFKcPA9HY=
 github.com/googleapis/gax-go/v2 v2.0.3/go.mod h1:LLvjysVCY1JZeum8Z6l8qUty8fiNwE08qbEPm1M08qg=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=

--- a/apps/platform/pkg/auth/auth.go
+++ b/apps/platform/pkg/auth/auth.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/crewjam/saml"
 	"github.com/crewjam/saml/samlsp"
+	"github.com/go-chi/traceid"
 	"github.com/thecloudmasters/uesio/pkg/bundle"
 	"github.com/thecloudmasters/uesio/pkg/configstore"
 	"github.com/thecloudmasters/uesio/pkg/constant/commonfields"
@@ -163,7 +164,7 @@ func GetSiteFromHost(host string) (*meta.Site, error) {
 	site.Subdomain = subdomain
 	site.Scheme = tls.ServeAppDefaultScheme()
 
-	bundleDef, err := bundle.GetSiteBundleDef(context.Background(), site, nil)
+	bundleDef, err := bundle.GetSiteBundleDef(traceid.NewContext(context.Background()), site, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/apps/platform/pkg/auth/samlauth/samlauth.go
+++ b/apps/platform/pkg/auth/samlauth/samlauth.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/crewjam/saml"
 	"github.com/crewjam/saml/samlsp"
+	"github.com/go-chi/traceid"
 	"github.com/thecloudmasters/uesio/pkg/auth"
 
 	"github.com/thecloudmasters/uesio/pkg/meta"
@@ -93,7 +94,7 @@ func (c *Connection) getSPInternal(requestURL string) (*samlsp.Middleware, error
 			return nil, err
 		}
 
-		idpMetadata, err = samlsp.FetchMetadata(context.Background(), http.DefaultClient,
+		idpMetadata, err = samlsp.FetchMetadata(traceid.NewContext(context.Background()), http.DefaultClient,
 			*idpMetadataURL)
 		if err != nil {
 			return nil, err

--- a/apps/platform/pkg/auth/session.go
+++ b/apps/platform/pkg/auth/session.go
@@ -8,6 +8,7 @@ import (
 
 	"golang.org/x/crypto/bcrypt"
 
+	"github.com/go-chi/traceid"
 	"github.com/thecloudmasters/uesio/pkg/datasource"
 	"github.com/thecloudmasters/uesio/pkg/meta"
 	"github.com/thecloudmasters/uesio/pkg/sess"
@@ -23,7 +24,7 @@ func GetUserFromAuthToken(token string, site *meta.Site) (*meta.User, error) {
 	id := cutToken[:8]
 	key := cutToken[8:]
 
-	adminSession := sess.GetAnonSession(context.Background(), site)
+	adminSession := sess.GetAnonSession(traceid.NewContext(context.Background()), site)
 	loginmethod, err := GetLoginMethod(id, "uesio/core.apikey", nil, adminSession)
 	if err != nil || loginmethod == nil {
 		return nil, exceptions.NewBadRequestException("the api key you are trying to log in with does not exist", nil)
@@ -63,7 +64,7 @@ func GetCachedUserByID(userid string, site *meta.Site) (*meta.User, error) {
 		return cachedUser, nil
 	}
 
-	s := sess.GetAnonSession(context.Background(), site)
+	s := sess.GetAnonSession(traceid.NewContext(context.Background()), site)
 
 	user, err := GetUserWithPictureByID(userid, s, nil)
 	if err != nil {

--- a/apps/platform/pkg/auth/site.go
+++ b/apps/platform/pkg/auth/site.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/go-chi/traceid"
 	"github.com/thecloudmasters/uesio/pkg/datasource"
 	"github.com/thecloudmasters/uesio/pkg/meta"
 	"github.com/thecloudmasters/uesio/pkg/sess"
@@ -31,7 +32,7 @@ func getDomain(domainType, domain string) (*meta.SiteDomain, error) {
 				},
 			},
 		},
-		sess.GetStudioAnonSession(context.Background()),
+		sess.GetStudioAnonSession(traceid.NewContext(context.Background())),
 	)
 	if err != nil {
 		return nil, err
@@ -47,14 +48,14 @@ func querySiteFromDomain(domainType, domain string) (*meta.Site, error) {
 	if siteDomain == nil {
 		return nil, errors.New("no site domain record for that host")
 	}
-	return datasource.QuerySiteByID(siteDomain.Site.ID, sess.GetStudioAnonSession(context.Background()), nil)
+	return datasource.QuerySiteByID(siteDomain.Site.ID, sess.GetStudioAnonSession(traceid.NewContext(context.Background())), nil)
 }
 
 func GetPublicUser(site *meta.Site, connection wire.Connection) (*meta.User, error) {
 	if site == nil {
 		return nil, errors.New("no site provided")
 	}
-	return GetUserByKey(meta.PublicUsername, sess.GetAnonSession(context.Background(), site), connection)
+	return GetUserByKey(meta.PublicUsername, sess.GetAnonSession(traceid.NewContext(context.Background()), site), connection)
 }
 
 func GetPublicSession(ctx context.Context, site *meta.Site, connection wire.Connection) (*sess.Session, error) {
@@ -69,7 +70,7 @@ func GetSystemUser(site *meta.Site, connection wire.Connection) (*meta.User, err
 	if site == nil {
 		return nil, errors.New("no site provided")
 	}
-	return GetUserByKey(meta.SystemUsername, sess.GetAnonSession(context.Background(), site), connection)
+	return GetUserByKey(meta.SystemUsername, sess.GetAnonSession(traceid.NewContext(context.Background()), site), connection)
 }
 
 func GetSystemSession(ctx context.Context, site *meta.Site, connection wire.Connection) (*sess.Session, error) {

--- a/apps/platform/pkg/bundle/bundles.go
+++ b/apps/platform/pkg/bundle/bundles.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/go-chi/traceid"
 	"github.com/thecloudmasters/uesio/pkg/bundlestore"
 	"github.com/thecloudmasters/uesio/pkg/meta"
 	"github.com/thecloudmasters/uesio/pkg/sess"
@@ -98,7 +99,7 @@ func GetBundleStoreConnection(namespace string, session *sess.Session, connectio
 	} else if connection != nil {
 		ctx = connection.Context()
 	} else {
-		ctx = context.Background()
+		ctx = traceid.NewContext(traceid.NewContext(context.Background()))
 	}
 	return bundlestore.GetConnection(bundlestore.ConnectionOptions{
 		Context:      ctx,

--- a/apps/platform/pkg/bundlestore/platformbundlestore/platformbundlestore.go
+++ b/apps/platform/pkg/bundlestore/platformbundlestore/platformbundlestore.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/go-chi/traceid"
 	"github.com/thecloudmasters/uesio/pkg/bundle"
 	"github.com/thecloudmasters/uesio/pkg/bundlestore"
 	"github.com/thecloudmasters/uesio/pkg/bundlestore/filebundlestore"
@@ -20,7 +21,7 @@ var bundleStoreCache *bundle.BundleStoreCache
 var platformFileConnection file.Connection
 
 var initConnection = sync.OnceValues(func() (file.Connection, error) {
-	return fileadapt.GetFileConnection("uesio/core.bundlestore", sess.GetStudioAnonSession(context.Background()))
+	return fileadapt.GetFileConnection("uesio/core.bundlestore", sess.GetStudioAnonSession(traceid.NewContext(context.Background())))
 })
 
 func init() {

--- a/apps/platform/pkg/bundlestore/workspacebundlestore/workspacebundlecacheutils.go
+++ b/apps/platform/pkg/bundlestore/workspacebundlestore/workspacebundlecacheutils.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/go-chi/traceid"
 	"github.com/thecloudmasters/uesio/pkg/adapt"
 	"github.com/thecloudmasters/uesio/pkg/bundle"
 	"github.com/thecloudmasters/uesio/pkg/datasource"
@@ -66,7 +67,7 @@ func getMinimumViableSession() *sess.Session {
 		FullName: "uesio/core",
 		Name:     "core",
 	}
-	s := sess.New(context.Background(), &meta.User{
+	s := sess.New(traceid.NewContext(context.Background()), &meta.User{
 		BuiltIn: meta.BuiltIn{
 			UniqueKey: meta.SystemUsername,
 		},

--- a/apps/platform/pkg/cmd/migrate.go
+++ b/apps/platform/pkg/cmd/migrate.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"strconv"
 
+	"github.com/go-chi/traceid"
 	"github.com/spf13/cobra"
 
 	"github.com/thecloudmasters/uesio/pkg/datasource"
@@ -90,8 +91,8 @@ func newMigrateDownOptions() migrations.MigrateOptions {
 }
 
 func migrate(opts *migrations.MigrateOptions) error {
-
-	ctx := context.Background()
+	ctx := traceid.NewContext(context.Background())
+	slog.InfoContext(ctx, "Running migration(s)")
 
 	anonSession := sess.GetStudioAnonSession(ctx)
 
@@ -102,7 +103,7 @@ func migrate(opts *migrations.MigrateOptions) error {
 		return fmt.Errorf("migrations failed: %w", err)
 	}
 
-	slog.InfoContext(ctx, "Successfully ran migrations")
+	slog.InfoContext(ctx, "Successfully ran migration(s)")
 	return nil
 }
 

--- a/apps/platform/pkg/cmd/seed.go
+++ b/apps/platform/pkg/cmd/seed.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/go-chi/traceid"
 	"github.com/spf13/cobra"
 
 	"github.com/thecloudmasters/uesio/pkg/auth"
@@ -145,12 +146,10 @@ func runSeeds(ctx context.Context, connection wire.Connection) error {
 }
 
 func seed(cmd *cobra.Command, args []string) error {
-
-	slog.Info("Running seeds")
+	ctx := traceid.NewContext(context.Background())
+	slog.InfoContext(ctx, "Running seeds")
 
 	ignoreSeedFailures, _ := cmd.Flags().GetBool("ignore-failures")
-
-	ctx := context.Background()
 
 	anonSession := sess.GetStudioAnonSession(ctx)
 

--- a/apps/platform/pkg/controller/ctlutil/errors.go
+++ b/apps/platform/pkg/controller/ctlutil/errors.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/go-chi/httplog/v3"
+	"github.com/go-chi/traceid"
 	httputil "github.com/thecloudmasters/uesio/pkg/http"
 )
 
@@ -56,7 +57,7 @@ func HandleTrailingError(ctx context.Context, w http.ResponseWriter, err error) 
 }
 
 func AddTrailingStatus(w http.ResponseWriter) {
-	AddTrailingStatusContext(context.Background(), w)
+	AddTrailingStatusContext(traceid.NewContext(context.Background()), w)
 }
 
 func AddTrailingStatusContext(ctx context.Context, w http.ResponseWriter) {

--- a/apps/platform/pkg/datasource/domain.go
+++ b/apps/platform/pkg/datasource/domain.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/go-chi/traceid"
 	"github.com/thecloudmasters/uesio/pkg/meta"
 	"github.com/thecloudmasters/uesio/pkg/sess"
 	"github.com/thecloudmasters/uesio/pkg/tls"
@@ -32,7 +33,7 @@ func QueryDomainFromSite(siteID string, connection wire.Connection) (*meta.SiteD
 			BatchSize:  1,
 			Connection: connection,
 		},
-		sess.GetStudioAnonSession(context.Background()),
+		sess.GetStudioAnonSession(traceid.NewContext(context.Background())),
 	)
 	if err != nil {
 		return nil, err

--- a/apps/platform/pkg/datasource/licensing.go
+++ b/apps/platform/pkg/datasource/licensing.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/go-chi/traceid"
 	"github.com/thecloudmasters/uesio/pkg/cache"
 	"github.com/thecloudmasters/uesio/pkg/constant/commonfields"
 	"github.com/thecloudmasters/uesio/pkg/meta"
@@ -61,7 +62,7 @@ func GetLicenses(namespace string, connection wire.Connection) (LicenseMap, erro
 	if ok {
 		return licenseMap, nil
 	}
-	anonSession := sess.GetStudioAnonSession(context.Background())
+	anonSession := sess.GetStudioAnonSession(traceid.NewContext(context.Background()))
 	app := meta.App{}
 	err := PlatformLoadOne(&app, &PlatformLoadOptions{
 		Connection: connection,

--- a/apps/platform/pkg/invoices/invoices.go
+++ b/apps/platform/pkg/invoices/invoices.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-chi/traceid"
 	"github.com/thecloudmasters/uesio/pkg/auth"
 	"github.com/thecloudmasters/uesio/pkg/datasource"
 	"github.com/thecloudmasters/uesio/pkg/meta"
@@ -17,7 +18,7 @@ import (
 )
 
 func InvoicingJobNoContext() error {
-	return InvoicingJob(context.Background())
+	return InvoicingJob(traceid.NewContext(context.Background()))
 }
 
 func InvoicingJob(ctx context.Context) error {

--- a/apps/platform/pkg/usage/usage_worker/usage_worker.go
+++ b/apps/platform/pkg/usage/usage_worker/usage_worker.go
@@ -5,12 +5,13 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/go-chi/traceid"
 	"github.com/thecloudmasters/uesio/pkg/auth"
 	"github.com/thecloudmasters/uesio/pkg/usage"
 )
 
 func UsageWorkerNoContext() error {
-	return UsageWorker(context.Background())
+	return UsageWorker(traceid.NewContext(context.Background()))
 }
 
 func UsageWorker(ctx context.Context) error {


### PR DESCRIPTION
# What does this PR do?

What this does: Adds a traceid for log correlation to places where we use a background context.

What this does NOT do: 
1. Fix the underlying issues with use of background context - in most places that we currently use one, we should not be and instead using session.Context()/request.Context()
2. Ensure that slog statements are using the *Context variants so that the traceid will actually appear in the logs

More PRs coming on improving the flow and use of contexts, this is just the next step.

# Testing

ci & e2e will cover.
