### PR TITLE
fix: allow system and input params for invokemodel

### DIFF
--- a/apps/platform-integration-tests/hurl_specs/bedrock_integration_actions.hurl
+++ b/apps/platform-integration-tests/hurl_specs/bedrock_integration_actions.hurl
@@ -30,6 +30,27 @@ Uesio Test Model was invoked with the following options:
 }
 ```
 
+# Invoke the deprecated test model with a compatibility mapping
+POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/uesio/tests/dev/integrationactions/run/uesio/aikit/bedrock?action=invokemodel
+{
+    "model": "uesio.test-simple-responder-deprecated",
+    "messages": [],
+		"system": "test",
+		"tools": []
+}
+HTTP 200
+[Asserts]
+```
+Uesio Test Model was invoked with the following options:
+
+{
+  "messages": [],
+  "model": "uesio.test-simple-responder",
+  "system": "test",
+  "tools": []
+}
+```
+
 # Invoke the anthropic test model -- and verify that input and system parameters are expanded
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/uesio/tests/dev/integrationactions/run/uesio/aikit/bedrock?action=invokemodel
 {

--- a/apps/platform-integration-tests/hurl_specs/bedrock_integration_actions.hurl
+++ b/apps/platform-integration-tests/hurl_specs/bedrock_integration_actions.hurl
@@ -30,12 +30,12 @@ Uesio Test Model was invoked with the following options:
 }
 ```
 
-# Invoke the test model -- sanity test
+# Invoke the anthropic test model -- and verify that input and system parameters are expanded
 POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/uesio/tests/dev/integrationactions/run/uesio/aikit/bedrock?action=invokemodel
 {
     "model": "uesio.test-anthropic-format",
     "input": "hello!",
-		"system": "you are a good bot"
+    "system": "you are a good bot"
 }
 HTTP 200
 [Asserts]

