### PR TITLE
chore: eliminate context from connection types

### DIFF
--- a/apps/cli/pkg/config/app.go
+++ b/apps/cli/pkg/config/app.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/thecloudmasters/cli/pkg/localbundlestore"
@@ -12,7 +13,7 @@ func GetApp() (string, error) {
 	sbs := &localbundlestore.LocalBundleStore{}
 	conn := sbs.GetConnection(bundlestore.ConnectionOptions{})
 
-	def, err := conn.GetBundleDef()
+	def, err := conn.GetBundleDef(context.Background())
 	if err != nil {
 		return "", err
 	}
@@ -25,7 +26,7 @@ func GetVersion(namespace string) (string, error) {
 	sbs := &localbundlestore.LocalBundleStore{}
 	conn := sbs.GetConnection(bundlestore.ConnectionOptions{})
 
-	def, err := conn.GetBundleDef()
+	def, err := conn.GetBundleDef(context.Background())
 	if err != nil {
 		return "", err
 	}

--- a/apps/cli/pkg/pack/entryfiles.go
+++ b/apps/cli/pkg/pack/entryfiles.go
@@ -1,6 +1,7 @@
 package pack
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -21,10 +22,11 @@ func fileExists(path string) bool {
 }
 
 func CreateEntryFiles() (map[string]string, error) {
+	ctx := context.Background()
 	sbs := &localbundlestore.LocalBundleStore{}
 	conn := sbs.GetConnection(bundlestore.ConnectionOptions{})
 
-	def, err := conn.GetBundleDef()
+	def, err := conn.GetBundleDef(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -33,13 +35,13 @@ func CreateEntryFiles() (map[string]string, error) {
 	namespace := def.Name
 
 	components := &meta.ComponentCollection{}
-	err = conn.GetAllItems(components, nil)
+	err = conn.GetAllItems(ctx, components, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	utilities := &meta.UtilityCollection{}
-	err = conn.GetAllItems(utilities, nil)
+	err = conn.GetAllItems(ctx, utilities, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/apps/cli/pkg/param/param.go
+++ b/apps/cli/pkg/param/param.go
@@ -1,6 +1,7 @@
 package param
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -26,7 +27,7 @@ import (
 )
 
 func getMetadataList(metadataType, token, grouping string) (labels []string, valuesByLabel map[string]string, err error) {
-
+	ctx := context.Background()
 	if metadataType == "" {
 		return nil, nil, errors.New("no metadata type provided for prompt")
 	}
@@ -50,12 +51,12 @@ func getMetadataList(metadataType, token, grouping string) (labels []string, val
 	sbs := &localbundlestore.LocalBundleStore{}
 	conn := sbs.GetConnection(bundlestore.ConnectionOptions{})
 
-	def, err := conn.GetBundleDef()
+	def, err := conn.GetBundleDef(ctx)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	err = conn.GetAllItems(group, &bundlestore.GetAllItemsOptions{
+	err = conn.GetAllItems(ctx, group, &bundlestore.GetAllItemsOptions{
 		Conditions: conditions,
 	})
 	if err != nil {

--- a/apps/platform/pkg/adapt/postgresio/get_tokens.go
+++ b/apps/platform/pkg/adapt/postgresio/get_tokens.go
@@ -1,6 +1,7 @@
 package postgresio
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/jackc/pgx/v5"
@@ -10,10 +11,10 @@ import (
 
 const TOKEN_QUERY = "SELECT token FROM public.tokens WHERE recordid = $1 AND tenant = $2"
 
-func (c *Connection) GetRecordAccessTokens(recordID string, session *sess.Session) ([]string, error) {
+func (c *Connection) GetRecordAccessTokens(ctx context.Context, recordID string, session *sess.Session) ([]string, error) {
 	c.mux.Lock()
 	defer c.mux.Unlock()
-	rows, err := c.GetClient().Query(c.ctx, TOKEN_QUERY, recordID, session.GetTenantID())
+	rows, err := c.GetClient().Query(ctx, TOKEN_QUERY, recordID, session.GetTenantID())
 	if err != nil {
 		return nil, fmt.Errorf("failed to load tokens: %w", err)
 	}

--- a/apps/platform/pkg/adapt/postgresio/load.go
+++ b/apps/platform/pkg/adapt/postgresio/load.go
@@ -1,6 +1,7 @@
 package postgresio
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strconv"
@@ -183,7 +184,7 @@ func getAliasedName(name, alias string) string {
 	return fmt.Sprintf("%s.%s", alias, name)
 }
 
-func (c *Connection) Load(op *wire.LoadOp, session *sess.Session) error {
+func (c *Connection) Load(ctx context.Context, op *wire.LoadOp, session *sess.Session) error {
 
 	// If we're loading uesio/core.user from a workspace, always use the site
 	// tenant id, not the workspace tenant id. Since workspaces don't have users.
@@ -341,9 +342,9 @@ func (c *Connection) Load(op *wire.LoadOp, session *sess.Session) error {
 	//fmt.Println(builder.Values)
 
 	op.HasMoreBatches = false
-	formulaPopulations := formula.GetFormulaFunction(c.ctx, fieldsResponse.FormulaFields, collectionMetadata)
+	formulaPopulations := formula.GetFormulaFunction(ctx, fieldsResponse.FormulaFields, collectionMetadata)
 
-	err = c.Query(func(scan func(dest ...any) error, index int) (bool, error) {
+	err = c.Query(ctx, func(scan func(dest ...any) error, index int) (bool, error) {
 
 		if op.BatchSize == index {
 			op.HasMoreBatches = true

--- a/apps/platform/pkg/adapt/postgresio/migrate.go
+++ b/apps/platform/pkg/adapt/postgresio/migrate.go
@@ -1,6 +1,7 @@
 package postgresio
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"net/url"
@@ -49,7 +50,7 @@ func getConnectionString(credentials *wire.Credentials) (string, error) {
 	return fmt.Sprintf("pgx5://%s:%s@%s:%s/%s?sslmode=%s", user, password, host, port, dbname, sslmode), nil
 }
 
-func (c *Connection) Migrate(options *migrations.MigrateOptions) error {
+func (c *Connection) Migrate(ctx context.Context, options *migrations.MigrateOptions) error {
 	if options.Down {
 		if options.Number >= 1 {
 			slog.Info(fmt.Sprintf("Reverting %d previously-run migrations", options.Number))

--- a/apps/platform/pkg/adapt/postgresio/publish.go
+++ b/apps/platform/pkg/adapt/postgresio/publish.go
@@ -1,13 +1,16 @@
 package postgresio
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+)
 
 // Publish sends a message on a given channel
-func (c *Connection) Publish(channelName, payload string) error {
+func (c *Connection) Publish(ctx context.Context, channelName, payload string) error {
 	c.mux.Lock()
 	defer c.mux.Unlock()
 	db := c.GetClient()
-	if _, err := db.Exec(c.ctx, "select pg_notify($1, $2)", channelName, payload); err != nil {
+	if _, err := db.Exec(ctx, "select pg_notify($1, $2)", channelName, payload); err != nil {
 		return fmt.Errorf("unable to publish message: %w", err)
 	}
 	return nil

--- a/apps/platform/pkg/adapt/postgresio/save.go
+++ b/apps/platform/pkg/adapt/postgresio/save.go
@@ -1,6 +1,8 @@
 package postgresio
 
 import (
+	"context"
+
 	"github.com/francoispqt/gojay"
 	"github.com/jackc/pgx/v5"
 
@@ -23,7 +25,7 @@ func queue(batch *pgx.Batch, query string, arguments ...any) {
 	})
 }
 
-func (c *Connection) Save(request *wire.SaveOp, session *sess.Session) error {
+func (c *Connection) Save(ctx context.Context, request *wire.SaveOp, session *sess.Session) error {
 
 	tenantID := session.GetTenantID()
 
@@ -89,6 +91,6 @@ func (c *Connection) Save(request *wire.SaveOp, session *sess.Session) error {
 		queue(batch, DELETE_QUERY, deleteIDs, collectionName, tenantID)
 	}
 
-	return c.SendBatch(batch)
+	return c.SendBatch(ctx, batch)
 
 }

--- a/apps/platform/pkg/adapt/postgresio/set_tokens.go
+++ b/apps/platform/pkg/adapt/postgresio/set_tokens.go
@@ -1,6 +1,8 @@
 package postgresio
 
 import (
+	"context"
+
 	"github.com/jackc/pgx/v5"
 
 	"github.com/thecloudmasters/uesio/pkg/sess"
@@ -10,7 +12,7 @@ import (
 const TOKEN_DELETE_QUERY = "DELETE FROM public.tokens WHERE recordid = ANY($1) and collection = $2 and tenant = $3"
 const TOKEN_INSERT_QUERY = "INSERT INTO public.tokens (recordid,token,collection,tenant,readonly) VALUES ($1,$2,$3,$4,$5)"
 
-func (c *Connection) SetRecordAccessTokens(request *wire.SaveOp, session *sess.Session) error {
+func (c *Connection) SetRecordAccessTokens(ctx context.Context, request *wire.SaveOp, session *sess.Session) error {
 
 	tenantID := session.GetTenantID()
 	collectionName := request.CollectionName
@@ -66,6 +68,6 @@ func (c *Connection) SetRecordAccessTokens(request *wire.SaveOp, session *sess.S
 		return err
 	}
 
-	return c.SendBatch(batch)
+	return c.SendBatch(ctx, batch)
 
 }

--- a/apps/platform/pkg/adapt/postgresio/subscribe.go
+++ b/apps/platform/pkg/adapt/postgresio/subscribe.go
@@ -1,25 +1,26 @@
 package postgresio
 
 import (
+	"context"
 	"fmt"
 )
 
 // Subscribe establishes a subscription on a channel,
 // and will invoke a function whenever a message is received on the channel
-func (c *Connection) Subscribe(channelName string, handler func(payload string)) error {
-	conn, err := c.GetPGConn()
+func (c *Connection) Subscribe(ctx context.Context, channelName string, handler func(payload string)) error {
+	conn, err := c.GetPGConn(ctx)
 	if err != nil {
 		return fmt.Errorf("unable to acquire PG connection for subscription: %s", err.Error())
 	}
 	defer conn.Release()
 
-	_, err = conn.Exec(c.ctx, "listen "+channelName)
+	_, err = conn.Exec(ctx, "listen "+channelName)
 	if err != nil {
 		return fmt.Errorf("unable to subscribe to channel %s : %s", channelName, err.Error())
 	}
 
 	for {
-		notification, waitErr := conn.Conn().WaitForNotification(c.ctx)
+		notification, waitErr := conn.Conn().WaitForNotification(ctx)
 		if waitErr != nil {
 			return waitErr
 		}

--- a/apps/platform/pkg/adapt/postgresio/truncate.go
+++ b/apps/platform/pkg/adapt/postgresio/truncate.go
@@ -1,6 +1,7 @@
 package postgresio
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -13,7 +14,7 @@ const (
 	TRUNCATE_TOKENS_QUERY = "DELETE FROM public.tokens WHERE tenant = $1"
 )
 
-func (c *Connection) TruncateTenantData(tenantID string) error {
+func (c *Connection) TruncateTenantData(ctx context.Context, tenantID string) error {
 	slog.Info("Truncating all data from tenant: " + tenantID)
 
 	batch := &pgx.Batch{}
@@ -21,7 +22,7 @@ func (c *Connection) TruncateTenantData(tenantID string) error {
 	batch.Queue(TRUNCATE_DATA_QUERY, tenantID)
 	batch.Queue(TRUNCATE_TOKENS_QUERY, tenantID)
 
-	err := c.SendBatch(batch)
+	err := c.SendBatch(ctx, batch)
 	if err != nil {
 		msg := fmt.Sprintf("error truncating data from tenant '%s': %s", tenantID, err.Error())
 		slog.Error(msg)

--- a/apps/platform/pkg/auth/auth.go
+++ b/apps/platform/pkg/auth/auth.go
@@ -302,7 +302,7 @@ func getAuthSource(key string, session *sess.Session) (*meta.AuthSource, error) 
 	if err != nil {
 		return nil, err
 	}
-	err = bundle.Load(authSource, nil, session, nil)
+	err = bundle.Load(session.Context(), authSource, nil, session, nil)
 
 	if err != nil {
 		return nil, err
@@ -316,7 +316,7 @@ func GetSignupMethod(key string, session *sess.Session) (*meta.SignupMethod, err
 	if err != nil {
 		return nil, err
 	}
-	err = bundle.Load(signupMethod, nil, session, nil)
+	err = bundle.Load(session.Context(), signupMethod, nil, session, nil)
 
 	if err != nil {
 		return nil, err

--- a/apps/platform/pkg/bot/jsdialect/apihelpers.go
+++ b/apps/platform/pkg/bot/jsdialect/apihelpers.go
@@ -92,7 +92,7 @@ func botGetFileData(sourceKey, sourcePath string, session *sess.Session, connect
 		return nil, "", err
 	}
 
-	if err := bundle.Load(file, nil, session, connection); err != nil {
+	if err := bundle.Load(session.Context(), file, nil, session, connection); err != nil {
 		return nil, "", err
 	}
 
@@ -101,7 +101,7 @@ func botGetFileData(sourceKey, sourcePath string, session *sess.Session, connect
 		path = file.Path
 	}
 
-	r, _, err := bundle.GetItemAttachment(file, path, session, connection)
+	r, _, err := bundle.GetItemAttachment(session.Context(), file, path, session, connection)
 	if err != nil {
 		return nil, "", err
 	}
@@ -116,7 +116,7 @@ func botCopyFile(sourceKey, sourcePath, destCollectionID, destRecordID, destFiel
 	}
 	defer r.Close()
 
-	_, err = filesource.Upload([]*filesource.FileUploadOp{
+	_, err = filesource.Upload(session.Context(), []*filesource.FileUploadOp{
 		{
 			Data:         r,
 			Path:         path,
@@ -130,13 +130,13 @@ func botCopyFile(sourceKey, sourcePath, destCollectionID, destRecordID, destFiel
 }
 
 func botCopyUserFile(sourceFileID, destCollectionID, destRecordID, destFieldID string, session *sess.Session, connection wire.Connection) error {
-	r, userFileMetadata, err := filesource.Download(sourceFileID, session)
+	r, userFileMetadata, err := filesource.Download(session.Context(), sourceFileID, session)
 	if err != nil {
 		return err
 	}
 	defer r.Close()
 
-	_, err = filesource.Upload([]*filesource.FileUploadOp{
+	_, err = filesource.Upload(session.Context(), []*filesource.FileUploadOp{
 		{
 			Data:         r,
 			Path:         userFileMetadata.Path(),

--- a/apps/platform/pkg/bot/jsdialect/generatorbot.go
+++ b/apps/platform/pkg/bot/jsdialect/generatorbot.go
@@ -292,7 +292,7 @@ func (gba *GeneratorBotAPI) RunIntegrationAction(integrationID string, action st
 
 func (gba *GeneratorBotAPI) GetTemplate(templateFile string) (string, error) {
 	// Load in the template text from the Bot.
-	r, _, err := bundle.GetItemAttachment(gba.bot, templateFile, gba.session, gba.connection)
+	r, _, err := bundle.GetItemAttachment(gba.session.Context(), gba.bot, templateFile, gba.session, gba.connection)
 	if err != nil {
 		return "", err
 	}

--- a/apps/platform/pkg/bot/jsdialect/jsdialect.go
+++ b/apps/platform/pkg/bot/jsdialect/jsdialect.go
@@ -52,7 +52,7 @@ func init() {
 }
 
 func (b *JSDialect) hydrateBot(bot *meta.Bot, session *sess.Session, connection wire.Connection) error {
-	r, _, err := bundle.GetItemAttachment(bot, b.GetFilePath(), session, connection)
+	r, _, err := bundle.GetItemAttachment(session.Context(), bot, b.GetFilePath(), session, connection)
 	if err != nil {
 		return err
 	}

--- a/apps/platform/pkg/bot/jsdialect/routebotapi.go
+++ b/apps/platform/pkg/bot/jsdialect/routebotapi.go
@@ -122,7 +122,7 @@ func HandleBotResponse(api *RouteBotAPI) (finalRoute *meta.Route, err error) {
 		if err != nil {
 			return nil, err
 		}
-		if err = bundle.Load(route, nil, api.session, api.connection); err != nil {
+		if err = bundle.Load(api.session.Context(), route, nil, api.session, api.connection); err != nil {
 			return nil, fmt.Errorf("unable to load redirect route for key '%s': %w", localizedRouteKey, err)
 		}
 		finalRoute = route

--- a/apps/platform/pkg/bot/params.go
+++ b/apps/platform/pkg/bot/params.go
@@ -58,7 +58,7 @@ func GetBotParams(namespace, name, metadataType string, session *sess.Session) (
 		robot = meta.NewRunActionBot(namespace, name)
 	}
 
-	err := bundle.Load(robot, nil, session, nil)
+	err := bundle.Load(session.Context(), robot, nil, session, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/apps/platform/pkg/bot/systemdialect/systembot_after_bundle.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_after_bundle.go
@@ -70,12 +70,11 @@ func clearFilesForBundles(ids []string, session *sess.Session) error {
 		dest, err := bundlestore.GetConnection(bundlestore.ConnectionOptions{
 			Namespace: appName,
 			Version:   appVersion,
-			Context:   session.Context(),
 		})
 		if err != nil {
 			return err
 		}
-		if err = dest.DeleteBundle(); err != nil {
+		if err = dest.DeleteBundle(session.Context()); err != nil {
 			return err
 		}
 	}

--- a/apps/platform/pkg/bot/systemdialect/systembot_after_site.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_after_site.go
@@ -133,7 +133,7 @@ func runSiteAfterSaveBot(request *wire.SaveOp, connection wire.Connection, sessi
 		if siteUniqueKey == "" {
 			return errors.New("unable to get site unique key, cannot truncate data")
 		}
-		if err = connection.TruncateTenantData(sess.MakeSiteTenantID(siteUniqueKey)); err != nil {
+		if err = connection.TruncateTenantData(session.Context(), sess.MakeSiteTenantID(siteUniqueKey)); err != nil {
 			return fmt.Errorf("unable to truncate site data: %w", err)
 		}
 		return nil

--- a/apps/platform/pkg/bot/systemdialect/systembot_after_workspace.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_after_workspace.go
@@ -33,7 +33,6 @@ func deployWorkspaceFromBundle(workspaceID, bundleID string, connection wire.Con
 	}
 
 	bs, err := bundlestore.GetConnection(bundlestore.ConnectionOptions{
-		Context:      session.Context(),
 		Namespace:    workspaceSession.GetContextAppName(),
 		Version:      bundle.GetVersionString(),
 		Connection:   connection,
@@ -46,7 +45,7 @@ func deployWorkspaceFromBundle(workspaceID, bundleID string, connection wire.Con
 	// Retrieve the bundle zip
 	// Create a new zip archive.
 	buf := new(bytes.Buffer)
-	err = bs.GetBundleZip(buf, nil)
+	err = bs.GetBundleZip(session.Context(), buf, nil)
 	if err != nil {
 		return err
 	}
@@ -122,7 +121,7 @@ func runWorkspaceAfterSaveBot(request *wire.SaveOp, connection wire.Connection, 
 		if workspaceUniqueKey == "" {
 			return errors.New("unable to get workspace unique key, cannot truncate data")
 		}
-		if err = connection.TruncateTenantData(sess.MakeWorkspaceTenantID(workspaceUniqueKey)); err != nil {
+		if err = connection.TruncateTenantData(session.Context(), sess.MakeWorkspaceTenantID(workspaceUniqueKey)); err != nil {
 			return fmt.Errorf("unable to truncate workspace data: %w", err)
 		}
 		return nil

--- a/apps/platform/pkg/bot/systemdialect/systembot_before_userfile.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_before_userfile.go
@@ -56,7 +56,7 @@ func runUserFileBeforeSaveBot(request *wire.SaveOp, connection wire.Connection, 
 			}
 			fullPath := ufm.GetFullPath(tenantID)
 			// Ignore missing files, possibly it was already deleted
-			_ = conn.Delete(fullPath)
+			_ = conn.Delete(session.Context(), fullPath)
 		}
 	}
 

--- a/apps/platform/pkg/bot/systemdialect/systembot_listener_runagent.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_listener_runagent.go
@@ -47,7 +47,7 @@ func runAgentListenerBot(params map[string]any, connection wire.Connection, sess
 		return nil, exceptions.NewBadRequestException("", err)
 	}
 
-	err = bundle.Load(agent, nil, session.RemoveVersionContext(), connection)
+	err = bundle.Load(session.Context(), agent, nil, session.RemoveVersionContext(), connection)
 	if err != nil {
 		if exceptions.IsType[*exceptions.NotFoundException](err) {
 			return nil, exceptions.NewBadRequestException("", err)
@@ -55,7 +55,7 @@ func runAgentListenerBot(params map[string]any, connection wire.Connection, sess
 		return nil, err
 	}
 
-	r, _, err := bundle.GetItemAttachment(agent, "prompt.txt", session.RemoveVersionContext(), connection)
+	r, _, err := bundle.GetItemAttachment(session.Context(), agent, "prompt.txt", session.RemoveVersionContext(), connection)
 	if err != nil {
 		return nil, err
 	}

--- a/apps/platform/pkg/bot/systemdialect/systembot_load_allmetadata.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_load_allmetadata.go
@@ -336,7 +336,7 @@ func runAllMetadataLoadBot(op *wire.LoadOp, connection wire.Connection, session 
 			return err
 		}
 		group.AddItem(item)
-		err = bundle.Load(item, &bundlestore.GetItemOptions{
+		err = bundle.Load(session.Context(), item, &bundlestore.GetItemOptions{
 			IncludeUserFields: true,
 		}, session, connection)
 		if err != nil {
@@ -400,7 +400,7 @@ func runAllMetadataLoadBot(op *wire.LoadOp, connection wire.Connection, session 
 		}
 
 		if !onlyLoadCommonFields {
-			err = bundle.LoadAllFromNamespaces(namespaces, group, &bundlestore.GetAllItemsOptions{
+			err = bundle.LoadAllFromNamespaces(session.Context(), namespaces, group, &bundlestore.GetAllItemsOptions{
 				Conditions:        conditions,
 				IncludeUserFields: true,
 				Fields:            requestFields,
@@ -492,7 +492,7 @@ func runAllMetadataLoadBot(op *wire.LoadOp, connection wire.Connection, session 
 				// Also get attachments
 				attachableItem, isAttachableItem := item.(meta.AttachableItem)
 				if isAttachableItem {
-					pathInfos, err := bundle.GetAttachmentPaths(attachableItem, session, connection)
+					pathInfos, err := bundle.GetAttachmentPaths(session.Context(), attachableItem, session, connection)
 					if err != nil {
 						return err
 					}

--- a/apps/platform/pkg/bot/systemdialect/systembot_load_myintegrationcredentials.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_load_myintegrationcredentials.go
@@ -134,13 +134,13 @@ func getAllPerUserIntegrationsUserHasAccessTo(session *sess.Session, connection 
 	// If we have unique namespaces to load from, do a more targeted load.
 	if len(uniqueNames) > 0 {
 		conditions["uesio/studio.name"] = goutils.MapKeys(uniqueNames)
-		if err := bundle.LoadAllFromNamespaces(goutils.MapKeys(uniqueNamespaces), group, &bundlestore.GetAllItemsOptions{
+		if err := bundle.LoadAllFromNamespaces(session.Context(), goutils.MapKeys(uniqueNamespaces), group, &bundlestore.GetAllItemsOptions{
 			Conditions: conditions,
 		}, session, connection); err != nil {
 			return nil, fmt.Errorf("unable to load integrations: %w", err)
 		}
 	} else {
-		if err := bundle.LoadAllFromAny(group, &bundlestore.GetAllItemsOptions{
+		if err := bundle.LoadAllFromAny(session.Context(), group, &bundlestore.GetAllItemsOptions{
 			Conditions: conditions,
 		}, session, connection); err != nil {
 			return nil, fmt.Errorf("unable to load integrations: %w", err)

--- a/apps/platform/pkg/bot/systemdialect/systembot_load_recentmetadata.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_load_recentmetadata.go
@@ -160,7 +160,7 @@ func runRecentMetadataLoadBot(op *wire.LoadOp, connection wire.Connection, sessi
 	})
 
 	// We need to query with the original session
-	err = connection.Load(newOp, session)
+	err = connection.Load(session.Context(), newOp, session)
 	if err != nil {
 		return err
 	}

--- a/apps/platform/pkg/bot/systemdialect/systembot_load_recordtokenvalue.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_load_recordtokenvalue.go
@@ -22,7 +22,9 @@ func runRecordTokenValueLoadBot(op *wire.LoadOp, connection wire.Connection, ses
 	if err != nil {
 		return err
 	}
-	tokens, err := connection.GetRecordAccessTokens(recordID, inContextSession)
+	// intentionally using session context and not inContextSession since session is what owns the processing
+	// context. The context in both session and inContextSession should be the same but session owns it
+	tokens, err := connection.GetRecordAccessTokens(session.Context(), recordID, inContextSession)
 	if err != nil {
 		return err
 	}

--- a/apps/platform/pkg/bot/systemdialect/systembot_load_userfile.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_load_userfile.go
@@ -53,7 +53,7 @@ func runUserfileLoadBot(op *wire.LoadOp, connection wire.Connection, session *se
 			return nil
 		}
 
-		r, _, err := filesource.Download(userFileIDString, session)
+		r, _, err := filesource.Download(session.Context(), userFileIDString, session)
 		if err != nil {
 			return err
 		}

--- a/apps/platform/pkg/bot/systemdialect/systembot_load_usertokenvalue.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_load_usertokenvalue.go
@@ -17,7 +17,7 @@ func runUserTokenValueLoadBot(op *wire.LoadOp, connection wire.Connection, sessi
 	searchCondition := extractConditionByType(op.Conditions, "SEARCH")
 
 	var uatc meta.UserAccessTokenCollection
-	err := bundle.LoadAllFromAny(&uatc, nil, session, nil)
+	err := bundle.LoadAllFromAny(session.Context(), &uatc, nil, session, nil)
 	if err != nil {
 		return err
 	}

--- a/apps/platform/pkg/bot/systemdialect/systembot_save_allmetadata.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_save_allmetadata.go
@@ -108,7 +108,7 @@ func runStudioMetadataSaveBot(op *wire.SaveOp, connection wire.Connection, sessi
 		if err != nil {
 			return errors.New("unable to serialize workspace metadata changes cache key")
 		}
-		if err = connection.Publish(workspacebundlestore.WorkspaceMetadataChangesChannel, string(messagePayload)); err != nil {
+		if err = connection.Publish(session.Context(), workspacebundlestore.WorkspaceMetadataChangesChannel, string(messagePayload)); err != nil {
 			slog.ErrorContext(session.Context(), "unable to invalidate workspace cache: "+err.Error())
 			return errors.New("unable to invalidate workspace cache")
 		}

--- a/apps/platform/pkg/bot/systemdialect/systembot_save_userfile.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_save_userfile.go
@@ -76,7 +76,7 @@ func runUserfileSaveBot(op *wire.SaveOp, connection wire.Connection, session *se
 		return err
 	}
 
-	_, err = filesource.Upload(uploadOps, connection, session, op.Params)
+	_, err = filesource.Upload(session.Context(), uploadOps, connection, session, op.Params)
 	if err != nil {
 		return err
 	}

--- a/apps/platform/pkg/bot/systemdialect/systembotutils.go
+++ b/apps/platform/pkg/bot/systemdialect/systembotutils.go
@@ -56,7 +56,7 @@ func checkValidItems(workspaceID string, items []meta.BundleableItem, session *s
 	if err != nil {
 		return err
 	}
-	return bundle.IsValid(items, wsSession, connection)
+	return bundle.IsValid(session.Context(), items, wsSession, connection)
 
 }
 

--- a/apps/platform/pkg/bot/tsdialect/tsdialect.go
+++ b/apps/platform/pkg/bot/tsdialect/tsdialect.go
@@ -22,7 +22,7 @@ type TSDialect struct {
 }
 
 func (b *TSDialect) hydrateBot(bot *meta.Bot, session *sess.Session, connection wire.Connection) error {
-	r, _, err := bundle.GetItemAttachment(bot, b.GetFilePath(), session, connection)
+	r, _, err := bundle.GetItemAttachment(session.Context(), bot, b.GetFilePath(), session, connection)
 	if err != nil {
 		return err
 	}

--- a/apps/platform/pkg/bulk/export.go
+++ b/apps/platform/pkg/bulk/export.go
@@ -51,7 +51,7 @@ func NewExportBatch(job meta.BulkJob, session *sess.Session) (*meta.BulkBatch, e
 
 	zipwriter.Close()
 
-	_, err = filesource.Upload([]*filesource.FileUploadOp{
+	_, err = filesource.Upload(session.Context(), []*filesource.FileUploadOp{
 		{
 			Data:         buf,
 			Path:         fileName,

--- a/apps/platform/pkg/bulk/exportfiles.go
+++ b/apps/platform/pkg/bulk/exportfiles.go
@@ -78,7 +78,7 @@ func exportFiles(create bundlestore.FileCreator, spec *meta.JobSpec, session *se
 			}
 			defer file.Close()
 
-			r, _, err := filesource.DownloadItem(userFile, session)
+			r, _, err := filesource.DownloadItem(session.Context(), userFile, session)
 			if err != nil {
 				return err
 			}

--- a/apps/platform/pkg/bulk/uploadfiles.go
+++ b/apps/platform/pkg/bulk/uploadfiles.go
@@ -128,7 +128,7 @@ func NewFileUploadBatch(body io.ReadCloser, job meta.BulkJob, session *sess.Sess
 		return nil, err
 	}
 
-	_, err = filesource.Upload(uploadOps, connection, session, nil)
+	_, err = filesource.Upload(session.Context(), uploadOps, connection, session, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/apps/platform/pkg/bundlestore/bundlestore.go
+++ b/apps/platform/pkg/bundlestore/bundlestore.go
@@ -47,7 +47,6 @@ func GetBundleStoreByType(bundleStoreType string) (BundleStore, error) {
 }
 
 type ConnectionOptions struct {
-	Context      context.Context
 	Namespace    string
 	Version      string
 	Connection   wire.Connection
@@ -87,18 +86,18 @@ type HasAnyOptions struct {
 }
 
 type BundleStoreConnection interface {
-	GetItem(item meta.BundleableItem, options *GetItemOptions) error
-	GetManyItems(items []meta.BundleableItem, options *GetManyItemsOptions) error
-	GetAllItems(group meta.BundleableGroup, options *GetAllItemsOptions) error
-	HasAny(group meta.BundleableGroup, options *HasAnyOptions) (bool, error)
-	GetItemAttachment(item meta.AttachableItem, path string) (io.ReadSeekCloser, file.Metadata, error)
-	GetItemAttachments(creator FileCreator, item meta.AttachableItem) error
-	GetAttachmentPaths(item meta.AttachableItem) ([]file.Metadata, error)
-	GetBundleDef() (*meta.BundleDef, error)
-	HasAllItems(items []meta.BundleableItem) error
-	DeleteBundle() error
-	GetBundleZip(writer io.Writer, options *BundleZipOptions) error
-	SetBundleZip(reader io.ReaderAt, size int64) error
+	GetItem(ctx context.Context, item meta.BundleableItem, options *GetItemOptions) error
+	GetManyItems(ctx context.Context, items []meta.BundleableItem, options *GetManyItemsOptions) error
+	GetAllItems(ctx context.Context, group meta.BundleableGroup, options *GetAllItemsOptions) error
+	HasAny(ctx context.Context, group meta.BundleableGroup, options *HasAnyOptions) (bool, error)
+	GetItemAttachment(ctx context.Context, item meta.AttachableItem, path string) (io.ReadSeekCloser, file.Metadata, error)
+	GetItemAttachments(ctx context.Context, creator FileCreator, item meta.AttachableItem) error
+	GetAttachmentPaths(ctx context.Context, item meta.AttachableItem) ([]file.Metadata, error)
+	GetBundleDef(ctx context.Context) (*meta.BundleDef, error)
+	HasAllItems(ctx context.Context, items []meta.BundleableItem) error
+	DeleteBundle(ctx context.Context) error
+	GetBundleZip(ctx context.Context, writer io.Writer, options *BundleZipOptions) error
+	SetBundleZip(ctx context.Context, reader io.ReaderAt, size int64) error
 }
 
 func getBundleStore(namespace string, workspace *meta.Workspace) (BundleStore, error) {

--- a/apps/platform/pkg/bundlestore/workspacebundlestore/workspacebundlecacheutils.go
+++ b/apps/platform/pkg/bundlestore/workspacebundlestore/workspacebundlecacheutils.go
@@ -53,7 +53,7 @@ func setupPlatformSubscription() {
 		panic("unable to establish platform connection!")
 	}
 
-	if err = conn.Subscribe(WorkspaceMetadataChangesChannel, handleWorkspaceMetadataChange); err != nil {
+	if err = conn.Subscribe(s.Context(), WorkspaceMetadataChangesChannel, handleWorkspaceMetadataChange); err != nil {
 		slog.Error("unable to subscribe on channel! " + err.Error())
 		panic("unable to subscribe on channel!")
 	}

--- a/apps/platform/pkg/cmd/migrate.go
+++ b/apps/platform/pkg/cmd/migrate.go
@@ -97,7 +97,7 @@ func migrate(opts *migrations.MigrateOptions) error {
 	anonSession := sess.GetStudioAnonSession(ctx)
 
 	err := datasource.WithTransaction(anonSession, nil, func(conn wire.Connection) error {
-		return conn.Migrate(opts)
+		return conn.Migrate(ctx, opts)
 	})
 	if err != nil {
 		return fmt.Errorf("migrations failed: %w", err)

--- a/apps/platform/pkg/configstore/configstore.go
+++ b/apps/platform/pkg/configstore/configstore.go
@@ -27,7 +27,7 @@ func GetConfigValues(session *sess.Session, options *ConfigLoadOptions) (*meta.C
 		options = &ConfigLoadOptions{}
 	}
 	allConfigValues := meta.ConfigValueCollection{}
-	err := bundle.LoadAllFromAny(&allConfigValues, nil, session, nil)
+	err := bundle.LoadAllFromAny(session.Context(), &allConfigValues, nil, session, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -111,7 +111,7 @@ func GetValue(key string, session *sess.Session) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	err = bundle.Load(configValue, nil, session, nil)
+	err = bundle.Load(session.Context(), configValue, nil, session, nil)
 	if err != nil {
 		return "", err
 	}
@@ -142,7 +142,7 @@ func SetValue(key, value string, session *sess.Session) error {
 	if err != nil {
 		return err
 	}
-	err = bundle.Load(configValue, nil, session, nil)
+	err = bundle.Load(session.Context(), configValue, nil, session, nil)
 	if err != nil {
 		return err
 	}
@@ -173,7 +173,7 @@ func Remove(key string, session *sess.Session) error {
 	if err != nil {
 		return err
 	}
-	err = bundle.Load(configValue, nil, session, nil)
+	err = bundle.Load(session.Context(), configValue, nil, session, nil)
 	if err != nil {
 		return err
 	}

--- a/apps/platform/pkg/controller/bundlesretrieve.go
+++ b/apps/platform/pkg/controller/bundlesretrieve.go
@@ -34,7 +34,6 @@ func BundlesRetrieve(w http.ResponseWriter, r *http.Request) {
 		Version:    version,
 		Connection: nil,
 		Workspace:  nil,
-		Context:    session.Context(),
 	})
 	if err != nil {
 		ctlutil.HandleError(r.Context(), w, exceptions.NewBadRequestException("failed getting bundle", err))
@@ -46,7 +45,7 @@ func BundlesRetrieve(w http.ResponseWriter, r *http.Request) {
 	middleware.Set1YearCache(w)
 	ctlutil.AddTrailingStatus(w)
 
-	err = source.GetBundleZip(w, nil)
+	err = source.GetBundleZip(session.Context(), w, nil)
 	if err != nil {
 		// Note - We are streaming result so Http StatusCode will have been set to 200 after
 		// the first Write so we implement custom approach to detecting failure on client

--- a/apps/platform/pkg/controller/file/componentpack.go
+++ b/apps/platform/pkg/controller/file/componentpack.go
@@ -27,12 +27,12 @@ func ServeComponentPackFile(w http.ResponseWriter, r *http.Request) {
 		ctlutil.HandleError(r.Context(), w, err)
 		return
 	}
-	if err = bundle.Load(componentPack, nil, session, nil); err != nil {
+	if err = bundle.Load(session.Context(), componentPack, nil, session, nil); err != nil {
 		ctlutil.HandleError(r.Context(), w, err)
 		return
 	}
 
-	rs, fileMeta, err := bundle.GetItemAttachment(componentPack, "dist/"+path, session, connection)
+	rs, fileMeta, err := bundle.GetItemAttachment(session.Context(), componentPack, "dist/"+path, session, connection)
 	if err != nil {
 		ctlutil.HandleError(r.Context(), w, err)
 		return

--- a/apps/platform/pkg/controller/file/font.go
+++ b/apps/platform/pkg/controller/file/font.go
@@ -27,12 +27,12 @@ func ServeFontFile(w http.ResponseWriter, r *http.Request) {
 		ctlutil.HandleError(r.Context(), w, err)
 		return
 	}
-	if err = bundle.Load(font, nil, session, nil); err != nil {
+	if err = bundle.Load(session.Context(), font, nil, session, nil); err != nil {
 		ctlutil.HandleError(r.Context(), w, err)
 		return
 	}
 
-	rs, fileMeta, err := bundle.GetItemAttachment(font, path, session, connection)
+	rs, fileMeta, err := bundle.GetItemAttachment(session.Context(), font, path, session, connection)
 	if err != nil {
 		ctlutil.HandleError(r.Context(), w, err)
 		return

--- a/apps/platform/pkg/controller/file/serve_file.go
+++ b/apps/platform/pkg/controller/file/serve_file.go
@@ -68,7 +68,7 @@ func ServeFileContent(file *meta.File, path string, supportsCaching bool, w http
 		return
 	}
 
-	if err := bundle.Load(file, nil, session, connection); err != nil {
+	if err := bundle.Load(session.Context(), file, nil, session, connection); err != nil {
 		ctlutil.HandleError(r.Context(), w, err)
 		return
 	}
@@ -77,7 +77,7 @@ func ServeFileContent(file *meta.File, path string, supportsCaching bool, w http
 		path = file.Path
 	}
 
-	rs, fileMetadata, err := bundle.GetItemAttachment(file, path, session, connection)
+	rs, fileMetadata, err := bundle.GetItemAttachment(session.Context(), file, path, session, connection)
 	if err != nil {
 		ctlutil.HandleError(r.Context(), w, err)
 		return

--- a/apps/platform/pkg/controller/file/userfile.go
+++ b/apps/platform/pkg/controller/file/userfile.go
@@ -51,7 +51,7 @@ func processUploadRequest(r *http.Request) (*meta.UserFileMetadata, error) {
 				return nil, errors.New("no recordid specified")
 			}
 			op.Data = part
-			results, err := filesource.Upload([]*filesource.FileUploadOp{op}, nil, session, op.Params)
+			results, err := filesource.Upload(session.Context(), []*filesource.FileUploadOp{op}, nil, session, op.Params)
 			if err != nil {
 				return nil, err
 			}
@@ -76,7 +76,7 @@ func UploadUserFile(w http.ResponseWriter, r *http.Request) {
 // DeleteUserFile deletes the requested user file
 func DeleteUserFile(w http.ResponseWriter, r *http.Request) {
 	session := middleware.GetSession(r)
-	if err := filesource.Delete(mux.Vars(r)["fileid"], session); err != nil {
+	if err := filesource.Delete(r.Context(), mux.Vars(r)["fileid"], session); err != nil {
 		ctlutil.HandleError(r.Context(), w, err)
 	} else {
 		filejson.RespondJSON(w, r, &bot.BotResponse{
@@ -94,7 +94,7 @@ func DownloadUserFile(w http.ResponseWriter, r *http.Request) {
 		ctlutil.HandleError(r.Context(), w, exceptions.NewBadRequestException("missing required query parameter: userfileid", nil))
 		return
 	}
-	rs, userFile, err := filesource.Download(userFileID, session)
+	rs, userFile, err := filesource.Download(r.Context(), userFileID, session)
 	if err != nil {
 		ctlutil.HandleError(r.Context(), w, err)
 		return
@@ -125,7 +125,7 @@ func DownloadAttachment(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	rs, userFile, err := filesource.DownloadAttachment(recordID, path, session)
+	rs, userFile, err := filesource.DownloadAttachment(r.Context(), recordID, path, session)
 	if err != nil {
 		ctlutil.HandleError(r.Context(), w, err)
 		return

--- a/apps/platform/pkg/controller/getrouteparams.go
+++ b/apps/platform/pkg/controller/getrouteparams.go
@@ -69,7 +69,7 @@ func GetRouteParams(w http.ResponseWriter, r *http.Request) {
 	name := vars["name"]
 	session := middleware.GetSession(r)
 	loader := func(item meta.BundleableItem) error {
-		return bundle.Load(item, nil, session, nil)
+		return bundle.Load(session.Context(), item, nil, session, nil)
 	}
 	route := meta.NewBaseRoute(namespace, name)
 	if err := loader(route); err != nil {

--- a/apps/platform/pkg/controller/getviewparams.go
+++ b/apps/platform/pkg/controller/getviewparams.go
@@ -62,7 +62,7 @@ func GetViewParams(w http.ResponseWriter, r *http.Request) {
 	name := vars["name"]
 	session := middleware.GetSession(r)
 	loader := func(item meta.BundleableItem) error {
-		return bundle.Load(item, nil, session, nil)
+		return bundle.Load(session.Context(), item, nil, session, nil)
 	}
 	viewParams, err := getParamsForView(namespace, name, loader)
 	if err != nil {

--- a/apps/platform/pkg/controller/integrationaction.go
+++ b/apps/platform/pkg/controller/integrationaction.go
@@ -185,7 +185,7 @@ func DescribeIntegrationAction(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		robot := meta.NewRunActionBot(actionBotNamespace, actionBotName)
-		err = bundle.Load(robot, nil, session, nil)
+		err = bundle.Load(session.Context(), robot, nil, session, nil)
 		if err != nil {
 			ctlutil.HandleError(r.Context(), w, err)
 			return

--- a/apps/platform/pkg/controller/metadatalist.go
+++ b/apps/platform/pkg/controller/metadatalist.go
@@ -36,7 +36,7 @@ func getMetadataList(metadatatype, namespace, grouping string, session *sess.Ses
 	var appNames []string
 
 	if namespace != "" {
-		err = bundle.LoadAll(collection, namespace, &bundlestore.GetAllItemsOptions{
+		err = bundle.LoadAll(session.Context(), collection, namespace, &bundlestore.GetAllItemsOptions{
 			Conditions: conditions,
 		}, session, nil)
 		if err != nil {
@@ -44,7 +44,7 @@ func getMetadataList(metadatatype, namespace, grouping string, session *sess.Ses
 		}
 		appNames = []string{namespace}
 	} else {
-		err := bundle.LoadAllFromAny(collection, &bundlestore.GetAllItemsOptions{
+		err := bundle.LoadAllFromAny(session.Context(), collection, &bundlestore.GetAllItemsOptions{
 			Conditions: conditions,
 		}, session, nil)
 		if err != nil {

--- a/apps/platform/pkg/controller/namespaces.go
+++ b/apps/platform/pkg/controller/namespaces.go
@@ -28,7 +28,7 @@ func getNamespaces(metadataType string, session *sess.Session) ([]string, error)
 		if err != nil {
 			return nil, err
 		}
-		hasSome, err := bundle.HasAny(collection, namespace, nil, session, nil)
+		hasSome, err := bundle.HasAny(session.Context(), collection, namespace, nil, session, nil)
 		if err != nil {
 			return nil, err
 		}

--- a/apps/platform/pkg/controller/oauth/callback.go
+++ b/apps/platform/pkg/controller/oauth/callback.go
@@ -87,7 +87,7 @@ func Callback(w http.ResponseWriter, r *http.Request) {
 
 func loadCallbackRoute(r *http.Request, coreSession *sess.Session, platformConn wire.Connection) (*meta.Route, error) {
 	route := meta.NewBaseRoute("uesio/core", "oauth2callback")
-	if err := bundle.Load(route, nil, coreSession, platformConn); err != nil {
+	if err := bundle.Load(coreSession.Context(), route, nil, coreSession, platformConn); err != nil {
 		return nil, fmt.Errorf("unable to load oauth callback route: %w", err)
 	}
 	// Make sure to do a copy to avoid mutating in-memory/cached metadata

--- a/apps/platform/pkg/controller/retrieve.go
+++ b/apps/platform/pkg/controller/retrieve.go
@@ -33,7 +33,7 @@ func Retrieve(w http.ResponseWriter, r *http.Request) {
 	file.SetContentDispositionHeader(w, "attachment", fileName)
 	ctlutil.AddTrailingStatus(w)
 
-	if err := bs.GetBundleZip(w, &bundlestore.BundleZipOptions{
+	if err := bs.GetBundleZip(session.Context(), w, &bundlestore.BundleZipOptions{
 		// Only include generated types if we're in a workspace context
 		IncludeGeneratedTypes: session.GetWorkspaceSession() != nil,
 	}); err != nil {

--- a/apps/platform/pkg/controller/retrievetypes.go
+++ b/apps/platform/pkg/controller/retrievetypes.go
@@ -21,7 +21,7 @@ func RetrieveAppTypes(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "application/typescript")
-	if err := retrieve.GenerateAppTypeScriptTypes(w, bs); err != nil {
+	if err := retrieve.GenerateAppTypeScriptTypes(r.Context(), w, bs); err != nil {
 		ctlutil.HandleError(r.Context(), w, err)
 		return
 	}

--- a/apps/platform/pkg/controller/robots.go
+++ b/apps/platform/pkg/controller/robots.go
@@ -51,13 +51,13 @@ func Robots(w http.ResponseWriter, r *http.Request) {
 	// Load all public routes to get their paths, along with public files.
 	// We are assuming that a crawler would have a public guest session,
 	// so we can just let our permissions system do the work of finding which routes/files are accessible)
-	err := bundle.LoadAllFromAny(&routes, nil, session, nil)
+	err := bundle.LoadAllFromAny(session.Context(), &routes, nil, session, nil)
 
 	if err != nil || len(routes) == 0 {
 		return
 	}
 
-	err = bundle.LoadAllFromAny(&files, nil, session, nil)
+	err = bundle.LoadAllFromAny(session.Context(), &files, nil, session, nil)
 
 	if err != nil {
 		return

--- a/apps/platform/pkg/controller/view.go
+++ b/apps/platform/pkg/controller/view.go
@@ -30,7 +30,7 @@ func ViewPreview(buildMode bool) http.HandlerFunc {
 		view := meta.NewBaseView(viewNamespace, viewName)
 
 		// Make sure this is a legit view that we have access to
-		err := bundle.Load(view, nil, session, nil)
+		err := bundle.Load(session.Context(), view, nil, session, nil)
 		if err != nil {
 			HandleErrorRoute(w, r, session, "", "", err, false)
 			return

--- a/apps/platform/pkg/datasource/bots.go
+++ b/apps/platform/pkg/datasource/bots.go
@@ -48,7 +48,7 @@ func RunRouteBots(route *meta.Route, request *http.Request, session *sess.Sessio
 
 	bundleLoader := func(item meta.BundleableItem) error {
 		// TODO: WHY DOES connection have to be nil here
-		return bundle.Load(item, nil, session, nil)
+		return bundle.Load(session.Context(), item, nil, session, nil)
 	}
 
 	routeBot = meta.NewRouteBot(botNamespace, botName)
@@ -86,7 +86,7 @@ func runBeforeSaveBots(request *wire.SaveOp, connection wire.Connection, session
 	var robots meta.BotCollection
 
 	// TODO why does connection have to be nil
-	err := bundle.LoadAllFromAny(&robots, &bundlestore.GetAllItemsOptions{
+	err := bundle.LoadAllFromAny(session.Context(), &robots, &bundlestore.GetAllItemsOptions{
 		Conditions: meta.BundleConditions{
 			"uesio/studio.collection": collectionName,
 			"uesio/studio.type":       "BEFORESAVE",
@@ -182,7 +182,7 @@ func runExternalDataSourceLoadBot(botName string, op *wire.LoadOp, connection wi
 	}
 
 	// TODO: Figure out why connection has to be nil
-	err = bundle.Load(loadBot, nil, session, nil)
+	err = bundle.Load(session.Context(), loadBot, nil, session, nil)
 	if err != nil {
 		return err
 	}
@@ -211,7 +211,7 @@ func runExternalDataSourceSaveBot(botName string, op *wire.SaveOp, connection wi
 		Type: "SAVE",
 	}
 	// TODO: Figure out why connection has to be nil
-	err = bundle.Load(saveBot, nil, session, nil)
+	err = bundle.Load(session.Context(), saveBot, nil, session, nil)
 	if err != nil {
 		return fmt.Errorf("unable to load requested SAVE bot '%s': %w", botName, err)
 	}
@@ -231,7 +231,7 @@ func runAfterSaveBots(request *wire.SaveOp, connection wire.Connection, session 
 	var robots meta.BotCollection
 
 	// TODO: Figure out why connection has to be nil
-	err := bundle.LoadAllFromAny(&robots, &bundlestore.GetAllItemsOptions{
+	err := bundle.LoadAllFromAny(session.Context(), &robots, &bundlestore.GetAllItemsOptions{
 		Conditions: meta.BundleConditions{
 			"uesio/studio.collection": collectionName,
 			"uesio/studio.type":       "AFTERSAVE",
@@ -276,7 +276,7 @@ func CallGeneratorBot(create bundlestore.FileCreator, namespace, name string, pa
 	robot := meta.NewGeneratorBot(namespace, name)
 	bundleLoader := func(item meta.BundleableItem) error {
 		// TODO: WHY DOES connection have to be nil here
-		return bundle.Load(item, nil, session, nil)
+		return bundle.Load(session.Context(), item, nil, session, nil)
 	}
 
 	if err := bundleLoader(robot); err != nil {
@@ -319,7 +319,7 @@ func CallListenerBot(namespace, name string, params map[string]any, connection w
 
 	bundleLoader := func(item meta.BundleableItem) error {
 		// TODO: WHY DOES connection have to be nil here
-		return bundle.Load(item, nil, session, nil)
+		return bundle.Load(session.Context(), item, nil, session, nil)
 	}
 
 	// First try to run a system bot
@@ -427,7 +427,7 @@ func RunIntegrationAction(ic *wire.IntegrationConnection, actionKey string, requ
 
 	bundleLoader := func(item meta.BundleableItem) error {
 		// TODO: WHY DOES connection have to be nil here
-		return bundle.Load(item, nil, session, nil)
+		return bundle.Load(session.Context(), item, nil, session, nil)
 	}
 	robot := meta.NewRunActionBot(botNamespace, botName)
 	if err = bundleLoader(robot); err != nil {

--- a/apps/platform/pkg/datasource/cascade.go
+++ b/apps/platform/pkg/datasource/cascade.go
@@ -81,7 +81,7 @@ func getCascadeDeletes(
 
 		idLoadOp.AttachMetadataCache(metadata)
 
-		err = connection.Load(idLoadOp, versionSession)
+		err = connection.Load(session.Context(), idLoadOp, versionSession)
 		if err != nil {
 			return nil, fmt.Errorf("cascade delete error: %w", err)
 		}

--- a/apps/platform/pkg/datasource/credentials.go
+++ b/apps/platform/pkg/datasource/credentials.go
@@ -30,7 +30,7 @@ func GetCredentials(key string, session *sess.Session) (*wire.Credentials, error
 		return nil, err
 	}
 
-	err = bundle.Load(credential, nil, session, nil)
+	err = bundle.Load(session.Context(), credential, nil, session, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/apps/platform/pkg/datasource/integ.go
+++ b/apps/platform/pkg/datasource/integ.go
@@ -19,7 +19,7 @@ func GetIntegration(integrationID string, session *sess.Session, connection wire
 	if err != nil {
 		return nil, err
 	}
-	if err = bundle.Load(integrationInstance, nil, session, connection); err != nil {
+	if err = bundle.Load(session.Context(), integrationInstance, nil, session, connection); err != nil {
 		return nil, fmt.Errorf("unable to load integration '%s': %w", integrationID, err)
 	}
 	return integrationInstance, nil
@@ -31,7 +31,7 @@ func GetIntegrationType(integrationTypeName string, session *sess.Session, conne
 	if err != nil {
 		return nil, err
 	}
-	if err = bundle.Load(integrationType, nil, session, connection); err != nil {
+	if err = bundle.Load(session.Context(), integrationType, nil, session, connection); err != nil {
 		return nil, fmt.Errorf("unable to load integration type '%s': %w", integrationTypeName, err)
 	}
 	return integrationType, nil
@@ -44,7 +44,7 @@ func GetIntegrationAction(integrationType, actionKey string, session *sess.Sessi
 	if err != nil {
 		return nil, exceptions.NewNotFoundException("could not find integration action: " + actionKey)
 	}
-	if err = bundle.Load(action, nil, session, connection); err != nil {
+	if err = bundle.Load(session.Context(), action, nil, session, connection); err != nil {
 		return nil, fmt.Errorf("unable to load integration action '%s': %w", actionKey, err)
 	}
 	return action, nil

--- a/apps/platform/pkg/datasource/load.go
+++ b/apps/platform/pkg/datasource/load.go
@@ -234,7 +234,7 @@ func performExternalIntegrationLoad(integrationName string, op *wire.LoadOp, con
 // WARNING!!! This is not a shortcut for Load(ops...)---DO NOT CALL THIS unless you know what you're doing
 func LoadOp(op *wire.LoadOp, connection wire.Connection, session *sess.Session) error {
 
-	if err := connection.Load(op, session); err != nil {
+	if err := connection.Load(session.Context(), op, session); err != nil {
 		return err
 	}
 

--- a/apps/platform/pkg/datasource/loadprofile.go
+++ b/apps/platform/pkg/datasource/loadprofile.go
@@ -11,7 +11,7 @@ func LoadAndHydrateProfile(profileKey string, session *sess.Session) (*meta.Prof
 	if err != nil {
 		return nil, err
 	}
-	if err = bundle.Load(profile, nil, session, nil); err != nil {
+	if err = bundle.Load(session.Context(), profile, nil, session, nil); err != nil {
 		return nil, err
 	}
 	// LoadFromSite in the permission sets for this profile
@@ -20,7 +20,7 @@ func LoadAndHydrateProfile(profileKey string, session *sess.Session) (*meta.Prof
 		if err != nil {
 			return nil, err
 		}
-		if err := bundle.Load(permissionSet, nil, session, nil); err != nil {
+		if err := bundle.Load(session.Context(), permissionSet, nil, session, nil); err != nil {
 			return nil, err
 		}
 		profile.PermissionSets = append(profile.PermissionSets, *permissionSet)

--- a/apps/platform/pkg/datasource/metadata.go
+++ b/apps/platform/pkg/datasource/metadata.go
@@ -203,7 +203,7 @@ func LoadCollectionMetadata(key string, metadataCache *wire.MetadataCache, sessi
 		return nil, err
 	}
 
-	err = bundle.Load(collection, nil, session, connection)
+	err = bundle.Load(session.Context(), collection, nil, session, connection)
 	if err != nil {
 		return nil, err
 	}
@@ -215,7 +215,7 @@ func LoadCollectionMetadata(key string, metadataCache *wire.MetadataCache, sessi
 
 	if collectionMetadata.Access != "" {
 		var recordChallengeTokens meta.RecordChallengeTokenCollection
-		err = bundle.LoadAllFromAny(&recordChallengeTokens, &bundlestore.GetAllItemsOptions{
+		err = bundle.LoadAllFromAny(session.Context(), &recordChallengeTokens, &bundlestore.GetAllItemsOptions{
 			Conditions: meta.BundleConditions{"uesio/studio.collection": collectionMetadata.GetKey()},
 		}, adminSession, connection)
 		if err != nil {
@@ -236,7 +236,7 @@ func LoadCollectionMetadata(key string, metadataCache *wire.MetadataCache, sessi
 func LoadAllFieldsMetadata(collectionKey string, collectionMetadata *wire.CollectionMetadata, session *sess.Session, connection wire.Connection) error {
 	var fields meta.FieldCollection
 
-	err := bundle.LoadAllFromAny(&fields, &bundlestore.GetAllItemsOptions{
+	err := bundle.LoadAllFromAny(session.Context(), &fields, &bundlestore.GetAllItemsOptions{
 		Conditions: meta.BundleConditions{
 			"uesio/studio.collection": collectionKey,
 		},
@@ -282,7 +282,7 @@ func LoadFieldsMetadata(keys []string, collectionKey string, collectionMetadata 
 	if len(fields) == 0 {
 		return nil
 	}
-	err := bundle.LoadMany(fields, &bundlestore.GetManyItemsOptions{
+	err := bundle.LoadMany(session.Context(), fields, &bundlestore.GetManyItemsOptions{
 		AllowMissingItems: true,
 	}, session, connection)
 	if err != nil {
@@ -307,7 +307,7 @@ func LoadSelectListMetadata(key string, metadataCache *wire.MetadataCache, sessi
 		if err != nil {
 			return err
 		}
-		if err = bundle.Load(selectList, nil, session, connection); err != nil {
+		if err = bundle.Load(session.Context(), selectList, nil, session, connection); err != nil {
 			return err
 		}
 		metadataCache.AddSelectList(key, &wire.SelectListMetadata{

--- a/apps/platform/pkg/datasource/references.go
+++ b/apps/platform/pkg/datasource/references.go
@@ -52,7 +52,7 @@ func LoadLooper(
 
 	op.AttachMetadataCache(metadata)
 
-	err := connection.Load(op, session)
+	err := connection.Load(session.Context(), op, session)
 	if err != nil {
 		return err
 	}

--- a/apps/platform/pkg/datasource/referencesgroup.go
+++ b/apps/platform/pkg/datasource/referencesgroup.go
@@ -16,7 +16,7 @@ func loadData(op *wire.LoadOp, connection wire.Connection, session *sess.Session
 		return errors.New("you have reached the maximum limit of reference group")
 	}
 
-	err := connection.Load(op, session)
+	err := connection.Load(session.Context(), op, session)
 	if err != nil {
 		return err
 	}

--- a/apps/platform/pkg/datasource/save.go
+++ b/apps/platform/pkg/datasource/save.go
@@ -260,14 +260,14 @@ func SaveOp(op *wire.SaveOp, connection wire.Connection, session *sess.Session) 
 		err = performExternalIntegrationSave(integrationName, op, connection, session)
 	} else {
 		// handle Uesio DB saves
-		err = connection.Save(op, session)
+		err = connection.Save(session.Context(), op, session)
 	}
 	if err != nil {
 		return HandleErrorAndAddToSaveOp(op, err)
 	}
 
 	if !isExternalIntegrationCollection(op) {
-		if err = connection.SetRecordAccessTokens(op, session); err != nil {
+		if err = connection.SetRecordAccessTokens(session.Context(), op, session); err != nil {
 			return err
 		}
 	}

--- a/apps/platform/pkg/datasource/transaction.go
+++ b/apps/platform/pkg/datasource/transaction.go
@@ -10,19 +10,19 @@ func WithTransaction(session *sess.Session, existingConn wire.Connection, fn fun
 	if err != nil {
 		return err
 	}
-	err = conn.BeginTransaction()
+	err = conn.BeginTransaction(session.Context())
 	if err != nil {
 		return err
 	}
 	err = fn(conn)
 	if err != nil {
-		rbErr := conn.RollbackTransaction()
+		rbErr := conn.RollbackTransaction(session.Context())
 		if rbErr != nil {
 			return rbErr
 		}
 		return err
 	}
-	return conn.CommitTransaction()
+	return conn.CommitTransaction(session.Context())
 }
 
 func WithTransactionResult[T any](session *sess.Session, existingConn wire.Connection, fn func(conn wire.Connection) (T, error)) (T, error) {
@@ -31,19 +31,19 @@ func WithTransactionResult[T any](session *sess.Session, existingConn wire.Conne
 	if err != nil {
 		return result, err
 	}
-	err = conn.BeginTransaction()
+	err = conn.BeginTransaction(session.Context())
 	if err != nil {
 		return result, err
 	}
 	result, err = fn(conn)
 	if err != nil {
-		rbErr := conn.RollbackTransaction()
+		rbErr := conn.RollbackTransaction(session.Context())
 		if rbErr != nil {
 			return result, rbErr
 		}
 		return result, err
 	}
-	err = conn.CommitTransaction()
+	err = conn.CommitTransaction(session.Context())
 	if err != nil {
 		return result, err
 	}

--- a/apps/platform/pkg/datasource/usertokens.go
+++ b/apps/platform/pkg/datasource/usertokens.go
@@ -61,7 +61,7 @@ func getTokensForRequest(metadata *wire.MetadataCache, session *sess.Session, to
 	}
 
 	// TBD: Why is connection nil here??
-	if err := bundle.LoadMany(tokens, &bundlestore.GetManyItemsOptions{
+	if err := bundle.LoadMany(session.Context(), tokens, &bundlestore.GetManyItemsOptions{
 		AllowMissingItems:     false,
 		IgnoreUnlicensedItems: true,
 	}, session, nil); err != nil {
@@ -156,7 +156,9 @@ func HydrateTokenMap(tokenMap sess.TokenMap, tokenDefs meta.UserAccessTokenColle
 
 			loadOp.AttachMetadataCache(metadata)
 
-			err = connection.Load(loadOp, adminSession)
+			// intentionally using session context and not adminSession - adminSession is used for permissions
+			// but should not be considered to carry the active context (although it should be the same as session.Context())
+			err = connection.Load(session.Context(), loadOp, adminSession)
 			if err != nil {
 				return err
 			}

--- a/apps/platform/pkg/deploy/createbundle.go
+++ b/apps/platform/pkg/deploy/createbundle.go
@@ -145,7 +145,6 @@ func CreateBundle(options *CreateBundleOptions, connection wire.Connection, sess
 		Version:    workspace.Name,
 		Connection: connection,
 		Workspace:  workspace,
-		Context:    session.Context(),
 	})
 	if err != nil {
 		return nil, err
@@ -155,7 +154,7 @@ func CreateBundle(options *CreateBundleOptions, connection wire.Connection, sess
 	// so that we can easily download everything when needed rather than having to get the individual bundle files.
 	buf := new(bytes.Buffer)
 
-	err = source.GetBundleZip(buf, nil)
+	err = source.GetBundleZip(session.Context(), buf, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -178,18 +177,17 @@ func CreateBundleFromData(data []byte, bundle *meta.Bundle, connection wire.Conn
 	dest, err := bundlestore.GetConnection(bundlestore.ConnectionOptions{
 		Namespace: bundle.App.UniqueKey,
 		Version:   bundle.GetVersionString(),
-		Context:   session.Context(),
 	})
 	if err != nil {
 		return err
 	}
 
-	err = dest.SetBundleZip(bytes.NewReader(data), int64(len(data)))
+	err = dest.SetBundleZip(session.Context(), bytes.NewReader(data), int64(len(data)))
 	if err != nil {
 		return err
 	}
 
-	if _, err = filesource.Upload([]*filesource.FileUploadOp{
+	if _, err = filesource.Upload(session.Context(), []*filesource.FileUploadOp{
 		{
 			Data:         bytes.NewReader(data),
 			Path:         bundle.GetVersionString() + ".zip",

--- a/apps/platform/pkg/deploy/deploy.go
+++ b/apps/platform/pkg/deploy/deploy.go
@@ -351,7 +351,7 @@ func DeployWithOptions(body io.ReadCloser, session *sess.Session, options *Deplo
 	if err = datasource.PlatformSaves(saves, options.Connection, studioSession); err != nil {
 		return err
 	}
-	if _, err = filesource.Upload(uploadOps, options.Connection, studioSession, params); err != nil {
+	if _, err = filesource.Upload(session.Context(), uploadOps, options.Connection, studioSession, params); err != nil {
 		return err
 	}
 

--- a/apps/platform/pkg/featureflagstore/featureflagstore.go
+++ b/apps/platform/pkg/featureflagstore/featureflagstore.go
@@ -22,7 +22,7 @@ func GetFeatureFlag(key string, session *sess.Session, user string) (*meta.Featu
 	if err != nil {
 		return nil, err
 	}
-	err = bundle.Load(flag, nil, session, nil)
+	err = bundle.Load(session.Context(), flag, nil, session, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -50,7 +50,7 @@ func GetFeatureFlag(key string, session *sess.Session, user string) (*meta.Featu
 
 func GetFeatureFlags(session *sess.Session, user string) (*meta.FeatureFlagCollection, error) {
 	featureFlags := meta.FeatureFlagCollection{}
-	err := bundle.LoadAllFromAny(&featureFlags, nil, session, nil)
+	err := bundle.LoadAllFromAny(session.Context(), &featureFlags, nil, session, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -122,7 +122,7 @@ func SetValue(key string, value any, userID string, session *sess.Session) error
 	if err != nil {
 		return err
 	}
-	err = bundle.Load(featureFlag, nil, session, nil)
+	err = bundle.Load(session.Context(), featureFlag, nil, session, nil)
 	if err != nil {
 		return err
 	}

--- a/apps/platform/pkg/fileadapt/fileadapter.go
+++ b/apps/platform/pkg/fileadapt/fileadapter.go
@@ -40,7 +40,7 @@ func GetFileConnection(fileSourceID string, session *sess.Session) (file.Connect
 	if err != nil {
 		return nil, err
 	}
-	err = bundle.Load(fs, nil, session, nil)
+	err = bundle.Load(session.Context(), fs, nil, session, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/apps/platform/pkg/fileadapt/s3/delete.go
+++ b/apps/platform/pkg/fileadapt/s3/delete.go
@@ -1,6 +1,7 @@
 package s3
 
 import (
+	"context"
 	"errors"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -8,9 +9,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 )
 
-func (c *Connection) Delete(path string) error {
+func (c *Connection) Delete(ctx context.Context, path string) error {
 
-	_, err := c.client.DeleteObject(c.ctx, &s3.DeleteObjectInput{
+	_, err := c.client.DeleteObject(ctx, &s3.DeleteObjectInput{
 		Bucket: aws.String(c.bucket),
 		Key:    aws.String(path),
 	})
@@ -22,9 +23,9 @@ func (c *Connection) Delete(path string) error {
 	return nil
 }
 
-func (c *Connection) EmptyDir(path string) error {
+func (c *Connection) EmptyDir(ctx context.Context, path string) error {
 
-	objKeys, err := c.List(path)
+	objKeys, err := c.List(ctx, path)
 	if err != nil {
 		return errors.New("failed to empty directory")
 	}
@@ -38,7 +39,7 @@ func (c *Connection) EmptyDir(path string) error {
 		s3Ids[i] = types.ObjectIdentifier{Key: aws.String(path + fileInfo.Path())}
 	}
 
-	_, err = c.client.DeleteObjects(c.ctx, &s3.DeleteObjectsInput{
+	_, err = c.client.DeleteObjects(ctx, &s3.DeleteObjectsInput{
 		Bucket: aws.String(c.bucket),
 		Delete: &types.Delete{
 			Objects: s3Ids,

--- a/apps/platform/pkg/fileadapt/s3/download.go
+++ b/apps/platform/pkg/fileadapt/s3/download.go
@@ -1,6 +1,7 @@
 package s3
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -36,14 +37,14 @@ func (fm *s3FileMeta) LastModified() time.Time {
 	return fm.s3Output.ModTime()
 }
 
-func (c *Connection) Download(path string) (io.ReadSeekCloser, file.Metadata, error) {
-	bucket, err := s3blob.OpenBucketV2(c.ctx, c.client, c.bucket, nil)
+func (c *Connection) Download(ctx context.Context, path string) (io.ReadSeekCloser, file.Metadata, error) {
+	bucket, err := s3blob.OpenBucketV2(ctx, c.client, c.bucket, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 	defer bucket.Close()
 
-	r, err := bucket.NewReader(c.ctx, path, nil)
+	r, err := bucket.NewReader(ctx, path, nil)
 	if err != nil {
 		var respErr *awshttp.ResponseError
 		if errors.As(err, &respErr) && respErr.HTTPStatusCode() == http.StatusNotFound {

--- a/apps/platform/pkg/fileadapt/s3/list.go
+++ b/apps/platform/pkg/fileadapt/s3/list.go
@@ -1,6 +1,7 @@
 package s3
 
 import (
+	"context"
 	"strings"
 	"time"
 
@@ -35,7 +36,7 @@ func (fm *s3PaginatorFileMeta) LastModified() time.Time {
 	return *fm.s3Output.LastModified
 }
 
-func (c *Connection) List(path string) ([]file.Metadata, error) {
+func (c *Connection) List(ctx context.Context, path string) ([]file.Metadata, error) {
 
 	input := &s3.ListObjectsV2Input{
 		Bucket: aws.String(c.bucket),
@@ -46,7 +47,7 @@ func (c *Connection) List(path string) ([]file.Metadata, error) {
 
 	var paths []file.Metadata
 	for paginator.HasMorePages() {
-		result, err := paginator.NextPage(c.ctx)
+		result, err := paginator.NextPage(ctx)
 		if err != nil {
 			return nil, err
 		}

--- a/apps/platform/pkg/fileadapt/s3/s3.go
+++ b/apps/platform/pkg/fileadapt/s3/s3.go
@@ -23,7 +23,6 @@ func (a *FileAdapter) GetFileConnection(ctx context.Context, credentials *wire.C
 		credentials: credentials,
 		bucket:      bucket,
 		client:      client,
-		ctx:         ctx,
 	}, nil
 }
 
@@ -31,7 +30,6 @@ type Connection struct {
 	credentials *wire.Credentials
 	bucket      string
 	client      *s3.Client
-	ctx         context.Context
 }
 
 // TODO: Figure out a way to clean up and close unused clients

--- a/apps/platform/pkg/fileadapt/s3/upload.go
+++ b/apps/platform/pkg/fileadapt/s3/upload.go
@@ -33,12 +33,12 @@ func (r *contentLengthReader) GetContentLength() int64 {
 	return r.contentLength
 }
 
-func (c *Connection) Upload(req file.FileUploadRequest) (int64, error) {
+func (c *Connection) Upload(ctx context.Context, req file.FileUploadRequest) (int64, error) {
 	uploader := manager.NewUploader(c.client)
-	return handleFileUpload(c.ctx, uploader, c.bucket, req.Data(), req.Path())
+	return handleFileUpload(ctx, uploader, c.bucket, req.Data(), req.Path())
 }
 
-func (c *Connection) UploadMany(reqs []file.FileUploadRequest) ([]int64, error) {
+func (c *Connection) UploadMany(ctx context.Context, reqs []file.FileUploadRequest) ([]int64, error) {
 	uploader := manager.NewUploader(c.client)
 
 	// TODO: make maxRequestUploadConcurrency configurable. This is a "per request" concurrency limit currently. Need
@@ -47,7 +47,7 @@ func (c *Connection) UploadMany(reqs []file.FileUploadRequest) ([]int64, error) 
 	// backend provider as the "host" instance and backend provider will have different resource limitations.
 	maxRequestUploadConcurrency := 5
 	g := &errgroup.Group{}
-	g, uploadCtx := errgroup.WithContext(c.ctx)
+	g, uploadCtx := errgroup.WithContext(ctx)
 	g.SetLimit(maxRequestUploadConcurrency)
 	bytesWritten := make([]int64, len(reqs))
 

--- a/apps/platform/pkg/filesource/delete.go
+++ b/apps/platform/pkg/filesource/delete.go
@@ -1,6 +1,7 @@
 package filesource
 
 import (
+	"context"
 	"errors"
 
 	"github.com/thecloudmasters/uesio/pkg/constant/commonfields"
@@ -10,7 +11,7 @@ import (
 	"github.com/thecloudmasters/uesio/pkg/types/wire"
 )
 
-func Delete(userFileID string, session *sess.Session) error {
+func Delete(ctx context.Context, userFileID string, session *sess.Session) error {
 	userFile := meta.UserFileMetadata{}
 	err := datasource.PlatformLoadOne(
 		&userFile,

--- a/apps/platform/pkg/filesource/download.go
+++ b/apps/platform/pkg/filesource/download.go
@@ -1,6 +1,7 @@
 package filesource
 
 import (
+	"context"
 	"errors"
 	"io"
 
@@ -13,7 +14,7 @@ import (
 	"github.com/thecloudmasters/uesio/pkg/usage"
 )
 
-func DownloadAttachment(recordID string, path string, session *sess.Session) (io.ReadSeekCloser, *meta.UserFileMetadata, error) {
+func DownloadAttachment(ctx context.Context, recordID string, path string, session *sess.Session) (io.ReadSeekCloser, *meta.UserFileMetadata, error) {
 
 	userFile := &meta.UserFileMetadata{}
 	err := datasource.PlatformLoadOne(
@@ -36,10 +37,10 @@ func DownloadAttachment(recordID string, path string, session *sess.Session) (io
 		return nil, nil, err
 	}
 
-	return DownloadItem(userFile, session)
+	return DownloadItem(ctx, userFile, session)
 }
 
-func Download(userFileID string, session *sess.Session) (io.ReadSeekCloser, *meta.UserFileMetadata, error) {
+func Download(ctx context.Context, userFileID string, session *sess.Session) (io.ReadSeekCloser, *meta.UserFileMetadata, error) {
 
 	userFile := &meta.UserFileMetadata{}
 	err := datasource.PlatformLoadOne(
@@ -85,10 +86,10 @@ func Download(userFileID string, session *sess.Session) (io.ReadSeekCloser, *met
 		return nil, nil, err
 	}
 
-	return DownloadItem(userFile, session)
+	return DownloadItem(ctx, userFile, session)
 }
 
-func DownloadItem(userFile *meta.UserFileMetadata, session *sess.Session) (io.ReadSeekCloser, *meta.UserFileMetadata, error) {
+func DownloadItem(ctx context.Context, userFile *meta.UserFileMetadata, session *sess.Session) (io.ReadSeekCloser, *meta.UserFileMetadata, error) {
 
 	if userFile == nil {
 		return nil, nil, errors.New("no file provided")
@@ -101,7 +102,7 @@ func DownloadItem(userFile *meta.UserFileMetadata, session *sess.Session) (io.Re
 
 	fullPath := userFile.GetFullPath(session.GetTenantID())
 
-	r, _, err := conn.Download(fullPath)
+	r, _, err := conn.Download(ctx, fullPath)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/apps/platform/pkg/filesource/upload.go
+++ b/apps/platform/pkg/filesource/upload.go
@@ -1,6 +1,7 @@
 package filesource
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -54,7 +55,7 @@ func getUploadMetadata(metadataResponse *wire.MetadataCache, collectionID, field
 	return collectionMetadata, fieldMetadata, nil
 }
 
-func Upload(ops []*FileUploadOp, connection wire.Connection, session *sess.Session, params map[string]any) ([]*meta.UserFileMetadata, error) {
+func Upload(ctx context.Context, ops []*FileUploadOp, connection wire.Connection, session *sess.Session, params map[string]any) ([]*meta.UserFileMetadata, error) {
 
 	var userFileCollection meta.UserFileMetadataCollection
 	if len(ops) == 0 {
@@ -148,7 +149,7 @@ func Upload(ops []*FileUploadOp, connection wire.Connection, session *sess.Sessi
 			if err != nil {
 				return err
 			}
-			writtenResults, err := conn.UploadMany(reqs)
+			writtenResults, err := conn.UploadMany(ctx, reqs)
 			if err != nil {
 				return err
 			}

--- a/apps/platform/pkg/middleware/authenticate.go
+++ b/apps/platform/pkg/middleware/authenticate.go
@@ -249,7 +249,7 @@ func getLoginRoute(session *sess.Session) (*meta.Route, error) {
 	if err != nil {
 		return nil, err
 	}
-	err = bundle.Load(loginRoute, nil, session, nil)
+	err = bundle.Load(session.Context(), loginRoute, nil, session, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/apps/platform/pkg/routing/deps.go
+++ b/apps/platform/pkg/routing/deps.go
@@ -43,7 +43,7 @@ func loadViewDef(key string, session *sess.Session) (*meta.View, error) {
 		return nil, err
 	}
 
-	err = bundle.Load(subViewDep, nil, session, nil)
+	err = bundle.Load(session.Context(), subViewDep, nil, session, nil)
 	if err != nil {
 		return nil, fmt.Errorf("unable to load SubView '%s': %w", key, err)
 	}
@@ -57,7 +57,7 @@ func loadVariant(key string, session *sess.Session) (*meta.ComponentVariant, err
 		return nil, err
 	}
 
-	err = bundle.Load(variantDep, nil, session, nil)
+	err = bundle.Load(session.Context(), variantDep, nil, session, nil)
 	if err != nil {
 		return nil, fmt.Errorf("unable to load variant '%s': %w", key, err)
 	}
@@ -90,7 +90,7 @@ func addComponentPackToDeps(deps *preload.PreloadMetadata, packNamespace, packNa
 			pack = existingPack
 		}
 	} else {
-		if err := bundle.Load(pack, nil, session, nil); err != nil {
+		if err := bundle.Load(session.Context(), pack, nil, session, nil); err != nil {
 			return err
 		}
 		// TODO: This check can be eventually removed.  It's intended to cover legacy code that
@@ -124,7 +124,7 @@ func getDepsForUtilityComponent(key string, deps *preload.PreloadMetadata, sessi
 
 	utility := meta.NewBaseUtility(namespace, name)
 
-	if err = bundle.Load(utility, nil, session, nil); err != nil {
+	if err = bundle.Load(session.Context(), utility, nil, session, nil); err != nil {
 		return err
 	}
 
@@ -420,7 +420,7 @@ func GetWorkspaceModeDeps(deps *preload.PreloadMetadata, session *sess.Session, 
 
 	baseStudioSession := session.RemoveWorkspaceContext()
 
-	err = bundle.Load(theme, nil, baseStudioSession, nil)
+	err = bundle.Load(session.Context(), theme, nil, baseStudioSession, nil)
 	if err != nil {
 		return err
 	}
@@ -481,13 +481,13 @@ func GetBuilderDependencies(viewNamespace, viewName string, deps *preload.Preloa
 	deps.Component.AddItem(preload.NewComponentMergeData(fmt.Sprintf("%s:metadata:viewdef:%s", builderComponentID, view.GetKey()), viewBytes.String()))
 
 	var variants meta.ComponentVariantCollection
-	err = bundle.LoadAllFromAny(&variants, nil, session, nil)
+	err = bundle.LoadAllFromAny(session.Context(), &variants, nil, session, nil)
 	if err != nil {
 		return fmt.Errorf("failed to load variants: %w", err)
 	}
 
 	var components meta.ComponentCollection
-	err = bundle.LoadAllFromAny(&components, nil, session, nil)
+	err = bundle.LoadAllFromAny(session.Context(), &components, nil, session, nil)
 	if err != nil {
 		return fmt.Errorf("failed to load components: %w", err)
 	}
@@ -532,7 +532,7 @@ func GetMetadataDeps(route *meta.Route, session *sess.Session) (*preload.Preload
 		return nil, err
 	}
 
-	err = bundle.Load(theme, nil, session, nil)
+	err = bundle.Load(session.Context(), theme, nil, session, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -561,7 +561,7 @@ func GetMetadataDeps(route *meta.Route, session *sess.Session) (*preload.Preload
 
 	// Add in fonts
 	var fonts meta.FontCollection
-	err = bundle.LoadAllFromAny(&fonts, nil, session, nil)
+	err = bundle.LoadAllFromAny(session.Context(), &fonts, nil, session, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load fonts: %w", err)
 	}
@@ -572,7 +572,7 @@ func GetMetadataDeps(route *meta.Route, session *sess.Session) (*preload.Preload
 
 	// Add in route assignments
 	var routeAssignments meta.RouteAssignmentCollection
-	err = bundle.LoadAllFromAny(&routeAssignments, nil, session, nil)
+	err = bundle.LoadAllFromAny(session.Context(), &routeAssignments, nil, session, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load route assignments: %w", err)
 	}
@@ -598,14 +598,14 @@ func GetMetadataDeps(route *meta.Route, session *sess.Session) (*preload.Preload
 		collectionMap[assignment.Collection] = collection
 	}
 
-	err = bundle.LoadMany(routes, &bundlestore.GetManyItemsOptions{
+	err = bundle.LoadMany(session.Context(), routes, &bundlestore.GetManyItemsOptions{
 		AllowMissingItems: true,
 	}, session, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load routes for route assignments: %w", err)
 	}
 
-	err = bundle.LoadMany(collections, &bundlestore.GetManyItemsOptions{
+	err = bundle.LoadMany(session.Context(), collections, &bundlestore.GetManyItemsOptions{
 		AllowMissingItems: true,
 	}, session, nil)
 	if err != nil {
@@ -705,7 +705,7 @@ func GetMetadataDeps(route *meta.Route, session *sess.Session) (*preload.Preload
 func addStaticFileModstampsForWorkspaceToDeps(deps *preload.PreloadMetadata, workspace *meta.Workspace, session *sess.Session) error {
 	// Query for all static files in the workspace
 	var files meta.FileCollection
-	err := bundle.LoadAllFromNamespaces([]string{workspace.GetAppFullName()}, &files, nil, session, nil)
+	err := bundle.LoadAllFromNamespaces(session.Context(), []string{workspace.GetAppFullName()}, &files, nil, session, nil)
 	if err != nil {
 		return fmt.Errorf("failed to load static files: %w", err)
 	}
@@ -957,7 +957,7 @@ func addComponentType(key string, deps *preload.PreloadMetadata, subViews map[st
 	if err != nil {
 		return nil, err
 	}
-	err = bundle.Load(component, nil, session, nil)
+	err = bundle.Load(session.Context(), component, nil, session, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/apps/platform/pkg/routing/routing.go
+++ b/apps/platform/pkg/routing/routing.go
@@ -28,7 +28,7 @@ func GetRouteFromKey(key string, session *sess.Session) (*meta.Route, error) {
 	if err != nil {
 		return nil, exceptions.NewNotFoundException(err.Error())
 	}
-	err = bundle.Load(route, nil, session, nil)
+	err = bundle.Load(session.Context(), route, nil, session, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -76,7 +76,7 @@ func GetRouteFromPath(r *http.Request, namespace, path, prefix string, session *
 	}
 
 	// TODO: Figure out why connection has to be nil
-	err := bundle.LoadAll(&routes, namespace, nil, session, nil)
+	err := bundle.LoadAll(session.Context(), &routes, namespace, nil, session, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -133,7 +133,7 @@ func GetRouteFromAssignment(r *http.Request, namespace, collection string, viewt
 	var routeAssignment *meta.RouteAssignment
 	var routeAssignments meta.RouteAssignmentCollection
 
-	err := bundle.LoadAllFromAny(&routeAssignments, &bundlestore.GetAllItemsOptions{
+	err := bundle.LoadAllFromAny(session.Context(), &routeAssignments, &bundlestore.GetAllItemsOptions{
 		Conditions: map[string]any{"uesio/studio.collection": namespace + "." + collection},
 	}, session, nil)
 	if err != nil {
@@ -156,7 +156,7 @@ func GetRouteFromAssignment(r *http.Request, namespace, collection string, viewt
 		return nil, err
 	}
 
-	err = bundle.Load(route, nil, session, nil)
+	err = bundle.Load(session.Context(), route, nil, session, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -187,7 +187,7 @@ func GetRouteFromAssignment(r *http.Request, namespace, collection string, viewt
 func GetRouteByKey(r *http.Request, namespace, routeName string, session *sess.Session, connection wire.Connection) (*meta.Route, error) {
 	route := meta.NewBaseRoute(namespace, routeName)
 	// TODO: connection should not have to be nil
-	err := bundle.Load(route, nil, session, nil)
+	err := bundle.Load(session.Context(), route, nil, session, nil)
 	if err != nil || route == nil {
 		return nil, fmt.Errorf("unable to load route '%s.%s': %w", namespace, routeName, err)
 	}

--- a/apps/platform/pkg/secretstore/secretstore.go
+++ b/apps/platform/pkg/secretstore/secretstore.go
@@ -42,7 +42,7 @@ func getEnvironmentVariableName(secret *meta.Secret) string {
 func GetSecrets(session *sess.Session) (*meta.SecretCollection, error) {
 
 	allSecrets := meta.SecretCollection{}
-	err := bundle.LoadAllFromAny(&allSecrets, nil, session, nil)
+	err := bundle.LoadAllFromAny(session.Context(), &allSecrets, nil, session, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -100,7 +100,7 @@ func GetSecret(key string, session *sess.Session) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if err = bundle.Load(secret, nil, session, nil); err != nil {
+	if err = bundle.Load(session.Context(), secret, nil, session, nil); err != nil {
 		return "", err
 	}
 	return getSecretInternal(secret, session)
@@ -112,7 +112,7 @@ func SetSecret(key, value string, session *sess.Session) error {
 	if err != nil {
 		return err
 	}
-	if err = bundle.Load(secret, nil, session, nil); err != nil {
+	if err = bundle.Load(session.Context(), secret, nil, session, nil); err != nil {
 		return err
 	}
 	return setSecretInternal(secret, value, session)
@@ -123,7 +123,7 @@ func Remove(key string, session *sess.Session) error {
 	if err != nil {
 		return err
 	}
-	err = bundle.Load(secret, nil, session, nil)
+	err = bundle.Load(session.Context(), secret, nil, session, nil)
 	if err != nil {
 		return err
 	}

--- a/apps/platform/pkg/translate/translate.go
+++ b/apps/platform/pkg/translate/translate.go
@@ -17,14 +17,14 @@ func GetTranslatedLabels(session *sess.Session) (map[string]string, error) {
 	userLanguage := session.GetContextUser().Language
 
 	var labels meta.LabelCollection
-	err := bundle.LoadAllFromAny(&labels, nil, session, nil)
+	err := bundle.LoadAllFromAny(session.Context(), &labels, nil, session, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load labels: %w", err)
 	}
 
 	var translations meta.TranslationCollection
 	if userLanguage != "" {
-		err = bundle.LoadAllFromAny(&translations, &bundlestore.GetAllItemsOptions{
+		err = bundle.LoadAllFromAny(session.Context(), &translations, &bundlestore.GetAllItemsOptions{
 			Conditions: meta.BundleConditions{
 				"uesio/studio.language": userLanguage,
 			},

--- a/apps/platform/pkg/truncate/truncate.go
+++ b/apps/platform/pkg/truncate/truncate.go
@@ -25,7 +25,7 @@ func TruncateWorkspaceData(tenantID string, session *sess.Session) error {
 	}
 
 	err := datasource.WithTransaction(session, nil, func(conn wire.Connection) error {
-		return conn.TruncateTenantData(tenantID)
+		return conn.TruncateTenantData(session.Context(), tenantID)
 	})
 	if err != nil {
 		return fmt.Errorf("unable to truncate workspace data: %w", err)

--- a/apps/platform/pkg/types/file/fileconnection.go
+++ b/apps/platform/pkg/types/file/fileconnection.go
@@ -1,6 +1,7 @@
 package file
 
 import (
+	"context"
 	"io"
 )
 
@@ -30,10 +31,10 @@ func (f *fileUploadRequest) Path() string {
 }
 
 type Connection interface {
-	Upload(req FileUploadRequest) (int64, error)
-	UploadMany(reqs []FileUploadRequest) ([]int64, error)
-	Download(path string) (io.ReadSeekCloser, Metadata, error)
-	Delete(path string) error
-	List(path string) ([]Metadata, error)
-	EmptyDir(path string) error
+	Upload(ctx context.Context, req FileUploadRequest) (int64, error)
+	UploadMany(ctx context.Context, reqs []FileUploadRequest) ([]int64, error)
+	Download(ctx context.Context, path string) (io.ReadSeekCloser, Metadata, error)
+	Delete(ctx context.Context, path string) error
+	List(ctx context.Context, path string) ([]Metadata, error)
+	EmptyDir(ctx context.Context, path string) error
 }

--- a/apps/platform/pkg/types/wire/connection.go
+++ b/apps/platform/pkg/types/wire/connection.go
@@ -8,18 +8,17 @@ import (
 )
 
 type Connection interface {
-	Context() context.Context
-	Load(*LoadOp, *sess.Session) error
-	Save(*SaveOp, *sess.Session) error
-	SetRecordAccessTokens(*SaveOp, *sess.Session) error
-	GetRecordAccessTokens(string, *sess.Session) ([]string, error)
-	Migrate(options *migrations.MigrateOptions) error
-	TruncateTenantData(tenantID string) error
-	GetCredentials() *Credentials
-	GetDataSource() string
-	BeginTransaction() error
-	CommitTransaction() error
-	RollbackTransaction() error
-	Publish(channelName, payload string) error
-	Subscribe(channelName string, handler func(payload string)) error
+	Load(context.Context, *LoadOp, *sess.Session) error
+	Save(context.Context, *SaveOp, *sess.Session) error
+	SetRecordAccessTokens(context.Context, *SaveOp, *sess.Session) error
+	GetRecordAccessTokens(context.Context, string, *sess.Session) ([]string, error)
+	Migrate(ctx context.Context, options *migrations.MigrateOptions) error
+	TruncateTenantData(ctx context.Context, tenantID string) error
+	GetCredentials(context.Context) *Credentials
+	GetDataSource(context.Context) string
+	BeginTransaction(context.Context) error
+	CommitTransaction(context.Context) error
+	RollbackTransaction(context.Context) error
+	Publish(ctx context.Context, channelName, payload string) error
+	Subscribe(ctx context.Context, channelName string, handler func(payload string)) error
 }


### PR DESCRIPTION
# What does this PR do?

Eliminates the `Context` property on all `Connection` based types.

# What does this PR not do?

Solve all the underlying issues with context - for example, `sess.Session` still maintains a context and it is still used throughout many places in the code base including changes in this PR where it was used to separate removing context from `Connection` and ultimately removing it from `Session`.

# Details

Previously, when creating various types of connections, a context would be passed in to the "GetConnection" equivalent and then the context that was passed used internally by the connection as needed.  This approach has several shortcomings:

1. In some cases, connections are long lived (e.g. singleton) so every request, which has its own request context, would utilize the context that was applied (typically a background context) when the connection was created.  This could lead to unexpected outcomes data/file wise since the context was not shared for a given request
3. In a lot of functions, we pass a session and a connection and each has a `Context()` accessor - so which do we use?  In theory, they should be the same but in some cases, they aren't and moreover, it's just confusing and very error prone.
4. Not having the same "context" used throughout the entire lifecycle of a request results in our `trace ids` in our logs not being able to be correlated

Recent PRs have been slowly iterating on improving context usage, but this is the first significant change.  There are several more PRs coming that will focus on "session context" (it suffers from similar issues) and ultimately get us to a standard API signature where there's always only one context so its obvious which to use while also ensuring a request only has a "single" context in its lifetime.

What 

# Testing

ci & e2e will cover.