--- a/apps/platform-integration-tests/hurl_specs/bedrock_integration_actions.hurl
+++ b/apps/platform-integration-tests/hurl_specs/bedrock_integration_actions.hurl
@@ -29,3 +29,39 @@ Uesio Test Model was invoked with the following options:
   "tools": []
 }
 ```
+
+# Invoke the test model -- sanity test
+POST {{site_scheme}}://studio.{{site_primary_domain}}:{{site_port}}/workspace/uesio/tests/dev/integrationactions/run/uesio/aikit/bedrock?action=invokemodel
+{
+    "model": "uesio.test-anthropic-format",
+    "input": "hello!",
+		"system": "you are a good bot"
+}
+HTTP 200
+[Asserts]
+jsonpath "$[0].text" == ```
+Uesio Test Model was invoked with the following options:
+
+{
+  "max_tokens": 4096,
+  "messages": [
+    {
+      "content": [
+        {
+          "text": "hello!",
+          "type": "text"
+        }
+      ],
+      "role": "user"
+    }
+  ],
+  "model": "uesio.test-anthropic-format",
+  "system": [
+    {
+      "text": "you are a good bot",
+      "type": "text"
+    }
+  ]
+}
+```
+

--- a/apps/platform/pkg/integ/bedrock/bedrock.go
+++ b/apps/platform/pkg/integ/bedrock/bedrock.go
@@ -54,6 +54,8 @@ var modelHandlers = map[string]ModelHandler{
 
 // This maps old, deprecated models to new, supported ones.
 // The key is the deprecated model and the value is the supported one.
+// TODO: We need to think through how we handle model retirement for
+// situations where modelId is speicified in yaml.
 var modelCompatibilityMap = map[string]string{
 	CLAUDE_3_HAIKU_MODEL_ID:               CLAUDE_3_5_HAIKU_MODEL_ID,
 	CLAUDE_3_SONNET_MODEL_ID:              CLAUDE_4_SONNET_MODEL_ID,

--- a/apps/platform/pkg/integ/bedrock/bedrock.go
+++ b/apps/platform/pkg/integ/bedrock/bedrock.go
@@ -26,6 +26,14 @@ type ModelHandler interface {
 	Stream() (stream *integ.Stream, err error)
 }
 
+// Deprecated Model IDs
+const CLAUDE_3_HAIKU_MODEL_ID = "anthropic.claude-3-haiku-20240307-v1:0"
+const CLAUDE_3_SONNET_MODEL_ID = "anthropic.claude-3-sonnet-20240229-v1:0"
+const CLAUDE_3_5_SONNET_MODEL_ID = "anthropic.claude-3-5-sonnet-20241022-v2:0"
+const CLAUDE_3_OPUS_MODEL_ID = "anthropic.claude-3-opus-20240229-v1:0"
+const UESIO_TEST_SIMPLE_MODEL_DEPRECATED_ID = "uesio.test-simple-responder-deprecated"
+
+// Supported Model IDs
 const CLAUDE_3_5_HAIKU_MODEL_ID = "us.anthropic.claude-3-5-haiku-20241022-v1:0"
 const CLAUDE_4_OPUS_MODEL_ID = "us.anthropic.claude-opus-4-20250514-v1:0"
 const CLAUDE_4_SONNET_MODEL_ID = "us.anthropic.claude-sonnet-4-20250514-v1:0"
@@ -44,8 +52,29 @@ var modelHandlers = map[string]ModelHandler{
 	STABILITY_IMAGE_ULTRA_MODEL_ID: stabilityModelHandler,
 }
 
+// This maps old, deprecated models to new, supported ones.
+// The key is the deprecated model and the value is the supported one.
+var modelCompatibilityMap = map[string]string{
+	CLAUDE_3_HAIKU_MODEL_ID:               CLAUDE_3_5_HAIKU_MODEL_ID,
+	CLAUDE_3_SONNET_MODEL_ID:              CLAUDE_4_SONNET_MODEL_ID,
+	CLAUDE_3_5_SONNET_MODEL_ID:            CLAUDE_4_SONNET_MODEL_ID,
+	CLAUDE_3_OPUS_MODEL_ID:                CLAUDE_4_OPUS_MODEL_ID,
+	UESIO_TEST_SIMPLE_MODEL_DEPRECATED_ID: UESIO_TEST_SIMPLE_MODEL_ID,
+}
+
+func getCompatibleModelId(modelID string) string {
+	supportedModelID, hasMapping := modelCompatibilityMap[modelID]
+	if hasMapping {
+		return supportedModelID
+	}
+	return modelID
+}
+
 func getHandler(ic *wire.IntegrationConnection, params map[string]any) (ModelHandler, error) {
 	modelID := param.GetOptionalString(params, "model", BEDROCK_DEFAULT_MODEL_ID)
+	// If the model ID is in the compatibility map, upgrade it to a supported one.
+	// Otherwise, just use the provide modelID.
+	modelID = getCompatibleModelId(modelID)
 	params["model"] = modelID
 	handler, ok := modelHandlers[modelID]
 	if !ok {

--- a/apps/platform/pkg/integ/bedrock/claude.go
+++ b/apps/platform/pkg/integ/bedrock/claude.go
@@ -49,20 +49,34 @@ var claudeModelHandler = &ClaudeModelHandler{}
 func (cmh *ClaudeModelHandler) Hydrate(ic *wire.IntegrationConnection, params map[string]any) error {
 	cmh.ic = ic
 	options := anthropic.MessageNewParams{}
-	// Special case for system parameter sent as string
+
+	// NOTE: Special case for system parameter sent as string
+	// The anthropic sdk will not unmarshal strings correctly into
+	// the "System" option. So we have to manually check for a system
+	// parameter that is a string and set its value.
 	systemPrompt, err := param.GetRequiredString(params, "system")
+	// If no err was returned, that means we successfully parsed the
+	// system parameter as a string.
 	if err == nil {
 		options.System = []anthropic.TextBlockParam{
 			{Text: systemPrompt},
 		}
+		delete(params, "system")
 	}
 
-	// Special case for input parameter
+	// NOTE: Special case for input parameter
+	// To ensure backwards compatibility and to handle simple cases,
+	// we accept an input parameter as the input from the user.
+	// If we find the input parameter, we convert it to the correct
+	// messages API format.
 	input, err := param.GetRequiredString(params, "input")
+	// If no error was returned, that means we successfully parsed the
+	// input parameter as a string.
 	if err == nil {
 		options.Messages = []anthropic.MessageParam{
 			anthropic.NewUserMessage(anthropic.NewTextBlock(input)),
 		}
+		delete(params, "input")
 	}
 	err = datasource.HydrateOptions(params, &options)
 	if err != nil {

--- a/libs/apps/uesio/aikit/bundle/fields/uesio/aikit/thread/agent.yaml
+++ b/libs/apps/uesio/aikit/bundle/fields/uesio/aikit/thread/agent.yaml
@@ -3,4 +3,3 @@ label: Agent
 type: METADATA
 metadata:
   type: AGENT
-required: true


### PR DESCRIPTION
# What does this PR do?

This PR returns the previous functionality of allowing the `uesio/aikit.bedrock` `invokemodel` action to accept an `input` param and a `system` param that are strings.

# Testing

All ai functionality in uesio should continue to work the same. The CRM app ai tab on the lead detail page should work now as well.
