### PR TITLE
Chore/eliminate context from session

### DIFF
--- a/apps/cli/pkg/call/call.go
+++ b/apps/cli/pkg/call/call.go
@@ -2,6 +2,7 @@ package call
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -10,7 +11,7 @@ import (
 	"strings"
 
 	"github.com/thecloudmasters/cli/pkg/config/host"
-	"github.com/thecloudmasters/cli/pkg/context"
+	appcontext "github.com/thecloudmasters/cli/pkg/context"
 	uesiohttp "github.com/thecloudmasters/uesio/pkg/http"
 	"github.com/thecloudmasters/uesio/pkg/middleware"
 	"github.com/thecloudmasters/uesio/pkg/types/exceptions"
@@ -20,7 +21,7 @@ type RequestSpec struct {
 	Method            string
 	Url               string
 	Token             string
-	AppContext        *context.AppContext
+	AppContext        *appcontext.AppContext
 	Body              io.Reader
 	AdditionalHeaders map[string]string
 }
@@ -40,7 +41,7 @@ func Request(r *RequestSpec) (*http.Response, error) {
 		return nil, err
 	}
 
-	req, err := http.NewRequest(r.Method, fmt.Sprintf("%s/%s", hostName, r.Url), r.Body)
+	req, err := http.NewRequestWithContext(context.Background(), r.Method, fmt.Sprintf("%s/%s", hostName, r.Url), r.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -123,7 +124,7 @@ func GetJSON(url, token string, response any) error {
 	return nil
 }
 
-func Delete(url, token string, appContext *context.AppContext) (int, error) {
+func Delete(url, token string, appContext *appcontext.AppContext) (int, error) {
 	resp, err := Request(&RequestSpec{
 		Method:     http.MethodDelete,
 		Url:        url,
@@ -137,7 +138,7 @@ func Delete(url, token string, appContext *context.AppContext) (int, error) {
 	return resp.StatusCode, nil
 }
 
-func Post(url string, payload io.Reader, token string, appContext *context.AppContext) (*http.Response, error) {
+func Post(url string, payload io.Reader, token string, appContext *appcontext.AppContext) (*http.Response, error) {
 	return Request(&RequestSpec{
 		Method:     http.MethodPost,
 		Url:        url,
@@ -147,7 +148,7 @@ func Post(url string, payload io.Reader, token string, appContext *context.AppCo
 	})
 }
 
-func PostForm(url string, payload io.Reader, token string, appContext *context.AppContext) (*http.Response, error) {
+func PostForm(url string, payload io.Reader, token string, appContext *appcontext.AppContext) (*http.Response, error) {
 	return Request(&RequestSpec{
 		Method:     http.MethodPost,
 		Url:        url,
@@ -160,7 +161,7 @@ func PostForm(url string, payload io.Reader, token string, appContext *context.A
 	})
 }
 
-func PostJSON(url, token string, request, response any, appContext *context.AppContext) error {
+func PostJSON(url, token string, request, response any, appContext *appcontext.AppContext) error {
 
 	payloadBytes := &bytes.Buffer{}
 
@@ -182,7 +183,7 @@ func PostJSON(url, token string, request, response any, appContext *context.AppC
 	return nil
 }
 
-func PostBytes(url string, payload io.Reader, token string, appContext *context.AppContext) ([]byte, error) {
+func PostBytes(url string, payload io.Reader, token string, appContext *appcontext.AppContext) ([]byte, error) {
 	return RequestResult(&RequestSpec{
 		Method:     http.MethodPost,
 		Url:        url,

--- a/apps/platform/pkg/adapt/postgresio/load.go
+++ b/apps/platform/pkg/adapt/postgresio/load.go
@@ -423,17 +423,17 @@ func (c *Connection) Load(ctx context.Context, op *wire.LoadOp, session *sess.Se
 	}
 	op.BatchNumber++
 
-	err = datasource.HandleReferencesGroup(c, op.Collection, fieldsResponse.ReferencedGroupCollections, metadata, session)
+	err = datasource.HandleReferencesGroup(ctx, c, op.Collection, fieldsResponse.ReferencedGroupCollections, metadata, session)
 	if err != nil {
 		return err
 	}
 
-	err = datasource.HandleMultiCollectionReferences(c, fieldsResponse.ReferencedColletions, metadata, session)
+	err = datasource.HandleMultiCollectionReferences(ctx, c, fieldsResponse.ReferencedColletions, metadata, session)
 	if err != nil {
 		return err
 	}
 
-	return datasource.HandleReferences(c, fieldsResponse.ReferencedColletions, metadata, session, &datasource.ReferenceOptions{
+	return datasource.HandleReferences(ctx, c, fieldsResponse.ReferencedColletions, metadata, session, &datasource.ReferenceOptions{
 		AllowMissingItems: true,
 	})
 }

--- a/apps/platform/pkg/auth/createlogin.go
+++ b/apps/platform/pkg/auth/createlogin.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"errors"
 
 	"github.com/thecloudmasters/uesio/pkg/constant"
@@ -10,25 +11,25 @@ import (
 	"github.com/thecloudmasters/uesio/pkg/types/wire"
 )
 
-func CreateLogin(signupMethod *meta.SignupMethod, payload AuthRequest, session *sess.Session) error {
-	return datasource.WithTransaction(session, nil, func(conn wire.Connection) error {
-		return CreateLoginWithConnection(signupMethod, payload, conn, session)
+func CreateLogin(ctx context.Context, signupMethod *meta.SignupMethod, payload AuthRequest, session *sess.Session) error {
+	return datasource.WithTransaction(ctx, session, nil, func(conn wire.Connection) error {
+		return CreateLoginWithConnection(ctx, signupMethod, payload, conn, session)
 	})
 }
 
-func CreateLoginWithConnection(signupMethod *meta.SignupMethod, payload AuthRequest, connection wire.Connection, session *sess.Session) error {
+func CreateLoginWithConnection(ctx context.Context, signupMethod *meta.SignupMethod, payload AuthRequest, connection wire.Connection, session *sess.Session) error {
 
 	if !session.GetContextPermissions().HasNamedPermission(constant.UserAdminPerm) {
 		return errors.New("you must be a user admin to create login methods for users")
 	}
 
 	site := session.GetContextSite()
-	systemSession, err := GetSystemSession(session.Context(), site, connection)
+	systemSession, err := GetSystemSession(ctx, site, connection)
 	if err != nil {
 		return err
 	}
 
-	authconn, err := GetAuthConnection(signupMethod.AuthSource, connection, systemSession)
+	authconn, err := GetAuthConnection(ctx, signupMethod.AuthSource, connection, systemSession)
 	if err != nil {
 		return err
 	}
@@ -38,11 +39,11 @@ func CreateLoginWithConnection(signupMethod *meta.SignupMethod, payload AuthRequ
 		return err
 	}
 
-	user, err := GetUserByKey(username, systemSession, connection)
+	user, err := GetUserByKey(ctx, username, systemSession, connection)
 	if err != nil {
 		return err
 	}
 
-	return authconn.CreateLogin(signupMethod, payload, user)
+	return authconn.CreateLogin(ctx, signupMethod, payload, user)
 
 }

--- a/apps/platform/pkg/auth/mock/mockauth.go
+++ b/apps/platform/pkg/auth/mock/mockauth.go
@@ -1,6 +1,7 @@
 package mock
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -32,8 +33,8 @@ type Connection struct {
 	session     *sess.Session
 }
 
-func (c *Connection) Login(loginRequest auth.AuthRequest) (*auth.LoginResult, error) {
-	user, loginMethod, err := c.DoLogin(loginRequest)
+func (c *Connection) Login(ctx context.Context, loginRequest auth.AuthRequest) (*auth.LoginResult, error) {
+	user, loginMethod, err := c.DoLogin(ctx, loginRequest)
 	if err != nil {
 		return nil, err
 	}
@@ -43,34 +44,34 @@ func (c *Connection) Login(loginRequest auth.AuthRequest) (*auth.LoginResult, er
 	}, nil
 }
 
-func (c *Connection) DoLogin(payload auth.AuthRequest) (*meta.User, *meta.LoginMethod, error) {
+func (c *Connection) DoLogin(ctx context.Context, payload auth.AuthRequest) (*meta.User, *meta.LoginMethod, error) {
 	federationID, err := auth.GetPayloadValue(payload, "token")
 	if err != nil {
 		return nil, nil, fmt.Errorf("mock login: %w", err)
 	}
-	return auth.GetUserFromFederationID(c.authSource.GetKey(), federationID, c.connection, c.session)
+	return auth.GetUserFromFederationID(ctx, c.authSource.GetKey(), federationID, c.connection, c.session)
 }
-func (c *Connection) Signup(signupMethod *meta.SignupMethod, payload auth.AuthRequest, username string) error {
+func (c *Connection) Signup(ctx context.Context, signupMethod *meta.SignupMethod, payload auth.AuthRequest, username string) error {
 	return errors.New("mock login: unfortunately you cannot sign up for mock login")
 }
-func (c *Connection) ResetPassword(payload auth.AuthRequest, authenticated bool) (*meta.LoginMethod, error) {
+func (c *Connection) ResetPassword(ctx context.Context, payload auth.AuthRequest, authenticated bool) (*meta.LoginMethod, error) {
 	return nil, errors.New("mock login: unfortunately you cannot change the password")
 }
-func (c *Connection) ConfirmResetPassword(payload auth.AuthRequest) (*meta.User, error) {
+func (c *Connection) ConfirmResetPassword(ctx context.Context, payload auth.AuthRequest) (*meta.User, error) {
 	return nil, errors.New("mock login: unfortunately you cannot change the password")
 }
-func (c *Connection) CreateLogin(signupMethod *meta.SignupMethod, payload auth.AuthRequest, user *meta.User) error {
+func (c *Connection) CreateLogin(ctx context.Context, signupMethod *meta.SignupMethod, payload auth.AuthRequest, user *meta.User) error {
 	return errors.New("mock login: unfortunately you cannot create a login")
 }
-func (c *Connection) ConfirmSignUp(signupMethod *meta.SignupMethod, payload auth.AuthRequest) error {
+func (c *Connection) ConfirmSignUp(ctx context.Context, signupMethod *meta.SignupMethod, payload auth.AuthRequest) error {
 	return errors.New("mock login: unfortunately you cannot change the password")
 }
 func (c *Connection) GetServiceProvider(r *http.Request) (*samlsp.Middleware, error) {
 	return nil, errors.New("saml auth is not supported by this auth source type")
 }
-func (c *Connection) LoginServiceProvider(assertion *saml.Assertion) (*auth.LoginResult, error) {
+func (c *Connection) LoginServiceProvider(ctx context.Context, assertion *saml.Assertion) (*auth.LoginResult, error) {
 	return nil, errors.New("saml auth login is not supported by this auth source type")
 }
-func (c *Connection) LoginCLI(loginRequest auth.AuthRequest) (*auth.LoginResult, error) {
-	return c.Login(loginRequest)
+func (c *Connection) LoginCLI(ctx context.Context, loginRequest auth.AuthRequest) (*auth.LoginResult, error) {
+	return c.Login(ctx, loginRequest)
 }

--- a/apps/platform/pkg/auth/resetpassword.go
+++ b/apps/platform/pkg/auth/resetpassword.go
@@ -13,12 +13,12 @@ func ResetPassword(ctx context.Context, authSourceID string, payload AuthRequest
 	if err != nil {
 		return nil, err
 	}
-	return datasource.WithTransactionResult(session, nil, func(connection wire.Connection) (*meta.LoginMethod, error) {
-		authconn, err := GetAuthConnection(authSourceID, connection, session)
+	return datasource.WithTransactionResult(ctx, session, nil, func(connection wire.Connection) (*meta.LoginMethod, error) {
+		authconn, err := GetAuthConnection(ctx, authSourceID, connection, session)
 		if err != nil {
 			return nil, err
 		}
-		return authconn.ResetPassword(payload, false)
+		return authconn.ResetPassword(ctx, payload, false)
 	})
 }
 
@@ -29,9 +29,9 @@ func ConfirmResetPassword(ctx context.Context, authSourceID string, payload Auth
 		return nil, err
 	}
 
-	authconn, err := GetAuthConnection(authSourceID, nil, session)
+	authconn, err := GetAuthConnection(ctx, authSourceID, nil, session)
 	if err != nil {
 		return nil, err
 	}
-	return authconn.ConfirmResetPassword(payload)
+	return authconn.ConfirmResetPassword(ctx, payload)
 }

--- a/apps/platform/pkg/auth/samlauth/samlauth.go
+++ b/apps/platform/pkg/auth/samlauth/samlauth.go
@@ -153,28 +153,28 @@ func (c *Connection) getSPInternal(requestURL string) (*samlsp.Middleware, error
 
 }
 
-func (c *Connection) Login(loginRequest auth.AuthRequest) (*auth.LoginResult, error) {
+func (c *Connection) Login(ctx context.Context, loginRequest auth.AuthRequest) (*auth.LoginResult, error) {
 	return nil, exceptions.NewBadRequestException("SAML login: unfortunately you cannot login", nil)
 }
-func (c *Connection) Signup(signupMethod *meta.SignupMethod, payload auth.AuthRequest, username string) error {
+func (c *Connection) Signup(ctx context.Context, signupMethod *meta.SignupMethod, payload auth.AuthRequest, username string) error {
 	return exceptions.NewBadRequestException("SAML login: unfortunately you cannot sign up", nil)
 }
-func (c *Connection) ResetPassword(payload auth.AuthRequest, authenticated bool) (*meta.LoginMethod, error) {
+func (c *Connection) ResetPassword(ctx context.Context, payload auth.AuthRequest, authenticated bool) (*meta.LoginMethod, error) {
 	return nil, exceptions.NewBadRequestException("SAML login: unfortunately you cannot change the password", nil)
 }
-func (c *Connection) ConfirmResetPassword(payload auth.AuthRequest) (*meta.User, error) {
+func (c *Connection) ConfirmResetPassword(ctx context.Context, payload auth.AuthRequest) (*meta.User, error) {
 	return nil, exceptions.NewBadRequestException("SAML login: unfortunately you cannot change the password", nil)
 }
-func (c *Connection) CreateLogin(signupMethod *meta.SignupMethod, payload auth.AuthRequest, user *meta.User) error {
+func (c *Connection) CreateLogin(ctx context.Context, signupMethod *meta.SignupMethod, payload auth.AuthRequest, user *meta.User) error {
 	return exceptions.NewBadRequestException("SAML login: unfortunately you cannot create a login", nil)
 }
-func (c *Connection) ConfirmSignUp(signupMethod *meta.SignupMethod, payload auth.AuthRequest) error {
+func (c *Connection) ConfirmSignUp(ctx context.Context, signupMethod *meta.SignupMethod, payload auth.AuthRequest) error {
 	return exceptions.NewBadRequestException("SAML login: unfortunately you cannot change the password", nil)
 }
 func (c *Connection) GetServiceProvider(r *http.Request) (*samlsp.Middleware, error) {
 	return c.getSP(r.Host)
 }
-func (c *Connection) LoginServiceProvider(assertion *saml.Assertion) (*auth.LoginResult, error) {
+func (c *Connection) LoginServiceProvider(ctx context.Context, assertion *saml.Assertion) (*auth.LoginResult, error) {
 	sess, err := samlsp.JWTSessionCodec{}.New(assertion)
 	if err != nil {
 		return nil, err
@@ -184,7 +184,7 @@ func (c *Connection) LoginServiceProvider(assertion *saml.Assertion) (*auth.Logi
 		return nil, errors.New("invalid session type")
 	}
 
-	user, loginMethod, err := auth.GetUserFromFederationID(c.authSource.GetKey(), claims.Subject, c.connection, c.session)
+	user, loginMethod, err := auth.GetUserFromFederationID(ctx, c.authSource.GetKey(), claims.Subject, c.connection, c.session)
 	if err != nil {
 		return nil, err
 	}
@@ -193,6 +193,6 @@ func (c *Connection) LoginServiceProvider(assertion *saml.Assertion) (*auth.Logi
 		PasswordReset: false,
 	}, nil
 }
-func (c *Connection) LoginCLI(loginRequest auth.AuthRequest) (*auth.LoginResult, error) {
+func (c *Connection) LoginCLI(ctx context.Context, loginRequest auth.AuthRequest) (*auth.LoginResult, error) {
 	return nil, exceptions.NewBadRequestException("SAML login: cli login is not supported, please use browser", nil)
 }

--- a/apps/platform/pkg/auth/site.go
+++ b/apps/platform/pkg/auth/site.go
@@ -4,16 +4,16 @@ import (
 	"context"
 	"errors"
 
-	"github.com/go-chi/traceid"
 	"github.com/thecloudmasters/uesio/pkg/datasource"
 	"github.com/thecloudmasters/uesio/pkg/meta"
 	"github.com/thecloudmasters/uesio/pkg/sess"
 	"github.com/thecloudmasters/uesio/pkg/types/wire"
 )
 
-func getDomain(domainType, domain string) (*meta.SiteDomain, error) {
+func getDomain(ctx context.Context, domainType, domain string) (*meta.SiteDomain, error) {
 	var sd meta.SiteDomain
 	err := datasource.PlatformLoadOne(
+		ctx,
 		&sd,
 		&datasource.PlatformLoadOptions{
 			Fields: []wire.LoadRequestField{
@@ -32,7 +32,7 @@ func getDomain(domainType, domain string) (*meta.SiteDomain, error) {
 				},
 			},
 		},
-		sess.GetStudioAnonSession(traceid.NewContext(context.Background())),
+		sess.GetStudioAnonSession(),
 	)
 	if err != nil {
 		return nil, err
@@ -40,47 +40,47 @@ func getDomain(domainType, domain string) (*meta.SiteDomain, error) {
 	return &sd, nil
 }
 
-func querySiteFromDomain(domainType, domain string) (*meta.Site, error) {
-	siteDomain, err := getDomain(domainType, domain)
+func querySiteFromDomain(ctx context.Context, domainType, domain string) (*meta.Site, error) {
+	siteDomain, err := getDomain(ctx, domainType, domain)
 	if err != nil {
 		return nil, err
 	}
 	if siteDomain == nil {
 		return nil, errors.New("no site domain record for that host")
 	}
-	return datasource.QuerySiteByID(siteDomain.Site.ID, sess.GetStudioAnonSession(traceid.NewContext(context.Background())), nil)
+	return datasource.QuerySiteByID(ctx, siteDomain.Site.ID, sess.GetStudioAnonSession(), nil)
 }
 
-func GetPublicUser(site *meta.Site, connection wire.Connection) (*meta.User, error) {
+func GetPublicUser(ctx context.Context, site *meta.Site, connection wire.Connection) (*meta.User, error) {
 	if site == nil {
 		return nil, errors.New("no site provided")
 	}
-	return GetUserByKey(meta.PublicUsername, sess.GetAnonSession(traceid.NewContext(context.Background()), site), connection)
+	return GetUserByKey(ctx, meta.PublicUsername, sess.GetAnonSession(site), connection)
 }
 
 func GetPublicSession(ctx context.Context, site *meta.Site, connection wire.Connection) (*sess.Session, error) {
-	publicUser, err := GetPublicUser(site, connection)
+	publicUser, err := GetPublicUser(ctx, site, connection)
 	if err != nil {
 		return nil, err
 	}
 	return GetSessionFromUser(ctx, publicUser, site, "")
 }
 
-func GetSystemUser(site *meta.Site, connection wire.Connection) (*meta.User, error) {
+func GetSystemUser(ctx context.Context, site *meta.Site, connection wire.Connection) (*meta.User, error) {
 	if site == nil {
 		return nil, errors.New("no site provided")
 	}
-	return GetUserByKey(meta.SystemUsername, sess.GetAnonSession(traceid.NewContext(context.Background()), site), connection)
+	return GetUserByKey(ctx, meta.SystemUsername, sess.GetAnonSession(site), connection)
 }
 
 func GetSystemSession(ctx context.Context, site *meta.Site, connection wire.Connection) (*sess.Session, error) {
-	user, err := GetSystemUser(site, connection)
+	user, err := GetSystemUser(ctx, site, connection)
 	if err != nil {
 		return nil, err
 	}
 
 	user.Permissions = meta.GetAdminPermissionSet()
-	session := sess.New(ctx, user, site)
+	session := sess.New(user, site)
 	return session, nil
 }
 

--- a/apps/platform/pkg/bot/declarativedialect/declarativedialect.go
+++ b/apps/platform/pkg/bot/declarativedialect/declarativedialect.go
@@ -1,6 +1,7 @@
 package declarativedialect
 
 import (
+	"context"
 	"errors"
 	"net/http"
 
@@ -74,18 +75,18 @@ func runStep(stepDef *yaml.Node, api any) error {
 	}
 }
 
-func (b *DeclarativeDialect) BeforeSave(bot *meta.Bot, request *wire.SaveOp, connection wire.Connection, session *sess.Session) error {
-	botAPI := jsdialect.NewBeforeSaveAPI(bot, request, connection, session)
+func (b *DeclarativeDialect) BeforeSave(ctx context.Context, bot *meta.Bot, request *wire.SaveOp, connection wire.Connection, session *sess.Session) error {
+	botAPI := jsdialect.NewBeforeSaveAPI(ctx, bot, request, connection, session)
 	return runSteps((*yaml.Node)(bot.Definition), botAPI)
 }
 
-func (b *DeclarativeDialect) AfterSave(bot *meta.Bot, request *wire.SaveOp, connection wire.Connection, session *sess.Session) error {
-	botAPI := jsdialect.NewAfterSaveAPI(bot, request, connection, session)
+func (b *DeclarativeDialect) AfterSave(ctx context.Context, bot *meta.Bot, request *wire.SaveOp, connection wire.Connection, session *sess.Session) error {
+	botAPI := jsdialect.NewAfterSaveAPI(ctx, bot, request, connection, session)
 	return runSteps((*yaml.Node)(bot.Definition), botAPI)
 }
 
-func (b *DeclarativeDialect) CallBot(bot *meta.Bot, params map[string]any, connection wire.Connection, session *sess.Session) (map[string]any, error) {
-	botAPI := jsdialect.NewCallBotAPI(bot, session, connection, params)
+func (b *DeclarativeDialect) CallBot(ctx context.Context, bot *meta.Bot, params map[string]any, connection wire.Connection, session *sess.Session) (map[string]any, error) {
+	botAPI := jsdialect.NewCallBotAPI(ctx, bot, session, connection, params)
 	err := runSteps((*yaml.Node)(bot.Definition), botAPI)
 	if err != nil {
 		return nil, err
@@ -93,22 +94,22 @@ func (b *DeclarativeDialect) CallBot(bot *meta.Bot, params map[string]any, conne
 	return botAPI.Results, nil
 }
 
-func (b *DeclarativeDialect) CallGeneratorBot(bot *meta.Bot, create bundlestore.FileCreator, params map[string]any, connection wire.Connection, session *sess.Session) (map[string]any, error) {
+func (b *DeclarativeDialect) CallGeneratorBot(ctx context.Context, bot *meta.Bot, create bundlestore.FileCreator, params map[string]any, connection wire.Connection, session *sess.Session) (map[string]any, error) {
 	return nil, errors.New("declarative dialect not implemented yet")
 }
 
-func (b *DeclarativeDialect) RouteBot(bot *meta.Bot, route *meta.Route, request *http.Request, connection wire.Connection, session *sess.Session) (*meta.Route, error) {
+func (b *DeclarativeDialect) RouteBot(ctx context.Context, bot *meta.Bot, route *meta.Route, request *http.Request, connection wire.Connection, session *sess.Session) (*meta.Route, error) {
 	return nil, errors.New("declarative dialect not implemented yet")
 }
 
-func (b *DeclarativeDialect) LoadBot(bot *meta.Bot, op *wire.LoadOp, connection wire.Connection, session *sess.Session) error {
+func (b *DeclarativeDialect) LoadBot(ctx context.Context, bot *meta.Bot, op *wire.LoadOp, connection wire.Connection, session *sess.Session) error {
 	return errors.New("declarative dialect not implemented yet")
 }
 
-func (b *DeclarativeDialect) SaveBot(bot *meta.Bot, op *wire.SaveOp, connection wire.Connection, session *sess.Session) error {
+func (b *DeclarativeDialect) SaveBot(ctx context.Context, bot *meta.Bot, op *wire.SaveOp, connection wire.Connection, session *sess.Session) error {
 	return errors.New("declarative dialect not implemented yet")
 }
 
-func (b *DeclarativeDialect) RunIntegrationActionBot(bot *meta.Bot, ic *wire.IntegrationConnection, actionName string, params map[string]any) (any, error) {
+func (b *DeclarativeDialect) RunIntegrationActionBot(ctx context.Context, bot *meta.Bot, ic *wire.IntegrationConnection, actionName string, params map[string]any) (any, error) {
 	return nil, errors.New("declarative dialect not implemented yet")
 }

--- a/apps/platform/pkg/bot/dialects.go
+++ b/apps/platform/pkg/bot/dialects.go
@@ -1,6 +1,7 @@
 package bot
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
@@ -13,10 +14,12 @@ import (
 var botDialectMap = map[string]BotDialect{}
 
 func RegisterBotDialect(name string, dialect BotDialect) {
+	// TODO: This needs to be synchronized!
 	botDialectMap[name] = dialect
 }
 
 func GetBotDialect(botDialectName string) (BotDialect, error) {
+	// TODO: This needs to be synchronized!
 	dialectKey, ok := meta.GetBotDialects()[botDialectName]
 	if !ok {
 		return nil, fmt.Errorf("invalid bot dialect name: %s", botDialectName)
@@ -29,12 +32,12 @@ func GetBotDialect(botDialectName string) (BotDialect, error) {
 }
 
 type BotDialect interface {
-	BeforeSave(bot *meta.Bot, request *wire.SaveOp, connection wire.Connection, session *sess.Session) error
-	AfterSave(bot *meta.Bot, request *wire.SaveOp, connection wire.Connection, session *sess.Session) error
-	CallBot(bot *meta.Bot, params map[string]any, connection wire.Connection, session *sess.Session) (map[string]any, error)
-	CallGeneratorBot(bot *meta.Bot, create bundlestore.FileCreator, params map[string]any, connection wire.Connection, session *sess.Session) (map[string]any, error)
-	RouteBot(bot *meta.Bot, route *meta.Route, request *http.Request, connection wire.Connection, session *sess.Session) (*meta.Route, error)
-	LoadBot(bot *meta.Bot, op *wire.LoadOp, connection wire.Connection, session *sess.Session) error
-	SaveBot(bot *meta.Bot, op *wire.SaveOp, connection wire.Connection, session *sess.Session) error
-	RunIntegrationActionBot(bot *meta.Bot, integration *wire.IntegrationConnection, actionName string, params map[string]any) (any, error)
+	BeforeSave(ctx context.Context, bot *meta.Bot, request *wire.SaveOp, connection wire.Connection, session *sess.Session) error
+	AfterSave(ctx context.Context, bot *meta.Bot, request *wire.SaveOp, connection wire.Connection, session *sess.Session) error
+	CallBot(ctx context.Context, bot *meta.Bot, params map[string]any, connection wire.Connection, session *sess.Session) (map[string]any, error)
+	CallGeneratorBot(ctx context.Context, bot *meta.Bot, create bundlestore.FileCreator, params map[string]any, connection wire.Connection, session *sess.Session) (map[string]any, error)
+	RouteBot(ctx context.Context, bot *meta.Bot, route *meta.Route, request *http.Request, connection wire.Connection, session *sess.Session) (*meta.Route, error)
+	LoadBot(ctx context.Context, bot *meta.Bot, op *wire.LoadOp, connection wire.Connection, session *sess.Session) error
+	SaveBot(ctx context.Context, bot *meta.Bot, op *wire.SaveOp, connection wire.Connection, session *sess.Session) error
+	RunIntegrationActionBot(ctx context.Context, bot *meta.Bot, integration *wire.IntegrationConnection, actionName string, params map[string]any) (any, error)
 }

--- a/apps/platform/pkg/bot/jsdialect/aftersave.go
+++ b/apps/platform/pkg/bot/jsdialect/aftersave.go
@@ -1,6 +1,8 @@
 package jsdialect
 
 import (
+	"context"
+
 	"github.com/thecloudmasters/uesio/pkg/configstore"
 	"github.com/thecloudmasters/uesio/pkg/meta"
 	"github.com/thecloudmasters/uesio/pkg/sess"
@@ -16,10 +18,13 @@ type AfterSaveAPI struct {
 	op         *wire.SaveOp
 	session    *sess.Session
 	connection wire.Connection
-	AsAdmin    AsAdminApi `bot:"asAdmin"`
+	AsAdmin    *AsAdminApi `bot:"asAdmin"`
+	// Intentionally maintaining a context here because this code is called from javascript so we have to keep track of the context
+	// upon creation so we can use as the bot processes. This is an exception to the rule of avoiding keeping context in structs.
+	ctx context.Context
 }
 
-func NewAfterSaveAPI(bot *meta.Bot, request *wire.SaveOp, connection wire.Connection, session *sess.Session) *AfterSaveAPI {
+func NewAfterSaveAPI(ctx context.Context, bot *meta.Bot, request *wire.SaveOp, connection wire.Connection, session *sess.Session) *AfterSaveAPI {
 	return &AfterSaveAPI{
 		Inserts: &InsertsAPI{
 			op: request,
@@ -30,14 +35,12 @@ func NewAfterSaveAPI(bot *meta.Bot, request *wire.SaveOp, connection wire.Connec
 		Deletes: &DeletesAPI{
 			op: request,
 		},
-		LogApi:     NewBotLogAPI(bot, session.Context()),
+		LogApi:     NewBotLogAPI(ctx, bot),
 		session:    session,
 		op:         request,
 		connection: connection,
-		AsAdmin: AsAdminApi{
-			session:    session,
-			connection: connection,
-		},
+		AsAdmin:    NewAsAdminAPI(ctx, session, connection),
+		ctx:        ctx,
 	}
 }
 
@@ -46,31 +49,31 @@ func (as *AfterSaveAPI) AddError(message string) {
 }
 
 func (as *AfterSaveAPI) Save(collection string, changes wire.Collection, options *wire.SaveOptions) (*wire.Collection, error) {
-	return botSave(collection, changes, options, as.session, as.connection, nil)
+	return botSave(as.ctx, collection, changes, options, as.session, as.connection, nil)
 }
 
 func (as *AfterSaveAPI) Delete(collection string, deletes wire.Collection) error {
-	return botDelete(collection, deletes, as.session, as.connection, nil)
+	return botDelete(as.ctx, collection, deletes, as.session, as.connection, nil)
 }
 
 func (as *AfterSaveAPI) Load(request BotLoadOp) (*wire.Collection, error) {
-	return botLoad(request, as.session, as.connection, nil)
+	return botLoad(as.ctx, request, as.session, as.connection, nil)
 }
 
 func (as *AfterSaveAPI) RunIntegrationAction(integrationID string, action string, options any) (any, error) {
-	return runIntegrationAction(integrationID, action, options, as.session, as.connection)
+	return runIntegrationAction(as.ctx, integrationID, action, options, as.session, as.connection)
 }
 
 func (as *AfterSaveAPI) GetConfigValue(configValueKey string) (string, error) {
-	return configstore.GetValue(configValueKey, as.session)
+	return configstore.GetValue(as.ctx, configValueKey, as.session)
 }
 
 func (as *AfterSaveAPI) CallBot(botKey string, params map[string]any) (any, error) {
-	return botCall(botKey, params, as.session, as.connection)
+	return botCall(as.ctx, botKey, params, as.session, as.connection)
 }
 
 func (as *AfterSaveAPI) GetHostUrl() (string, error) {
-	return getHostUrl(as.session, as.connection)
+	return getHostUrl(as.ctx, as.session, as.connection)
 }
 
 func (as *AfterSaveAPI) GetFileUrl(sourceKey, sourcePath string) string {
@@ -82,5 +85,5 @@ func (as *AfterSaveAPI) MergeTemplate(templateString string, params map[string]a
 }
 
 func (as *AfterSaveAPI) MergeTemplateFile(sourceKey, sourcePath string, params map[string]any) (string, error) {
-	return mergeTemplateFile(sourceKey, sourcePath, params, as.session, as.connection)
+	return mergeTemplateFile(as.ctx, sourceKey, sourcePath, params, as.session, as.connection)
 }

--- a/apps/platform/pkg/bot/jsdialect/asadminapi.go
+++ b/apps/platform/pkg/bot/jsdialect/asadminapi.go
@@ -1,37 +1,50 @@
 package jsdialect
 
 import (
+	"context"
+
 	"github.com/thecloudmasters/uesio/pkg/configstore"
 	"github.com/thecloudmasters/uesio/pkg/datasource"
 	"github.com/thecloudmasters/uesio/pkg/sess"
 	"github.com/thecloudmasters/uesio/pkg/types/wire"
 )
 
+func NewAsAdminAPI(ctx context.Context, session *sess.Session, connection wire.Connection) *AsAdminApi {
+	return &AsAdminApi{
+		session:    session,
+		connection: connection,
+		ctx:        ctx,
+	}
+}
+
 type AsAdminApi struct {
 	session    *sess.Session
 	connection wire.Connection
+	// Intentionally maintaining a context here because this code is called from javascript so we have to keep track of the context
+	// upon creation so we can use as the bot processes. This is an exception to the rule of avoiding keeping context in structs.
+	ctx context.Context
 }
 
 func (aaa *AsAdminApi) Save(collection string, changes wire.Collection, options *wire.SaveOptions) (*wire.Collection, error) {
-	return botSave(collection, changes, options, datasource.GetSiteAdminSession(aaa.session), aaa.connection, nil)
+	return botSave(aaa.ctx, collection, changes, options, datasource.GetSiteAdminSession(aaa.session), aaa.connection, nil)
 }
 
 func (aaa *AsAdminApi) Delete(collection string, deletes wire.Collection) error {
-	return botDelete(collection, deletes, datasource.GetSiteAdminSession(aaa.session), aaa.connection, nil)
+	return botDelete(aaa.ctx, collection, deletes, datasource.GetSiteAdminSession(aaa.session), aaa.connection, nil)
 }
 
 func (aaa *AsAdminApi) RunIntegrationAction(integrationID string, action string, options any) (any, error) {
-	return runIntegrationAction(integrationID, action, options, datasource.GetSiteAdminSession(aaa.session), aaa.connection)
+	return runIntegrationAction(aaa.ctx, integrationID, action, options, datasource.GetSiteAdminSession(aaa.session), aaa.connection)
 }
 
 func (aaa *AsAdminApi) CallBot(botKey string, params map[string]any) (any, error) {
-	return botCall(botKey, params, aaa.session, aaa.connection)
+	return botCall(aaa.ctx, botKey, params, aaa.session, aaa.connection)
 }
 
 func (aaa *AsAdminApi) GetConfigValue(configValueKey string) (string, error) {
-	return configstore.GetValue(configValueKey, datasource.GetSiteAdminSession(aaa.session))
+	return configstore.GetValue(aaa.ctx, configValueKey, datasource.GetSiteAdminSession(aaa.session))
 }
 
 func (aaa *AsAdminApi) Load(request BotLoadOp) (*wire.Collection, error) {
-	return botLoad(request, datasource.GetSiteAdminSession(aaa.session), aaa.connection, nil)
+	return botLoad(aaa.ctx, request, datasource.GetSiteAdminSession(aaa.session), aaa.connection, nil)
 }

--- a/apps/platform/pkg/bot/jsdialect/beforesave.go
+++ b/apps/platform/pkg/bot/jsdialect/beforesave.go
@@ -1,6 +1,8 @@
 package jsdialect
 
 import (
+	"context"
+
 	"github.com/thecloudmasters/uesio/pkg/configstore"
 	"github.com/thecloudmasters/uesio/pkg/meta"
 	"github.com/thecloudmasters/uesio/pkg/sess"
@@ -16,17 +18,21 @@ type BeforeSaveAPI struct {
 	op         *wire.SaveOp
 	session    *sess.Session
 	connection wire.Connection
+	// Intentionally maintaining a context here because this code is called from javascript so we have to keep track of the context
+	// upon creation so we can use as the bot processes. This is an exception to the rule of avoiding keeping context in structs.
+	ctx context.Context
 }
 
-func NewBeforeSaveAPI(bot *meta.Bot, op *wire.SaveOp, connection wire.Connection, session *sess.Session) *BeforeSaveAPI {
+func NewBeforeSaveAPI(ctx context.Context, bot *meta.Bot, op *wire.SaveOp, connection wire.Connection, session *sess.Session) *BeforeSaveAPI {
 	return &BeforeSaveAPI{
 		Inserts:    &InsertsAPI{op},
 		Updates:    &UpdatesAPI{op},
 		Deletes:    &DeletesAPI{op},
-		LogApi:     NewBotLogAPI(bot, session.Context()),
+		LogApi:     NewBotLogAPI(ctx, bot),
 		session:    session,
 		op:         op,
 		connection: connection,
+		ctx:        ctx,
 	}
 }
 
@@ -35,25 +41,25 @@ func (bs *BeforeSaveAPI) AddError(message string) {
 }
 
 func (bs *BeforeSaveAPI) Save(collection string, changes wire.Collection, options *wire.SaveOptions) (*wire.Collection, error) {
-	return botSave(collection, changes, options, bs.session, bs.connection, nil)
+	return botSave(bs.ctx, collection, changes, options, bs.session, bs.connection, nil)
 }
 
 func (bs *BeforeSaveAPI) Delete(collection string, deletes wire.Collection) error {
-	return botDelete(collection, deletes, bs.session, bs.connection, nil)
+	return botDelete(bs.ctx, collection, deletes, bs.session, bs.connection, nil)
 }
 
 func (bs *BeforeSaveAPI) Load(request BotLoadOp) (*wire.Collection, error) {
-	return botLoad(request, bs.session, bs.connection, nil)
+	return botLoad(bs.ctx, request, bs.session, bs.connection, nil)
 }
 
 func (bs *BeforeSaveAPI) RunIntegrationAction(integrationID string, action string, options any) (any, error) {
-	return runIntegrationAction(integrationID, action, options, bs.session, bs.connection)
+	return runIntegrationAction(bs.ctx, integrationID, action, options, bs.session, bs.connection)
 }
 
 func (bs *BeforeSaveAPI) GetConfigValue(configValueKey string) (string, error) {
-	return configstore.GetValue(configValueKey, bs.session)
+	return configstore.GetValue(bs.ctx, configValueKey, bs.session)
 }
 
 func (bs *BeforeSaveAPI) CallBot(botKey string, params map[string]any) (any, error) {
-	return botCall(botKey, params, bs.session, bs.connection)
+	return botCall(bs.ctx, botKey, params, bs.session, bs.connection)
 }

--- a/apps/platform/pkg/bot/jsdialect/bothttpapi_test.go
+++ b/apps/platform/pkg/bot/jsdialect/bothttpapi_test.go
@@ -34,7 +34,7 @@ func getIntegrationConnection(authType string, credentials *wire.Credentials) *w
 	user := &meta.User{
 		BuiltIn: meta.BuiltIn{ID: "user123"},
 	}
-	s := sess.New(context.Background(), user, site)
+	s := sess.New(user, site)
 	return wire.NewIntegrationConnection(
 		&meta.Integration{
 			BundleableBase: meta.BundleableBase{
@@ -92,15 +92,15 @@ func Test_Request(t *testing.T) {
 	var noOpSave oauth2.CredentialSaver
 	var noOpDelete oauth2.CredentialSaver
 
-	noOpFetch = func(ic *wire.IntegrationConnection) (*wire.Item, error) {
+	noOpFetch = func(ctx context.Context, ic *wire.IntegrationConnection) (*wire.Item, error) {
 		credentialFetchCalled = true
 		return nil, nil
 	}
-	noOpSave = func(item *wire.Item, ic *wire.IntegrationConnection) error {
+	noOpSave = func(ctx context.Context, item *wire.Item, ic *wire.IntegrationConnection) error {
 		credentialSaveCalled = true
 		return nil
 	}
-	noOpDelete = func(item *wire.Item, ic *wire.IntegrationConnection) error {
+	noOpDelete = func(ctx context.Context, item *wire.Item, ic *wire.IntegrationConnection) error {
 		return nil
 	}
 
@@ -691,7 +691,7 @@ func Test_Request(t *testing.T) {
 				}),
 				credentialAccessors: &oauth2.CredentialAccessors{
 					Fetch: noOpFetch,
-					Save: func(item *wire.Item, ic *wire.IntegrationConnection) error {
+					Save: func(ctx context.Context, item *wire.Item, ic *wire.IntegrationConnection) error {
 						credentialSaveCalled = true
 						// Verify that the expected fields were called
 						accessToken, _ := item.GetField(oauth2.AccessTokenField)
@@ -761,7 +761,7 @@ func Test_Request(t *testing.T) {
 					"scopes":       "api,refresh_token",
 				}),
 				credentialAccessors: &oauth2.CredentialAccessors{
-					Fetch: func(ic *wire.IntegrationConnection) (*wire.Item, error) {
+					Fetch: func(ctx context.Context, ic *wire.IntegrationConnection) (*wire.Item, error) {
 						credentialFetchCalled = true
 						item := &wire.Item{
 							oauth2.AccessTokenField:           "abcd1234",
@@ -808,7 +808,7 @@ func Test_Request(t *testing.T) {
 					"clientSecret": "muchsecret",
 				}),
 				credentialAccessors: &oauth2.CredentialAccessors{
-					Fetch: func(ic *wire.IntegrationConnection) (*wire.Item, error) {
+					Fetch: func(ctx context.Context, ic *wire.IntegrationConnection) (*wire.Item, error) {
 						credentialFetchCalled = true
 						item := &wire.Item{
 							oauth2.AccessTokenField:           "oldtoken",
@@ -817,7 +817,7 @@ func Test_Request(t *testing.T) {
 						}
 						return item, nil
 					},
-					Save: func(item *wire.Item, ic *wire.IntegrationConnection) error {
+					Save: func(ctx context.Context, item *wire.Item, ic *wire.IntegrationConnection) error {
 						credentialSaveCalled = true
 						// Verify that the expected fields were provided
 						accessToken, _ := item.GetField(oauth2.AccessTokenField)
@@ -892,7 +892,7 @@ func Test_Request(t *testing.T) {
 			}
 			credentialSaveCalled = false
 			credentialFetchCalled = false
-			botApi := NewBotHttpAPI(tt.args.integration)
+			botApi := NewBotHttpAPI(context.Background(), tt.args.integration)
 			serveResponseBody = tt.args.response
 			serveContentType = tt.args.responseContentType
 			serveStatusCode = tt.args.responseStatusCode

--- a/apps/platform/pkg/bot/jsdialect/botlogapi.go
+++ b/apps/platform/pkg/bot/jsdialect/botlogapi.go
@@ -17,12 +17,14 @@ type BotLogAPI struct {
 	ctx     context.Context
 }
 
-func NewBotLogAPI(bot *meta.Bot, ctx context.Context) *BotLogAPI {
+func NewBotLogAPI(ctx context.Context, bot *meta.Bot) *BotLogAPI {
 	return &BotLogAPI{
 		bot:     bot,
 		counter: 0,
 		start:   time.Now(),
-		ctx:     ctx,
+		// Intentionally maintaining a context here because this code is called from javascript so we have to keep track of the context
+		// upon creation so we can use as the bot processes. This is an exception to the rule of avoiding keeping context in structs.
+		ctx: ctx,
 	}
 }
 

--- a/apps/platform/pkg/bot/jsdialect/callbot.go
+++ b/apps/platform/pkg/bot/jsdialect/callbot.go
@@ -1,29 +1,29 @@
 package jsdialect
 
 import (
+	"context"
+
 	"github.com/thecloudmasters/uesio/pkg/configstore"
 	"github.com/thecloudmasters/uesio/pkg/meta"
 	"github.com/thecloudmasters/uesio/pkg/sess"
 	"github.com/thecloudmasters/uesio/pkg/types/wire"
 )
 
-func NewCallBotAPI(bot *meta.Bot, session *sess.Session, connection wire.Connection, params map[string]any) *CallBotAPI {
+func NewCallBotAPI(ctx context.Context, bot *meta.Bot, session *sess.Session, connection wire.Connection, params map[string]any) *CallBotAPI {
 	return &CallBotAPI{
 		Session: session,
 		Params: &ParamsAPI{
 			Params: params,
 		},
-		AsAdmin: AsAdminApi{
-			session:    session,
-			connection: connection,
-		},
+		AsAdmin:    NewAsAdminAPI(ctx, session, connection),
 		errors:     []string{},
 		connection: connection,
 		metadata:   &wire.MetadataCache{},
 		bot:        bot,
 		Results:    map[string]any{},
-		LogApi:     NewBotLogAPI(bot, session.Context()),
-		Http:       NewBotHttpAPI(wire.NewIntegrationConnection(nil, nil, session, nil, connection)),
+		LogApi:     NewBotLogAPI(ctx, bot),
+		Http:       NewBotHttpAPI(ctx, wire.NewIntegrationConnection(nil, nil, session, nil, connection)),
+		ctx:        ctx,
 	}
 }
 
@@ -34,10 +34,13 @@ type CallBotAPI struct {
 	bot        *meta.Bot
 	errors     []string
 	metadata   *wire.MetadataCache
-	Results    map[string]any
-	AsAdmin    AsAdminApi  `bot:"asAdmin"`
-	LogApi     *BotLogAPI  `bot:"log"`
-	Http       *BotHttpAPI `bot:"http"`
+	// Intentionally maintaining a context here because this code is called from javascript so we have to keep track of the context
+	// upon creation so we can use as the bot processes. This is an exception to the rule of avoiding keeping context in structs.
+	ctx     context.Context
+	Results map[string]any
+	AsAdmin *AsAdminApi `bot:"asAdmin"`
+	LogApi  *BotLogAPI  `bot:"log"`
+	Http    *BotHttpAPI `bot:"http"`
 }
 
 func (cba *CallBotAPI) AddError(message string) {
@@ -53,31 +56,31 @@ func (cba *CallBotAPI) AddResult(key string, value any) {
 }
 
 func (cba *CallBotAPI) Save(collection string, changes wire.Collection, options *wire.SaveOptions) (*wire.Collection, error) {
-	return botSave(collection, changes, options, cba.Session, cba.connection, cba.metadata)
+	return botSave(cba.ctx, collection, changes, options, cba.Session, cba.connection, cba.metadata)
 }
 
 func (cba *CallBotAPI) Delete(collection string, deletes wire.Collection) error {
-	return botDelete(collection, deletes, cba.Session, cba.connection, cba.metadata)
+	return botDelete(cba.ctx, collection, deletes, cba.Session, cba.connection, cba.metadata)
 }
 
 func (cba *CallBotAPI) Load(request BotLoadOp) (*wire.Collection, error) {
-	return botLoad(request, cba.Session, cba.connection, cba.metadata)
+	return botLoad(cba.ctx, request, cba.Session, cba.connection, cba.metadata)
 }
 
 func (cba *CallBotAPI) RunIntegrationAction(integrationID string, action string, options any) (any, error) {
-	return runIntegrationAction(integrationID, action, options, cba.Session, cba.connection)
+	return runIntegrationAction(cba.ctx, integrationID, action, options, cba.Session, cba.connection)
 }
 
 func (cba *CallBotAPI) CallBot(botKey string, params map[string]any) (any, error) {
-	return botCall(botKey, params, cba.Session, cba.connection)
+	return botCall(cba.ctx, botKey, params, cba.Session, cba.connection)
 }
 
 func (cba *CallBotAPI) GetConfigValue(configValueKey string) (string, error) {
-	return configstore.GetValue(configValueKey, cba.Session)
+	return configstore.GetValue(cba.ctx, configValueKey, cba.Session)
 }
 
 func (cba *CallBotAPI) GetSession() *SessionAPI {
-	return NewSessionAPI(cba.Session)
+	return NewSessionAPI(cba.ctx, cba.Session)
 }
 
 func (cba *CallBotAPI) GetUser() *UserAPI {
@@ -93,19 +96,19 @@ func (cba *CallBotAPI) GetName() string {
 }
 
 func (cba *CallBotAPI) CopyFile(sourceKey, sourcePath, destCollectionID, destRecordID, destFieldID string) error {
-	return botCopyFile(sourceKey, sourcePath, destCollectionID, destRecordID, destFieldID, cba.Session, cba.connection)
+	return botCopyFile(cba.ctx, sourceKey, sourcePath, destCollectionID, destRecordID, destFieldID, cba.Session, cba.connection)
 }
 
 func (cba *CallBotAPI) CopyUserFile(sourceFileID, destCollectionID, destRecordID, destFieldID string) error {
-	return botCopyUserFile(sourceFileID, destCollectionID, destRecordID, destFieldID, cba.Session, cba.connection)
+	return botCopyUserFile(cba.ctx, sourceFileID, destCollectionID, destRecordID, destFieldID, cba.Session, cba.connection)
 }
 
 func (cba *CallBotAPI) GetFileContents(sourceKey, sourcePath string) (string, error) {
-	return getFileContents(sourceKey, sourcePath, cba.Session, cba.connection)
+	return getFileContents(cba.ctx, sourceKey, sourcePath, cba.Session, cba.connection)
 }
 
 func (cba *CallBotAPI) GetHostUrl() (string, error) {
-	return getHostUrl(cba.Session, cba.connection)
+	return getHostUrl(cba.ctx, cba.Session, cba.connection)
 }
 
 func (cba *CallBotAPI) GetFileUrl(sourceKey, sourcePath string) string {
@@ -117,7 +120,7 @@ func (cba *CallBotAPI) MergeTemplate(templateString string, params map[string]an
 }
 
 func (cba *CallBotAPI) MergeTemplateFile(sourceKey, sourcePath string, params map[string]any) (string, error) {
-	return mergeTemplateFile(sourceKey, sourcePath, params, cba.Session, cba.connection)
+	return mergeTemplateFile(cba.ctx, sourceKey, sourcePath, params, cba.Session, cba.connection)
 }
 
 func (cba *CallBotAPI) GetCollectionMetadata(collectionKey string) (*BotCollectionMetadata, error) {

--- a/apps/platform/pkg/bot/jsdialect/sessionapi.go
+++ b/apps/platform/pkg/bot/jsdialect/sessionapi.go
@@ -1,6 +1,7 @@
 package jsdialect
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/thecloudmasters/uesio/pkg/datasource"
@@ -16,6 +17,9 @@ type SessionAPI struct {
 	wsApi   *WorkspaceAPI
 	appApi  *AppAPI
 	siteApi *SiteAPI
+	// Intentionally maintaining a context here because this code is called from javascript so we have to keep track of the context
+	// upon creation so we can use as the bot processes. This is an exception to the rule of avoiding keeping context in structs.
+	ctx context.Context
 }
 
 type SiteAPI struct {
@@ -77,9 +81,10 @@ func (a *AppAPI) GetColor() string {
 	return a.color
 }
 
-func NewSessionAPI(session *sess.Session) *SessionAPI {
+func NewSessionAPI(ctx context.Context, session *sess.Session) *SessionAPI {
 	return &SessionAPI{
 		session: session,
+		ctx:     ctx,
 	}
 }
 
@@ -130,7 +135,7 @@ func (s *SessionAPI) GetApp(connection wire.Connection) *AppAPI {
 
 	appApi.name = name
 
-	appData, err := datasource.GetAppData(s.session.Context(), []string{appName}, connection)
+	appData, err := datasource.GetAppData(s.ctx, []string{appName}, connection)
 	if err != nil {
 		return appApi
 	}

--- a/apps/platform/pkg/bot/params.go
+++ b/apps/platform/pkg/bot/params.go
@@ -1,6 +1,8 @@
 package bot
 
 import (
+	"context"
+
 	"github.com/thecloudmasters/uesio/pkg/bundle"
 	"github.com/thecloudmasters/uesio/pkg/meta"
 	"github.com/thecloudmasters/uesio/pkg/sess"
@@ -42,7 +44,7 @@ func GetParamResponse(params meta.BotParams) meta.BotParamsResponse {
 	return response
 }
 
-func GetBotParams(namespace, name, metadataType string, session *sess.Session) (meta.BotParamsResponse, error) {
+func GetBotParams(ctx context.Context, namespace, name, metadataType string, session *sess.Session) (meta.BotParamsResponse, error) {
 
 	if metadataType != "GENERATOR" && metadataType != "LISTENER" && metadataType != "RUNACTION" {
 		return nil, exceptions.NewBadRequestException("Wrong bot type: "+metadataType, nil)
@@ -58,7 +60,7 @@ func GetBotParams(namespace, name, metadataType string, session *sess.Session) (
 		robot = meta.NewRunActionBot(namespace, name)
 	}
 
-	err := bundle.Load(session.Context(), robot, nil, session, nil)
+	err := bundle.Load(ctx, robot, nil, session, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/apps/platform/pkg/bot/systemdialect/systembot_after_bundledependency.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_after_bundledependency.go
@@ -1,6 +1,7 @@
 package systemdialect
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -20,7 +21,7 @@ func parseKey(key string) (string, string, error) {
 	return keyArray[0], keyArray[2], nil
 }
 
-func runBundleDependencyAfterSaveBot(request *wire.SaveOp, connection wire.Connection, session *sess.Session) error {
+func runBundleDependencyAfterSaveBot(ctx context.Context, request *wire.SaveOp, connection wire.Connection, session *sess.Session) error {
 
 	LicenseTemplateDeps := wire.Collection{}
 	visited := map[string]bool{}
@@ -43,6 +44,7 @@ func runBundleDependencyAfterSaveBot(request *wire.SaveOp, connection wire.Conne
 
 		var existingLicense meta.License
 		err = datasource.PlatformLoadOne(
+			ctx,
 			&existingLicense,
 			&datasource.PlatformLoadOptions{
 				Connection: connection,
@@ -76,6 +78,7 @@ func runBundleDependencyAfterSaveBot(request *wire.SaveOp, connection wire.Conne
 
 		var lt meta.LicenseTemplate
 		err = datasource.PlatformLoadOne(
+			ctx,
 			&lt,
 			&datasource.PlatformLoadOptions{
 				Connection: connection,
@@ -118,7 +121,7 @@ func runBundleDependencyAfterSaveBot(request *wire.SaveOp, connection wire.Conne
 
 	// Deletes first
 	if len(corruptedLicenses) > 0 {
-		err = datasource.SaveWithOptions([]datasource.SaveRequest{
+		err = datasource.SaveWithOptions(ctx, []datasource.SaveRequest{
 			{
 				Collection: "uesio/studio.license",
 				Wire:       "LicensedWire",
@@ -134,7 +137,7 @@ func runBundleDependencyAfterSaveBot(request *wire.SaveOp, connection wire.Conne
 	}
 
 	// Inserts next
-	err = datasource.SaveWithOptions([]datasource.SaveRequest{
+	err = datasource.SaveWithOptions(ctx, []datasource.SaveRequest{
 		{
 			Collection: "uesio/studio.license",
 			Wire:       "LicensedWire",

--- a/apps/platform/pkg/bot/systemdialect/systembot_after_collection.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_after_collection.go
@@ -1,6 +1,7 @@
 package systemdialect
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -21,7 +22,7 @@ func parseUniquekeyToCollectionKey(uniquekey string) (string, error) {
 	return keyArray[0] + "." + keyArray[2], nil
 }
 
-func runCollectionAfterSaveBot(request *wire.SaveOp, connection wire.Connection, session *sess.Session) error {
+func runCollectionAfterSaveBot(ctx context.Context, request *wire.SaveOp, connection wire.Connection, session *sess.Session) error {
 
 	// We will end up here through several different avenues and sometimes we will be in an admin context,
 	// sometimes in an anon context and sometimes in a workspace context, etc. Additionally, depending on
@@ -79,7 +80,7 @@ func runCollectionAfterSaveBot(request *wire.SaveOp, connection wire.Connection,
 	}
 
 	fc := meta.FieldCollection{}
-	if err := datasource.PlatformLoad(&fc, &datasource.PlatformLoadOptions{
+	if err := datasource.PlatformLoad(ctx, &fc, &datasource.PlatformLoadOptions{
 		Fields: []wire.LoadRequestField{
 			{
 				ID: commonfields.Id,
@@ -93,7 +94,7 @@ func runCollectionAfterSaveBot(request *wire.SaveOp, connection wire.Connection,
 	}
 
 	rac := meta.RouteAssignmentCollection{}
-	if err := datasource.PlatformLoad(&rac, &datasource.PlatformLoadOptions{
+	if err := datasource.PlatformLoad(ctx, &rac, &datasource.PlatformLoadOptions{
 		Fields: []wire.LoadRequestField{
 			{
 				ID: commonfields.Id,
@@ -107,7 +108,7 @@ func runCollectionAfterSaveBot(request *wire.SaveOp, connection wire.Connection,
 	}
 
 	rct := meta.RecordChallengeTokenCollection{}
-	if err := datasource.PlatformLoad(&rct, &datasource.PlatformLoadOptions{
+	if err := datasource.PlatformLoad(ctx, &rct, &datasource.PlatformLoadOptions{
 		Fields: []wire.LoadRequestField{
 			{
 				ID: commonfields.Id,
@@ -155,6 +156,6 @@ func runCollectionAfterSaveBot(request *wire.SaveOp, connection wire.Connection,
 		return nil
 	}
 
-	return datasource.SaveWithOptions(requests, session, datasource.NewSaveOptions(connection, nil))
+	return datasource.SaveWithOptions(ctx, requests, session, datasource.NewSaveOptions(connection, nil))
 
 }

--- a/apps/platform/pkg/bot/systemdialect/systembot_after_field.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_after_field.go
@@ -44,7 +44,7 @@ func (te *TestEvaluator) SelectGVal(ctx context.Context, k string) (any, error) 
 
 }
 
-func runFieldAfterSaveBot(request *wire.SaveOp, connection wire.Connection, session *sess.Session) error {
+func runFieldAfterSaveBot(ctx context.Context, request *wire.SaveOp, connection wire.Connection, session *sess.Session) error {
 
 	// If there are no changes, only deletes, we have nothing to do
 	if !request.HasChanges() {
@@ -60,7 +60,7 @@ func runFieldAfterSaveBot(request *wire.SaveOp, connection wire.Connection, sess
 		},
 	}
 
-	wsAccessResult := datasource.RequestWorkspaceWriteAccess(request.Params, connection, session)
+	wsAccessResult := datasource.RequestWorkspaceWriteAccess(ctx, request.Params, connection, session)
 	if !wsAccessResult.HasWriteAccess() {
 		return wsAccessResult.Error()
 	}
@@ -94,12 +94,12 @@ func runFieldAfterSaveBot(request *wire.SaveOp, connection wire.Connection, sess
 
 	if request.HasChanges() {
 
-		wsSession, err := datasource.AddWorkspaceContextByID(workspaceID, session, connection)
+		wsSession, err := datasource.AddWorkspaceContextByID(ctx, workspaceID, session, connection)
 		if err != nil {
 			return err
 		}
 
-		err = collections.Load(metadataResponse, wsSession, connection)
+		err = collections.Load(ctx, metadataResponse, wsSession, connection)
 		if err != nil {
 			return err
 		}
@@ -170,6 +170,6 @@ func runFieldAfterSaveBot(request *wire.SaveOp, connection wire.Connection, sess
 		return err
 	}
 
-	return checkValidItems(workspaceID, items, session, connection)
+	return checkValidItems(ctx, workspaceID, items, session, connection)
 
 }

--- a/apps/platform/pkg/bot/systemdialect/systembot_after_integration_type.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_after_integration_type.go
@@ -1,6 +1,7 @@
 package systemdialect
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -22,7 +23,7 @@ func parseUniquekeyToIntegrationTypeKey(uniquekey string) (string, error) {
 }
 
 // Delete all Integration Actions when an Integration Type is deleted
-func runIntegrationTypeAfterSaveBot(request *wire.SaveOp, connection wire.Connection, session *sess.Session) error {
+func runIntegrationTypeAfterSaveBot(ctx context.Context, request *wire.SaveOp, connection wire.Connection, session *sess.Session) error {
 
 	// We will end up here through several different avenues and sometimes we will be in an admin context,
 	// sometimes in an anon context and sometimes in a workspace context, etc. Additionally, depending on
@@ -80,7 +81,7 @@ func runIntegrationTypeAfterSaveBot(request *wire.SaveOp, connection wire.Connec
 	}
 
 	iac := meta.IntegrationActionCollection{}
-	err := datasource.PlatformLoad(&iac, &datasource.PlatformLoadOptions{
+	err := datasource.PlatformLoad(ctx, &iac, &datasource.PlatformLoadOptions{
 		Fields: []wire.LoadRequestField{
 			{
 				ID: "uesio/core.id",
@@ -109,6 +110,6 @@ func runIntegrationTypeAfterSaveBot(request *wire.SaveOp, connection wire.Connec
 		return nil
 	}
 
-	return datasource.SaveWithOptions(requests, session, datasource.NewSaveOptions(connection, nil))
+	return datasource.SaveWithOptions(ctx, requests, session, datasource.NewSaveOptions(connection, nil))
 
 }

--- a/apps/platform/pkg/bot/systemdialect/systembot_after_license.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_after_license.go
@@ -1,6 +1,8 @@
 package systemdialect
 
 import (
+	"context"
+
 	"github.com/thecloudmasters/uesio/pkg/constant/commonfields"
 	"github.com/thecloudmasters/uesio/pkg/datasource"
 	"github.com/thecloudmasters/uesio/pkg/goutils"
@@ -20,7 +22,7 @@ func setLicenced(licensed map[string]bool, change *wire.ChangeItem) error {
 	return nil
 }
 
-func runLicenseAfterSaveBot(request *wire.SaveOp, connection wire.Connection, session *sess.Session) error {
+func runLicenseAfterSaveBot(ctx context.Context, request *wire.SaveOp, connection wire.Connection, session *sess.Session) error {
 
 	licensePricingItemDeps := wire.Collection{}
 	visited := map[string]bool{}
@@ -62,6 +64,7 @@ func runLicenseAfterSaveBot(request *wire.SaveOp, connection wire.Connection, se
 
 		var lptc meta.LicensePricingTemplateCollection
 		err = datasource.PlatformLoad(
+			ctx,
 			&lptc,
 			&datasource.PlatformLoadOptions{
 				Connection: connection,
@@ -105,6 +108,7 @@ func runLicenseAfterSaveBot(request *wire.SaveOp, connection wire.Connection, se
 	// But first find the namespaces
 	var apps meta.AppCollection
 	err = datasource.PlatformLoad(
+		ctx,
 		&apps,
 		&datasource.PlatformLoadOptions{
 			Connection: connection,
@@ -134,7 +138,7 @@ func runLicenseAfterSaveBot(request *wire.SaveOp, connection wire.Connection, se
 		return nil
 	}
 
-	return datasource.SaveWithOptions([]datasource.SaveRequest{
+	return datasource.SaveWithOptions(ctx, []datasource.SaveRequest{
 		{
 			Collection: "uesio/studio.licensepricingitem",
 			Wire:       "LicensePricingTemplatedWire",

--- a/apps/platform/pkg/bot/systemdialect/systembot_after_user.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_after_user.go
@@ -1,6 +1,7 @@
 package systemdialect
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/thecloudmasters/uesio/pkg/auth"
@@ -9,7 +10,7 @@ import (
 	"github.com/thecloudmasters/uesio/pkg/types/wire"
 )
 
-func runUserAfterSaveBot(request *wire.SaveOp, connection wire.Connection, session *sess.Session) error {
+func runUserAfterSaveBot(ctx context.Context, request *wire.SaveOp, connection wire.Connection, session *sess.Session) error {
 	if len(request.Deletes) > 0 {
 		if err := preventSystemGuestUserDeletion(request); err != nil {
 			return err

--- a/apps/platform/pkg/bot/systemdialect/systembot_after_userfile.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_after_userfile.go
@@ -1,6 +1,7 @@
 package systemdialect
 
 import (
+	"context"
 	"time"
 
 	"github.com/thecloudmasters/uesio/pkg/auth"
@@ -16,7 +17,7 @@ const (
 	studioBotCollectionId  = "uesio/studio.bot"
 )
 
-func runUserFileAfterSaveBot(request *wire.SaveOp, connection wire.Connection, session *sess.Session) error {
+func runUserFileAfterSaveBot(ctx context.Context, request *wire.SaveOp, connection wire.Connection, session *sess.Session) error {
 	// TASKS:
 	// 1. Whenever a user file is inserted or updated,  if the file is the User's profile,
 	// we need to invalidate the User cache in Redis
@@ -98,7 +99,7 @@ func runUserFileAfterSaveBot(request *wire.SaveOp, connection wire.Connection, s
 	// If the related collection is uesio/studio.file,
 	// we need to set the file path on the related record as well
 	if len(studioFileUpdates) > 0 {
-		if err = datasource.SaveWithOptions([]datasource.SaveRequest{
+		if err = datasource.SaveWithOptions(ctx, []datasource.SaveRequest{
 			{
 				Collection: studioFileCollectionId,
 				Wire:       "StudioFiles",
@@ -110,7 +111,7 @@ func runUserFileAfterSaveBot(request *wire.SaveOp, connection wire.Connection, s
 		}
 	}
 	if len(studioBotUpdates) > 0 {
-		err = datasource.SaveWithOptions([]datasource.SaveRequest{
+		err = datasource.SaveWithOptions(ctx, []datasource.SaveRequest{
 			{
 				Collection: studioBotCollectionId,
 				Wire:       "StudioBots",

--- a/apps/platform/pkg/bot/systemdialect/systembot_before_app.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_before_app.go
@@ -1,6 +1,7 @@
 package systemdialect
 
 import (
+	"context"
 	"errors"
 
 	"github.com/thecloudmasters/uesio/pkg/constant/commonfields"
@@ -8,7 +9,7 @@ import (
 	"github.com/thecloudmasters/uesio/pkg/types/wire"
 )
 
-func runAppBeforeSaveBot(request *wire.SaveOp, connection wire.Connection, session *sess.Session) error {
+func runAppBeforeSaveBot(ctx context.Context, request *wire.SaveOp, connection wire.Connection, session *sess.Session) error {
 	return request.LoopInserts(func(change *wire.ChangeItem) error {
 		user, err := change.GetField("uesio/studio.user")
 		if err != nil {

--- a/apps/platform/pkg/bot/systemdialect/systembot_before_bot.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_before_bot.go
@@ -1,19 +1,21 @@
 package systemdialect
 
 import (
+	"context"
+
 	"github.com/thecloudmasters/uesio/pkg/datasource"
 	"github.com/thecloudmasters/uesio/pkg/sess"
 	"github.com/thecloudmasters/uesio/pkg/types/wire"
 )
 
-func runBotBeforeSaveBot(request *wire.SaveOp, connection wire.Connection, session *sess.Session) error {
+func runBotBeforeSaveBot(ctx context.Context, request *wire.SaveOp, connection wire.Connection, session *sess.Session) error {
 
 	// early return if we only have deletes
 	if !request.HasChanges() {
 		return nil
 	}
 
-	wsAccessResult := datasource.RequestWorkspaceWriteAccess(request.Params, connection, session)
+	wsAccessResult := datasource.RequestWorkspaceWriteAccess(ctx, request.Params, connection, session)
 	if !wsAccessResult.HasWriteAccess() {
 		return wsAccessResult.Error()
 	}
@@ -52,6 +54,6 @@ func runBotBeforeSaveBot(request *wire.SaveOp, connection wire.Connection, sessi
 		return err
 	}
 
-	return checkValidItems(workspaceID, items, session, connection)
+	return checkValidItems(ctx, workspaceID, items, session, connection)
 
 }

--- a/apps/platform/pkg/bot/systemdialect/systembot_before_collection.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_before_collection.go
@@ -1,11 +1,13 @@
 package systemdialect
 
 import (
+	"context"
+
 	"github.com/thecloudmasters/uesio/pkg/sess"
 	"github.com/thecloudmasters/uesio/pkg/types/wire"
 )
 
-func runCollectionBeforeSaveBot(request *wire.SaveOp, connection wire.Connection, session *sess.Session) error {
+func runCollectionBeforeSaveBot(ctx context.Context, request *wire.SaveOp, connection wire.Connection, session *sess.Session) error {
 
 	err := request.LoopChanges(func(change *wire.ChangeItem) error {
 

--- a/apps/platform/pkg/bot/systemdialect/systembot_before_field.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_before_field.go
@@ -1,6 +1,7 @@
 package systemdialect
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -10,14 +11,14 @@ import (
 	"github.com/thecloudmasters/uesio/pkg/types/wire"
 )
 
-func runFieldBeforeSaveBot(request *wire.SaveOp, connection wire.Connection, session *sess.Session) error {
+func runFieldBeforeSaveBot(ctx context.Context, request *wire.SaveOp, connection wire.Connection, session *sess.Session) error {
 
 	// early return if we only have deletes
 	if !request.HasChanges() {
 		return nil
 	}
 
-	wsAccessResult := datasource.RequestWorkspaceWriteAccess(request.Params, connection, session)
+	wsAccessResult := datasource.RequestWorkspaceWriteAccess(ctx, request.Params, connection, session)
 	if !wsAccessResult.HasWriteAccess() {
 		return wsAccessResult.Error()
 	}
@@ -117,6 +118,6 @@ func runFieldBeforeSaveBot(request *wire.SaveOp, connection wire.Connection, ses
 		return err
 	}
 
-	return checkValidItems(workspaceID, items, session, connection)
+	return checkValidItems(ctx, workspaceID, items, session, connection)
 
 }

--- a/apps/platform/pkg/bot/systemdialect/systembot_before_route.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_before_route.go
@@ -1,13 +1,15 @@
 package systemdialect
 
 import (
+	"context"
+
 	"github.com/thecloudmasters/uesio/pkg/datasource"
 	"github.com/thecloudmasters/uesio/pkg/sess"
 	"github.com/thecloudmasters/uesio/pkg/types/exceptions"
 	"github.com/thecloudmasters/uesio/pkg/types/wire"
 )
 
-func runRouteBeforeSaveBot(request *wire.SaveOp, connection wire.Connection, session *sess.Session) error {
+func runRouteBeforeSaveBot(ctx context.Context, request *wire.SaveOp, connection wire.Connection, session *sess.Session) error {
 
 	// Early return if we have only deletes, no changes
 	if !request.HasChanges() {
@@ -16,7 +18,7 @@ func runRouteBeforeSaveBot(request *wire.SaveOp, connection wire.Connection, ses
 
 	depMap := wire.MetadataDependencyMap{}
 
-	wsAccessResult := datasource.RequestWorkspaceWriteAccess(request.Params, connection, session)
+	wsAccessResult := datasource.RequestWorkspaceWriteAccess(ctx, request.Params, connection, session)
 	if !wsAccessResult.HasWriteAccess() {
 		return wsAccessResult.Error()
 	}
@@ -52,6 +54,6 @@ func runRouteBeforeSaveBot(request *wire.SaveOp, connection wire.Connection, ses
 		return err
 	}
 
-	return checkValidItems(wsAccessResult.GetWorkspaceID(), items, session, connection)
+	return checkValidItems(ctx, wsAccessResult.GetWorkspaceID(), items, session, connection)
 
 }

--- a/apps/platform/pkg/bot/systemdialect/systembot_before_theme.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_before_theme.go
@@ -1,11 +1,13 @@
 package systemdialect
 
 import (
+	"context"
+
 	"github.com/thecloudmasters/uesio/pkg/sess"
 	"github.com/thecloudmasters/uesio/pkg/types/wire"
 )
 
-func runThemeBeforeSaveBot(request *wire.SaveOp, connection wire.Connection, session *sess.Session) error {
+func runThemeBeforeSaveBot(ctx context.Context, request *wire.SaveOp, connection wire.Connection, session *sess.Session) error {
 	return processTheme(request, connection, session)
 }
 

--- a/apps/platform/pkg/bot/systemdialect/systembot_before_usage.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_before_usage.go
@@ -1,6 +1,8 @@
 package systemdialect
 
 import (
+	"context"
+
 	"github.com/thecloudmasters/uesio/pkg/sess"
 	"github.com/thecloudmasters/uesio/pkg/types/wire"
 )
@@ -20,7 +22,7 @@ func getTotal(change *wire.ChangeItem) (int64, error) {
 	return oldTotal + newTotal, nil
 }
 
-func runUsageBeforeSaveBot(request *wire.SaveOp, connection wire.Connection, session *sess.Session) error {
+func runUsageBeforeSaveBot(ctx context.Context, request *wire.SaveOp, connection wire.Connection, session *sess.Session) error {
 	return request.LoopChanges(func(change *wire.ChangeItem) error {
 		total, err := getTotal(change)
 		if err != nil {

--- a/apps/platform/pkg/bot/systemdialect/systembot_before_user.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_before_user.go
@@ -1,6 +1,7 @@
 package systemdialect
 
 import (
+	"context"
 	"errors"
 
 	"github.com/thecloudmasters/uesio/pkg/constant/commonfields"
@@ -9,7 +10,7 @@ import (
 	"github.com/thecloudmasters/uesio/pkg/types/wire"
 )
 
-func runUserBeforeSaveBot(request *wire.SaveOp, connection wire.Connection, session *sess.Session) error {
+func runUserBeforeSaveBot(ctx context.Context, request *wire.SaveOp, connection wire.Connection, session *sess.Session) error {
 	// Make sure that all users are their own owner.
 	return request.LoopChanges(func(change *wire.ChangeItem) error {
 		usertype, err := change.GetFieldAsString("uesio/core.type")

--- a/apps/platform/pkg/bot/systemdialect/systembot_before_view.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_before_view.go
@@ -1,11 +1,13 @@
 package systemdialect
 
 import (
+	"context"
+
 	"github.com/thecloudmasters/uesio/pkg/sess"
 	"github.com/thecloudmasters/uesio/pkg/types/wire"
 )
 
-func runViewBeforeSaveBot(request *wire.SaveOp, connection wire.Connection, session *sess.Session) error {
+func runViewBeforeSaveBot(ctx context.Context, request *wire.SaveOp, connection wire.Connection, session *sess.Session) error {
 	return request.LoopInserts(func(change *wire.ChangeItem) error {
 		err := addViewDefaultDefinition(change)
 		if err != nil {

--- a/apps/platform/pkg/bot/systemdialect/systembot_listener_addexternalbundle.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_listener_addexternalbundle.go
@@ -1,6 +1,7 @@
 package systemdialect
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -19,7 +20,7 @@ import (
 	"github.com/thecloudmasters/uesio/pkg/types/wire"
 )
 
-func runAddExternalBundleListenerBot(params map[string]any, connection wire.Connection, session *sess.Session) (map[string]any, error) {
+func runAddExternalBundleListenerBot(ctx context.Context, params map[string]any, connection wire.Connection, session *sess.Session) (map[string]any, error) {
 
 	appID, err := param.GetRequiredString(params, "app")
 	if err != nil {
@@ -39,7 +40,7 @@ func runAddExternalBundleListenerBot(params map[string]any, connection wire.Conn
 		return nil, exceptions.NewForbiddenException("you must be a workspace admin to install bundles")
 	}
 
-	bundleStoreBaseUrl, err := configstore.GetValue("uesio/studio.external_bundle_store_base_url", session)
+	bundleStoreBaseUrl, err := configstore.GetValue(ctx, "uesio/studio.external_bundle_store_base_url", session)
 	if err != nil {
 		return nil, err
 	}
@@ -54,7 +55,7 @@ func runAddExternalBundleListenerBot(params map[string]any, connection wire.Conn
 		return nil, err
 	}
 
-	httpReq, err := http.NewRequest(http.MethodGet, url, nil)
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -71,7 +72,7 @@ func runAddExternalBundleListenerBot(params map[string]any, connection wire.Conn
 		return nil, err
 	}
 
-	err = deploy.CreateBundleFromData(body, newBundle, connection, session)
+	err = deploy.CreateBundleFromData(ctx, body, newBundle, connection, session)
 	if err != nil {
 		return nil, err
 	}

--- a/apps/platform/pkg/bot/systemdialect/systembot_listener_checkavailability.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_listener_checkavailability.go
@@ -1,13 +1,15 @@
 package systemdialect
 
 import (
+	"context"
+
 	"github.com/thecloudmasters/uesio/pkg/auth"
 	"github.com/thecloudmasters/uesio/pkg/sess"
 	"github.com/thecloudmasters/uesio/pkg/types/exceptions"
 	"github.com/thecloudmasters/uesio/pkg/types/wire"
 )
 
-func runCheckAvailabilityBot(params map[string]any, connection wire.Connection, session *sess.Session) (map[string]any, error) {
+func runCheckAvailabilityBot(ctx context.Context, params map[string]any, connection wire.Connection, session *sess.Session) (map[string]any, error) {
 
 	paramItems := (wire.Item)(params)
 	username, err := paramItems.GetFieldAsString("username")
@@ -15,12 +17,12 @@ func runCheckAvailabilityBot(params map[string]any, connection wire.Connection, 
 		return nil, exceptions.NewBadRequestException("no username provided", nil)
 	}
 
-	systemSession, err := auth.GetSystemSession(session.Context(), session.GetSite(), nil)
+	systemSession, err := auth.GetSystemSession(ctx, session.GetSite(), nil)
 	if err != nil {
 		return nil, err
 	}
 
-	_, err = auth.GetUserByKey(username, systemSession, nil)
+	_, err = auth.GetUserByKey(ctx, username, systemSession, nil)
 	if exceptions.IsNotFoundException(err) {
 		return map[string]any{
 			"message": "That username is available",

--- a/apps/platform/pkg/bot/systemdialect/systembot_listener_createapikey.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_listener_createapikey.go
@@ -1,6 +1,7 @@
 package systemdialect
 
 import (
+	"context"
 	"crypto/rand"
 	"errors"
 	"log"
@@ -45,7 +46,7 @@ func SecureRandomBytes(length int) []byte {
 	return randomBytes
 }
 
-func runCreateApiKeyListenerBot(params map[string]any, connection wire.Connection, session *sess.Session) (map[string]any, error) {
+func runCreateApiKeyListenerBot(ctx context.Context, params map[string]any, connection wire.Connection, session *sess.Session) (map[string]any, error) {
 
 	// Currently this only works in a siteadmin context
 	if session.GetSiteAdmin() == nil {
@@ -82,7 +83,7 @@ func runCreateApiKeyListenerBot(params map[string]any, connection wire.Connectio
 		return nil, err
 	}
 
-	err = auth.CreateLoginMethod(&meta.LoginMethod{
+	err = auth.CreateLoginMethod(ctx, &meta.LoginMethod{
 		User: &meta.User{
 			BuiltIn: meta.BuiltIn{
 				ID: userID,

--- a/apps/platform/pkg/bot/systemdialect/systembot_listener_createbundle.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_listener_createbundle.go
@@ -1,19 +1,21 @@
 package systemdialect
 
 import (
+	"context"
+
 	"github.com/thecloudmasters/uesio/pkg/deploy"
 	"github.com/thecloudmasters/uesio/pkg/sess"
 	"github.com/thecloudmasters/uesio/pkg/types/wire"
 )
 
-func runCreateBundleListenerBot(params map[string]any, connection wire.Connection, session *sess.Session) (map[string]any, error) {
+func runCreateBundleListenerBot(ctx context.Context, params map[string]any, connection wire.Connection, session *sess.Session) (map[string]any, error) {
 
 	options, err := deploy.NewCreateBundleOptions(params)
 	if err != nil {
 		return nil, err
 	}
 
-	bundle, err := deploy.CreateBundle(options, connection, session)
+	bundle, err := deploy.CreateBundle(ctx, options, connection, session)
 	if err != nil {
 		return nil, err
 	}

--- a/apps/platform/pkg/bot/systemdialect/systembot_listener_createsite.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_listener_createsite.go
@@ -1,19 +1,21 @@
 package systemdialect
 
 import (
+	"context"
+
 	"github.com/thecloudmasters/uesio/pkg/deploy"
 	"github.com/thecloudmasters/uesio/pkg/sess"
 	"github.com/thecloudmasters/uesio/pkg/types/wire"
 )
 
-func runCreateSiteListenerBot(params map[string]any, connection wire.Connection, session *sess.Session) (map[string]any, error) {
+func runCreateSiteListenerBot(ctx context.Context, params map[string]any, connection wire.Connection, session *sess.Session) (map[string]any, error) {
 
 	userOptions, err := deploy.NewCreateSiteOptions(params)
 	if err != nil {
 		return nil, err
 	}
 
-	site, err := deploy.CreateSite(userOptions, connection, session)
+	site, err := deploy.CreateSite(ctx, userOptions, connection, session)
 	if err != nil {
 		return nil, err
 	}
@@ -23,7 +25,7 @@ func runCreateSiteListenerBot(params map[string]any, connection wire.Connection,
 		return nil, err
 	}
 
-	_, err = deploy.CreateUser(siteOptions, connection, session)
+	_, err = deploy.CreateUser(ctx, siteOptions, connection, session)
 	if err != nil {
 		return nil, err
 	}

--- a/apps/platform/pkg/bot/systemdialect/systembot_listener_getstarterparams.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_listener_getstarterparams.go
@@ -1,6 +1,7 @@
 package systemdialect
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -12,7 +13,7 @@ import (
 	"github.com/thecloudmasters/uesio/pkg/types/wire"
 )
 
-func runGetStarterParamsBot(params map[string]any, connection wire.Connection, session *sess.Session) (map[string]any, error) {
+func runGetStarterParamsBot(ctx context.Context, params map[string]any, connection wire.Connection, session *sess.Session) (map[string]any, error) {
 
 	starterTemplate, ok := params["template"]
 	if !ok {
@@ -30,7 +31,7 @@ func runGetStarterParamsBot(params map[string]any, connection wire.Connection, s
 
 	// We should really not use the studio session to enter the version context here.
 	// This requires that studio have the starter template app installed. (This shouldn't be necessary)
-	versionSession, err := datasource.EnterVersionContext(starterApp, session, connection)
+	versionSession, err := datasource.EnterVersionContext(ctx, starterApp, session, connection)
 	if err != nil {
 		return nil, err
 	}
@@ -41,7 +42,7 @@ func runGetStarterParamsBot(params map[string]any, connection wire.Connection, s
 		return nil, err
 	}
 
-	botParams, err := bot.GetBotParams(generatorNamespace, generatorName, "GENERATOR", versionSession)
+	botParams, err := bot.GetBotParams(ctx, generatorNamespace, generatorName, "GENERATOR", versionSession)
 	if err != nil {
 		return nil, err
 	}

--- a/apps/platform/pkg/bot/systemdialect/systembot_listener_resetrecordaccesstokens.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_listener_resetrecordaccesstokens.go
@@ -1,13 +1,15 @@
 package systemdialect
 
 import (
+	"context"
+
 	"github.com/thecloudmasters/uesio/pkg/datasource"
 	"github.com/thecloudmasters/uesio/pkg/sess"
 	"github.com/thecloudmasters/uesio/pkg/types/exceptions"
 	"github.com/thecloudmasters/uesio/pkg/types/wire"
 )
 
-func runResetRecordAccessTokensListenerBot(params map[string]any, connection wire.Connection, session *sess.Session) (map[string]any, error) {
+func runResetRecordAccessTokensListenerBot(ctx context.Context, params map[string]any, connection wire.Connection, session *sess.Session) (map[string]any, error) {
 	paramItems := (wire.Item)(params)
 	collectionName, err := paramItems.GetFieldAsString("collection")
 	if err != nil {
@@ -20,7 +22,7 @@ func runResetRecordAccessTokensListenerBot(params map[string]any, connection wir
 	siteName, _ := paramItems.GetFieldAsString("sitename")
 	workspaceName, _ := paramItems.GetFieldAsString("workspacename")
 
-	inContextSession, err := datasource.GetContextSessionFromParams(map[string]any{
+	inContextSession, err := datasource.GetContextSessionFromParams(ctx, map[string]any{
 		"app":           app,
 		"sitename":      siteName,
 		"workspacename": workspaceName,
@@ -28,7 +30,7 @@ func runResetRecordAccessTokensListenerBot(params map[string]any, connection wir
 	if err != nil {
 		return nil, err
 	}
-	err = datasource.ResetRecordTokens(collectionName, inContextSession)
+	err = datasource.ResetRecordTokens(ctx, collectionName, inContextSession)
 	if err != nil {
 		return nil, err
 	}

--- a/apps/platform/pkg/bot/systemdialect/systembot_listener_setworkspaceuser.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_listener_setworkspaceuser.go
@@ -1,6 +1,7 @@
 package systemdialect
 
 import (
+	"context"
 	"errors"
 
 	"github.com/thecloudmasters/uesio/pkg/constant"
@@ -9,7 +10,7 @@ import (
 	"github.com/thecloudmasters/uesio/pkg/types/wire"
 )
 
-func runSetWorkspaceUserBot(params map[string]any, connection wire.Connection, session *sess.Session) (map[string]any, error) {
+func runSetWorkspaceUserBot(ctx context.Context, params map[string]any, connection wire.Connection, session *sess.Session) (map[string]any, error) {
 
 	workspaceID, hasWorkspaceID := params["workspaceid"]
 	if !hasWorkspaceID {
@@ -25,7 +26,7 @@ func runSetWorkspaceUserBot(params map[string]any, connection wire.Connection, s
 		return nil, errors.New("you must be a workspace admin to update workspace user settings")
 	}
 
-	err := datasource.Save([]datasource.SaveRequest{
+	err := datasource.Save(ctx, []datasource.SaveRequest{
 		{
 			Collection: "uesio/studio.workspaceuser",
 			Changes: &wire.Collection{

--- a/apps/platform/pkg/bot/systemdialect/systembot_listener_workspacetruncate.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_listener_workspacetruncate.go
@@ -1,13 +1,15 @@
 package systemdialect
 
 import (
+	"context"
+
 	"github.com/thecloudmasters/uesio/pkg/param"
 	"github.com/thecloudmasters/uesio/pkg/sess"
 	"github.com/thecloudmasters/uesio/pkg/truncate"
 	"github.com/thecloudmasters/uesio/pkg/types/wire"
 )
 
-func runWorkspaceTruncateListenerBot(params map[string]any, connection wire.Connection, session *sess.Session) (map[string]any, error) {
+func runWorkspaceTruncateListenerBot(ctx context.Context, params map[string]any, connection wire.Connection, session *sess.Session) (map[string]any, error) {
 
 	appID, err := param.GetRequiredString(params, "app")
 	if err != nil {
@@ -21,5 +23,5 @@ func runWorkspaceTruncateListenerBot(params map[string]any, connection wire.Conn
 
 	tenantID := sess.MakeWorkspaceTenantID(appID + ":" + workspaceName)
 
-	return nil, truncate.TruncateWorkspaceData(tenantID, session)
+	return nil, truncate.TruncateWorkspaceData(ctx, tenantID, session)
 }

--- a/apps/platform/pkg/bot/systemdialect/systembot_load_configvalue.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_load_configvalue.go
@@ -1,6 +1,7 @@
 package systemdialect
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -9,14 +10,14 @@ import (
 	"github.com/thecloudmasters/uesio/pkg/types/wire"
 )
 
-func runConfigValueLoadBot(op *wire.LoadOp, connection wire.Connection, session *sess.Session) error {
+func runConfigValueLoadBot(ctx context.Context, op *wire.LoadOp, connection wire.Connection, session *sess.Session) error {
 
 	// Currently, this doesn't work for regular contexts
 	if session.GetWorkspace() == nil && session.GetSiteAdmin() == nil {
 		return errors.New("must be in workspace or site admin context")
 	}
 
-	configValues, err := configstore.GetConfigValues(session, &configstore.ConfigLoadOptions{
+	configValues, err := configstore.GetConfigValues(ctx, session, &configstore.ConfigLoadOptions{
 		OnlyWriteable: true,
 	})
 	if err != nil {

--- a/apps/platform/pkg/bot/systemdialect/systembot_load_featureflag.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_load_featureflag.go
@@ -1,6 +1,7 @@
 package systemdialect
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -9,7 +10,7 @@ import (
 	"github.com/thecloudmasters/uesio/pkg/types/wire"
 )
 
-func runFeatureFlagLoadBot(op *wire.LoadOp, connection wire.Connection, session *sess.Session) error {
+func runFeatureFlagLoadBot(ctx context.Context, op *wire.LoadOp, connection wire.Connection, session *sess.Session) error {
 
 	var userID string
 	// Currently, this doesn't work for regular contexts
@@ -44,7 +45,7 @@ func runFeatureFlagLoadBot(op *wire.LoadOp, connection wire.Connection, session 
 		return errors.New("no user id provided to feature flag load")
 	}
 
-	featureFlags, err := featureflagstore.GetFeatureFlags(session, userID)
+	featureFlags, err := featureflagstore.GetFeatureFlags(ctx, session, userID)
 	if err != nil {
 		return fmt.Errorf("failed to get feature flags: %w", err)
 	}

--- a/apps/platform/pkg/bot/systemdialect/systembot_load_mock_user.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_load_mock_user.go
@@ -1,6 +1,8 @@
 package systemdialect
 
 import (
+	"context"
+
 	"github.com/thecloudmasters/uesio/pkg/configstore"
 	"github.com/thecloudmasters/uesio/pkg/datasource"
 	"github.com/thecloudmasters/uesio/pkg/meta"
@@ -8,10 +10,10 @@ import (
 	"github.com/thecloudmasters/uesio/pkg/types/wire"
 )
 
-func runMockUserBot(op *wire.LoadOp, connection wire.Connection, session *sess.Session) error {
+func runMockUserBot(ctx context.Context, op *wire.LoadOp, connection wire.Connection, session *sess.Session) error {
 
 	adminSession := sess.GetAnonSessionFrom(session)
-	mockAuthEnabled, err := configstore.GetValue("uesio/core.mock_auth", adminSession)
+	mockAuthEnabled, err := configstore.GetValue(ctx, "uesio/core.mock_auth", adminSession)
 	if err != nil {
 		return err
 	}
@@ -21,7 +23,7 @@ func runMockUserBot(op *wire.LoadOp, connection wire.Connection, session *sess.S
 	}
 
 	loginMethods := meta.LoginMethodCollection{}
-	if err := datasource.PlatformLoad(&loginMethods, &datasource.PlatformLoadOptions{
+	if err := datasource.PlatformLoad(ctx, &loginMethods, &datasource.PlatformLoadOptions{
 		Fields: []wire.LoadRequestField{
 			{
 				ID: "uesio/core.federation_id",

--- a/apps/platform/pkg/bot/systemdialect/systembot_load_recentmetadata.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_load_recentmetadata.go
@@ -1,6 +1,7 @@
 package systemdialect
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -29,7 +30,7 @@ var supportedCollections = []string{
 
 // intercepts the collection uesio/studio.recentmetadata & enhances the LoadOp
 // Add the required metadata to complete the operation
-func runRecentMetadataLoadBot(op *wire.LoadOp, connection wire.Connection, session *sess.Session) error {
+func runRecentMetadataLoadBot(ctx context.Context, op *wire.LoadOp, connection wire.Connection, session *sess.Session) error {
 
 	workspace := op.Params["workspacename"]
 	if workspace == "" {
@@ -45,7 +46,7 @@ func runRecentMetadataLoadBot(op *wire.LoadOp, connection wire.Connection, sessi
 
 	// We need to obtain the workspace id in order to have a condition on the uesio/studio.workspace field,
 	// which contains the UUID of the workspace associated with studio data.
-	inContextSession, err := datasource.AddWorkspaceContextByKey(workspaceKey, session, connection)
+	inContextSession, err := datasource.AddWorkspaceContextByKey(ctx, workspaceKey, session, connection)
 	if err != nil {
 		return err
 	}
@@ -160,7 +161,7 @@ func runRecentMetadataLoadBot(op *wire.LoadOp, connection wire.Connection, sessi
 	})
 
 	// We need to query with the original session
-	err = connection.Load(session.Context(), newOp, session)
+	err = connection.Load(ctx, newOp, session)
 	if err != nil {
 		return err
 	}

--- a/apps/platform/pkg/bot/systemdialect/systembot_load_recordtokenvalue.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_load_recordtokenvalue.go
@@ -1,6 +1,7 @@
 package systemdialect
 
 import (
+	"context"
 	"errors"
 	"strings"
 
@@ -9,7 +10,7 @@ import (
 	"github.com/thecloudmasters/uesio/pkg/types/wire"
 )
 
-func runRecordTokenValueLoadBot(op *wire.LoadOp, connection wire.Connection, session *sess.Session) error {
+func runRecordTokenValueLoadBot(ctx context.Context, op *wire.LoadOp, connection wire.Connection, session *sess.Session) error {
 
 	recordIDCondition := extractConditionByField(op.Conditions, "uesio/studio.recordid")
 	if recordIDCondition == nil {
@@ -18,13 +19,13 @@ func runRecordTokenValueLoadBot(op *wire.LoadOp, connection wire.Connection, ses
 
 	recordID := recordIDCondition.Value.(string)
 
-	inContextSession, err := datasource.GetContextSessionFromParams(op.Params, connection, session)
+	inContextSession, err := datasource.GetContextSessionFromParams(ctx, op.Params, connection, session)
 	if err != nil {
 		return err
 	}
 	// intentionally using session context and not inContextSession since session is what owns the processing
 	// context. The context in both session and inContextSession should be the same but session owns it
-	tokens, err := connection.GetRecordAccessTokens(session.Context(), recordID, inContextSession)
+	tokens, err := connection.GetRecordAccessTokens(ctx, recordID, inContextSession)
 	if err != nil {
 		return err
 	}

--- a/apps/platform/pkg/bot/systemdialect/systembot_load_secret.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_load_secret.go
@@ -1,6 +1,7 @@
 package systemdialect
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -9,14 +10,14 @@ import (
 	"github.com/thecloudmasters/uesio/pkg/types/wire"
 )
 
-func runSecretLoadBot(op *wire.LoadOp, connection wire.Connection, session *sess.Session) error {
+func runSecretLoadBot(ctx context.Context, op *wire.LoadOp, connection wire.Connection, session *sess.Session) error {
 
 	// Currently, this doesn't work for regular contexts
 	if session.GetWorkspace() == nil && session.GetSiteAdmin() == nil {
 		return errors.New("must be in workspace or site admin context")
 	}
 
-	secrets, err := secretstore.GetSecrets(session)
+	secrets, err := secretstore.GetSecrets(ctx, session)
 	if err != nil {
 		return fmt.Errorf("failed to get secrets: %w", err)
 	}

--- a/apps/platform/pkg/bot/systemdialect/systembot_load_usage.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_load_usage.go
@@ -1,6 +1,7 @@
 package systemdialect
 
 import (
+	"context"
 	"errors"
 
 	"github.com/thecloudmasters/uesio/pkg/datasource"
@@ -8,7 +9,7 @@ import (
 	"github.com/thecloudmasters/uesio/pkg/types/wire"
 )
 
-func runUsageLoadBot(op *wire.LoadOp, connection wire.Connection, session *sess.Session) error {
+func runUsageLoadBot(ctx context.Context, op *wire.LoadOp, connection wire.Connection, session *sess.Session) error {
 
 	siteAdmin := session.GetSiteAdmin()
 
@@ -47,7 +48,7 @@ func runUsageLoadBot(op *wire.LoadOp, connection wire.Connection, session *sess.
 		BatchNumber:    op.BatchNumber,
 	}
 
-	studioMetadata, err := datasource.Load([]*wire.LoadOp{newOp}, sess.GetStudioAnonSession(session.Context()), &datasource.LoadOptions{})
+	studioMetadata, err := datasource.Load(ctx, []*wire.LoadOp{newOp}, sess.GetStudioAnonSession(), &datasource.LoadOptions{})
 	if err != nil {
 		return err
 	}
@@ -97,7 +98,7 @@ func runUsageLoadBot(op *wire.LoadOp, connection wire.Connection, session *sess.
 	op.Collection = usageData
 
 	//get user references with the current site session
-	return datasource.HandleReferences(connection, referencedCollections, metadataResponse, session, &datasource.ReferenceOptions{
+	return datasource.HandleReferences(ctx, connection, referencedCollections, metadataResponse, session, &datasource.ReferenceOptions{
 		AllowMissingItems: true,
 	})
 

--- a/apps/platform/pkg/bot/systemdialect/systembot_load_userfile.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_load_userfile.go
@@ -1,6 +1,7 @@
 package systemdialect
 
 import (
+	"context"
 	"io"
 	"slices"
 
@@ -14,7 +15,7 @@ import (
 
 const USER_FILE_DATA_FIELD = "uesio/core.data"
 
-func runUserfileLoadBot(op *wire.LoadOp, connection wire.Connection, session *sess.Session) error {
+func runUserfileLoadBot(ctx context.Context, op *wire.LoadOp, connection wire.Connection, session *sess.Session) error {
 
 	// If the op included the uesio/core.data field, get it separately.
 	hasDataField := false
@@ -31,7 +32,7 @@ func runUserfileLoadBot(op *wire.LoadOp, connection wire.Connection, session *se
 		op.Fields = newSlice
 	}
 
-	err := datasource.LoadOp(op, connection, session)
+	err := datasource.LoadOp(ctx, op, connection, session)
 	if err != nil {
 		return err
 	}
@@ -53,7 +54,7 @@ func runUserfileLoadBot(op *wire.LoadOp, connection wire.Connection, session *se
 			return nil
 		}
 
-		r, _, err := filesource.Download(session.Context(), userFileIDString, session)
+		r, _, err := filesource.Download(ctx, userFileIDString, session)
 		if err != nil {
 			return err
 		}

--- a/apps/platform/pkg/bot/systemdialect/systembot_load_usertokenvalue.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_load_usertokenvalue.go
@@ -1,6 +1,7 @@
 package systemdialect
 
 import (
+	"context"
 	"strings"
 
 	"github.com/thecloudmasters/uesio/pkg/bundle"
@@ -10,14 +11,14 @@ import (
 	"github.com/thecloudmasters/uesio/pkg/types/wire"
 )
 
-func runUserTokenValueLoadBot(op *wire.LoadOp, connection wire.Connection, session *sess.Session) error {
+func runUserTokenValueLoadBot(ctx context.Context, op *wire.LoadOp, connection wire.Connection, session *sess.Session) error {
 
 	tokenMap := sess.TokenMap{}
 
 	searchCondition := extractConditionByType(op.Conditions, "SEARCH")
 
 	var uatc meta.UserAccessTokenCollection
-	err := bundle.LoadAllFromAny(session.Context(), &uatc, nil, session, nil)
+	err := bundle.LoadAllFromAny(ctx, &uatc, nil, session, nil)
 	if err != nil {
 		return err
 	}
@@ -27,7 +28,7 @@ func runUserTokenValueLoadBot(op *wire.LoadOp, connection wire.Connection, sessi
 		return err
 	}
 
-	err = datasource.HydrateTokenMap(tokenMap, uatc, connection, metadata, session, true)
+	err = datasource.HydrateTokenMap(ctx, tokenMap, uatc, connection, metadata, session, true)
 	if err != nil {
 		return err
 	}

--- a/apps/platform/pkg/bot/systemdialect/systembot_route_login.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_route_login.go
@@ -1,6 +1,7 @@
 package systemdialect
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/thecloudmasters/uesio/pkg/meta"
@@ -9,6 +10,6 @@ import (
 	"github.com/thecloudmasters/uesio/pkg/types/wire"
 )
 
-func runLoginRouteBot(route *meta.Route, request *http.Request, connection wire.Connection, session *sess.Session) (*meta.Route, error) {
-	return routing.GetLoginRoute(session)
+func runLoginRouteBot(ctx context.Context, route *meta.Route, request *http.Request, connection wire.Connection, session *sess.Session) (*meta.Route, error) {
+	return routing.GetLoginRoute(ctx, session)
 }

--- a/apps/platform/pkg/bot/systemdialect/systembot_route_signup.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_route_signup.go
@@ -1,6 +1,7 @@
 package systemdialect
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/thecloudmasters/uesio/pkg/meta"
@@ -9,6 +10,6 @@ import (
 	"github.com/thecloudmasters/uesio/pkg/types/wire"
 )
 
-func runSignupRouteBot(route *meta.Route, request *http.Request, connection wire.Connection, session *sess.Session) (*meta.Route, error) {
-	return routing.GetSignupRoute(session)
+func runSignupRouteBot(ctx context.Context, route *meta.Route, request *http.Request, connection wire.Connection, session *sess.Session) (*meta.Route, error) {
+	return routing.GetSignupRoute(ctx, session)
 }

--- a/apps/platform/pkg/bot/systemdialect/systembot_save_allmetadata.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_save_allmetadata.go
@@ -1,6 +1,7 @@
 package systemdialect
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"log/slog"
@@ -33,11 +34,11 @@ func init() {
 	}
 }
 
-func runStudioMetadataSaveBot(op *wire.SaveOp, connection wire.Connection, session *sess.Session) error {
+func runStudioMetadataSaveBot(ctx context.Context, op *wire.SaveOp, connection wire.Connection, session *sess.Session) error {
 
 	// Get the workspace ID from params, and verify that the user performing the query
 	// has write access to the requested workspace
-	wsAccessResult := datasource.RequestWorkspaceWriteAccess(op.Params, connection, session)
+	wsAccessResult := datasource.RequestWorkspaceWriteAccess(ctx, op.Params, connection, session)
 	if !wsAccessResult.HasWriteAccess() {
 		return wsAccessResult.Error()
 	}
@@ -56,7 +57,7 @@ func runStudioMetadataSaveBot(op *wire.SaveOp, connection wire.Connection, sessi
 		}
 	}
 
-	if err := datasource.SaveOp(op, connection, session); err != nil {
+	if err := datasource.SaveOp(ctx, op, connection, session); err != nil {
 		return err
 	}
 
@@ -108,8 +109,8 @@ func runStudioMetadataSaveBot(op *wire.SaveOp, connection wire.Connection, sessi
 		if err != nil {
 			return errors.New("unable to serialize workspace metadata changes cache key")
 		}
-		if err = connection.Publish(session.Context(), workspacebundlestore.WorkspaceMetadataChangesChannel, string(messagePayload)); err != nil {
-			slog.ErrorContext(session.Context(), "unable to invalidate workspace cache: "+err.Error())
+		if err = connection.Publish(ctx, workspacebundlestore.WorkspaceMetadataChangesChannel, string(messagePayload)); err != nil {
+			slog.ErrorContext(ctx, "unable to invalidate workspace cache: "+err.Error())
 			return errors.New("unable to invalidate workspace cache")
 		}
 	}

--- a/apps/platform/pkg/bot/systemdialect/systembot_save_configvalue.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_save_configvalue.go
@@ -1,12 +1,14 @@
 package systemdialect
 
 import (
+	"context"
+
 	"github.com/thecloudmasters/uesio/pkg/configstore"
 	"github.com/thecloudmasters/uesio/pkg/sess"
 	"github.com/thecloudmasters/uesio/pkg/types/wire"
 )
 
-func runConfigValueSaveBot(op *wire.SaveOp, connection wire.Connection, session *sess.Session) error {
+func runConfigValueSaveBot(ctx context.Context, op *wire.SaveOp, connection wire.Connection, session *sess.Session) error {
 
 	err := op.LoopUpdates(func(change *wire.ChangeItem) error {
 
@@ -20,7 +22,7 @@ func runConfigValueSaveBot(op *wire.SaveOp, connection wire.Connection, session 
 			return err
 		}
 
-		return configstore.SetValue(key, value, session)
+		return configstore.SetValue(ctx, key, value, session)
 	})
 	if err != nil {
 		return err
@@ -30,6 +32,6 @@ func runConfigValueSaveBot(op *wire.SaveOp, connection wire.Connection, session 
 		if err != nil {
 			return err
 		}
-		return configstore.Remove(key, session)
+		return configstore.Remove(ctx, key, session)
 	})
 }

--- a/apps/platform/pkg/bot/systemdialect/systembot_save_external.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_save_external.go
@@ -1,12 +1,13 @@
 package systemdialect
 
 import (
+	"context"
 	"errors"
 
 	"github.com/thecloudmasters/uesio/pkg/sess"
 	"github.com/thecloudmasters/uesio/pkg/types/wire"
 )
 
-func runUesioExternalSaveBot(op *wire.SaveOp, connection wire.Connection, session *sess.Session) error {
+func runUesioExternalSaveBot(ctx context.Context, op *wire.SaveOp, connection wire.Connection, session *sess.Session) error {
 	return errors.New("uesio external save not yet supported")
 }

--- a/apps/platform/pkg/bot/systemdialect/systembot_save_featureflag.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_save_featureflag.go
@@ -1,6 +1,7 @@
 package systemdialect
 
 import (
+	"context"
 	"errors"
 	"strings"
 
@@ -38,7 +39,7 @@ func getKeyInfo(change *wire.ChangeItem, session *sess.Session) (string, string,
 	return key, userID, nil
 }
 
-func runFeatureFlagSaveBot(op *wire.SaveOp, connection wire.Connection, session *sess.Session) error {
+func runFeatureFlagSaveBot(ctx context.Context, op *wire.SaveOp, connection wire.Connection, session *sess.Session) error {
 
 	err := op.LoopUpdates(func(change *wire.ChangeItem) error {
 
@@ -52,7 +53,7 @@ func runFeatureFlagSaveBot(op *wire.SaveOp, connection wire.Connection, session 
 			return err
 		}
 
-		return featureflagstore.SetValue(key, value, userID, session)
+		return featureflagstore.SetValue(ctx, key, value, userID, session)
 	})
 	if err != nil {
 		return err
@@ -62,6 +63,6 @@ func runFeatureFlagSaveBot(op *wire.SaveOp, connection wire.Connection, session 
 		if err != nil {
 			return err
 		}
-		return featureflagstore.Remove(key, userID, session)
+		return featureflagstore.Remove(ctx, key, userID, session)
 	})
 }

--- a/apps/platform/pkg/bot/systemdialect/systembot_save_secret.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_save_secret.go
@@ -1,12 +1,14 @@
 package systemdialect
 
 import (
+	"context"
+
 	"github.com/thecloudmasters/uesio/pkg/secretstore"
 	"github.com/thecloudmasters/uesio/pkg/sess"
 	"github.com/thecloudmasters/uesio/pkg/types/wire"
 )
 
-func runSecretSaveBot(op *wire.SaveOp, connection wire.Connection, session *sess.Session) error {
+func runSecretSaveBot(ctx context.Context, op *wire.SaveOp, connection wire.Connection, session *sess.Session) error {
 
 	err := op.LoopUpdates(func(change *wire.ChangeItem) error {
 
@@ -20,7 +22,7 @@ func runSecretSaveBot(op *wire.SaveOp, connection wire.Connection, session *sess
 			return err
 		}
 
-		return secretstore.SetSecret(key, value, session)
+		return secretstore.SetSecret(ctx, key, value, session)
 	})
 	if err != nil {
 		return err
@@ -30,6 +32,6 @@ func runSecretSaveBot(op *wire.SaveOp, connection wire.Connection, session *sess
 		if err != nil {
 			return err
 		}
-		return secretstore.Remove(key, session)
+		return secretstore.Remove(ctx, key, session)
 	})
 }

--- a/apps/platform/pkg/bot/systemdialect/systembot_save_userfile.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_save_userfile.go
@@ -1,6 +1,7 @@
 package systemdialect
 
 import (
+	"context"
 	"strings"
 
 	"github.com/thecloudmasters/uesio/pkg/datasource"
@@ -9,7 +10,7 @@ import (
 	"github.com/thecloudmasters/uesio/pkg/types/wire"
 )
 
-func runUserfileSaveBot(op *wire.SaveOp, connection wire.Connection, session *sess.Session) error {
+func runUserfileSaveBot(ctx context.Context, op *wire.SaveOp, connection wire.Connection, session *sess.Session) error {
 
 	fileData := []string{}
 	err := op.LoopChanges(func(change *wire.ChangeItem) error {
@@ -32,7 +33,7 @@ func runUserfileSaveBot(op *wire.SaveOp, connection wire.Connection, session *se
 		return err
 	}
 
-	err = datasource.SaveOp(op, connection, session)
+	err = datasource.SaveOp(ctx, op, connection, session)
 	if err != nil {
 		return err
 	}
@@ -76,7 +77,7 @@ func runUserfileSaveBot(op *wire.SaveOp, connection wire.Connection, session *se
 		return err
 	}
 
-	_, err = filesource.Upload(session.Context(), uploadOps, connection, session, op.Params)
+	_, err = filesource.Upload(ctx, uploadOps, connection, session, op.Params)
 	if err != nil {
 		return err
 	}

--- a/apps/platform/pkg/bot/systemdialect/systembotutils.go
+++ b/apps/platform/pkg/bot/systemdialect/systembotutils.go
@@ -1,6 +1,8 @@
 package systemdialect
 
 import (
+	"context"
+
 	"github.com/thecloudmasters/uesio/pkg/bundle"
 	"github.com/thecloudmasters/uesio/pkg/datasource"
 	"github.com/thecloudmasters/uesio/pkg/meta"
@@ -47,16 +49,16 @@ func getUniqueKeysFromDeletes(request *wire.SaveOp) []string {
 	return keys
 }
 
-func checkValidItems(workspaceID string, items []meta.BundleableItem, session *sess.Session, connection wire.Connection) error {
+func checkValidItems(ctx context.Context, workspaceID string, items []meta.BundleableItem, session *sess.Session, connection wire.Connection) error {
 	if len(items) == 0 {
 		return nil
 	}
 
-	wsSession, err := datasource.AddWorkspaceContextByID(workspaceID, session, connection)
+	wsSession, err := datasource.AddWorkspaceContextByID(ctx, workspaceID, session, connection)
 	if err != nil {
 		return err
 	}
-	return bundle.IsValid(session.Context(), items, wsSession, connection)
+	return bundle.IsValid(ctx, items, wsSession, connection)
 
 }
 

--- a/apps/platform/pkg/bulk/exportcollection.go
+++ b/apps/platform/pkg/bulk/exportcollection.go
@@ -1,6 +1,7 @@
 package bulk
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -12,8 +13,8 @@ import (
 	"github.com/thecloudmasters/uesio/pkg/types/wire"
 )
 
-func exportCollection(create bundlestore.FileCreator, spec *meta.JobSpec, session *sess.Session) error {
-	metadataResponse, err := getBatchMetadata(spec.Collection, session)
+func exportCollection(ctx context.Context, create bundlestore.FileCreator, spec *meta.JobSpec, session *sess.Session) error {
+	metadataResponse, err := getBatchMetadata(ctx, spec.Collection, session)
 	if err != nil {
 		return err
 	}
@@ -58,7 +59,7 @@ func exportCollection(create bundlestore.FileCreator, spec *meta.JobSpec, sessio
 		return fmt.Errorf("cannot process that file type: %s", spec.FileType)
 	}
 
-	return datasource.LoadWithError(&wire.LoadOp{
+	return datasource.LoadWithError(ctx, &wire.LoadOp{
 		WireName:       "uesio_data_export",
 		CollectionName: spec.Collection,
 		Collection:     collection,

--- a/apps/platform/pkg/bulk/exportfiles.go
+++ b/apps/platform/pkg/bulk/exportfiles.go
@@ -1,6 +1,7 @@
 package bulk
 
 import (
+	"context"
 	"encoding/csv"
 	"fmt"
 	"io"
@@ -14,11 +15,12 @@ import (
 	"github.com/thecloudmasters/uesio/pkg/types/wire"
 )
 
-func exportFiles(create bundlestore.FileCreator, spec *meta.JobSpec, session *sess.Session) error {
+func exportFiles(ctx context.Context, create bundlestore.FileCreator, spec *meta.JobSpec, session *sess.Session) error {
 
 	// Now do a special userfile export
 	userFiles := &meta.UserFileMetadataCollection{}
 	err := datasource.PlatformLoad(
+		ctx,
 		userFiles,
 		&datasource.PlatformLoadOptions{
 			Conditions: []wire.LoadRequestCondition{
@@ -34,7 +36,7 @@ func exportFiles(create bundlestore.FileCreator, spec *meta.JobSpec, session *se
 		return err
 	}
 
-	metadataResponse, err := getBatchMetadata(userFiles.GetName(), session)
+	metadataResponse, err := getBatchMetadata(ctx, userFiles.GetName(), session)
 	if err != nil {
 		return err
 	}
@@ -78,7 +80,7 @@ func exportFiles(create bundlestore.FileCreator, spec *meta.JobSpec, session *se
 			}
 			defer file.Close()
 
-			r, _, err := filesource.DownloadItem(session.Context(), userFile, session)
+			r, _, err := filesource.DownloadItem(ctx, userFile, session)
 			if err != nil {
 				return err
 			}

--- a/apps/platform/pkg/bulk/import.go
+++ b/apps/platform/pkg/bulk/import.go
@@ -1,6 +1,7 @@
 package bulk
 
 import (
+	"context"
 	"fmt"
 	"io"
 
@@ -9,13 +10,13 @@ import (
 	"github.com/thecloudmasters/uesio/pkg/sess"
 )
 
-func NewImportBatch(body io.ReadCloser, job meta.BulkJob, session *sess.Session) (*meta.BulkBatch, error) {
+func NewImportBatch(ctx context.Context, body io.ReadCloser, job meta.BulkJob, session *sess.Session) (*meta.BulkBatch, error) {
 
 	spec := job.Spec
 	fileFormat := spec.FileType
 	var saveRequest []datasource.SaveRequest
 
-	metadataResponse, err := getBatchMetadata(spec.Collection, session)
+	metadataResponse, err := getBatchMetadata(ctx, spec.Collection, session)
 	if err != nil {
 		return nil, err
 	}
@@ -40,7 +41,7 @@ func NewImportBatch(body io.ReadCloser, job meta.BulkJob, session *sess.Session)
 		return nil, fmt.Errorf("cannot process that file type: %s", fileFormat)
 	}
 
-	err = datasource.Save(saveRequest, session)
+	err = datasource.Save(ctx, saveRequest, session)
 	err = datasource.HandleSaveRequestErrors(saveRequest, err)
 	if err != nil {
 		return nil, err
@@ -51,7 +52,7 @@ func NewImportBatch(body io.ReadCloser, job meta.BulkJob, session *sess.Session)
 		BulkJobID: job.ID,
 	}
 
-	err = datasource.PlatformSaveOne(&batch, nil, nil, session)
+	err = datasource.PlatformSaveOne(ctx, &batch, nil, nil, session)
 	if err != nil {
 		return nil, err
 	}

--- a/apps/platform/pkg/bulk/job.go
+++ b/apps/platform/pkg/bulk/job.go
@@ -1,26 +1,28 @@
 package bulk
 
 import (
+	"context"
+
 	"github.com/thecloudmasters/uesio/pkg/datasource"
 	"github.com/thecloudmasters/uesio/pkg/meta"
 	"github.com/thecloudmasters/uesio/pkg/sess"
 )
 
-func NewJob(spec *meta.JobSpec, session *sess.Session) (string, error) {
+func NewJob(ctx context.Context, spec *meta.JobSpec, session *sess.Session) (string, error) {
 
 	job := meta.BulkJob{
 		Spec:       spec,
 		Collection: spec.Collection,
 	}
 
-	err := datasource.PlatformSaveOne(&job, nil, nil, session)
+	err := datasource.PlatformSaveOne(ctx, &job, nil, nil, session)
 	if err != nil {
 		return "", err
 	}
 
 	// If we're an export job go ahead and create the batch automatically.
 	if job.Spec.JobType == "EXPORT" {
-		_, err = NewExportBatch(job, session)
+		_, err = NewExportBatch(ctx, job, session)
 		if err != nil {
 			return "", err
 		}

--- a/apps/platform/pkg/bulk/uploadfiles.go
+++ b/apps/platform/pkg/bulk/uploadfiles.go
@@ -3,6 +3,7 @@ package bulk
 import (
 	"archive/zip"
 	"bytes"
+	"context"
 	"encoding/csv"
 	"errors"
 	"fmt"
@@ -15,7 +16,7 @@ import (
 	"github.com/thecloudmasters/uesio/pkg/sess"
 )
 
-func NewFileUploadBatch(body io.ReadCloser, job meta.BulkJob, session *sess.Session) (*meta.BulkBatch, error) {
+func NewFileUploadBatch(ctx context.Context, body io.ReadCloser, job meta.BulkJob, session *sess.Session) (*meta.BulkBatch, error) {
 
 	spec := job.Spec
 
@@ -123,12 +124,12 @@ func NewFileUploadBatch(body io.ReadCloser, job meta.BulkJob, session *sess.Sess
 
 	}
 
-	connection, err := datasource.GetPlatformConnection(session, nil)
+	connection, err := datasource.GetPlatformConnection(ctx, session, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	_, err = filesource.Upload(session.Context(), uploadOps, connection, session, nil)
+	_, err = filesource.Upload(ctx, uploadOps, connection, session, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -138,7 +139,7 @@ func NewFileUploadBatch(body io.ReadCloser, job meta.BulkJob, session *sess.Sess
 		BulkJobID: job.ID,
 	}
 
-	err = datasource.PlatformSaveOne(&batch, nil, connection, session)
+	err = datasource.PlatformSaveOne(ctx, &batch, nil, connection, session)
 	if err != nil {
 		return nil, err
 	}

--- a/apps/platform/pkg/bundlestore/filebundlestore/filebundlestore.go
+++ b/apps/platform/pkg/bundlestore/filebundlestore/filebundlestore.go
@@ -366,7 +366,7 @@ func (b *FileBundleStoreConnection) GetBundleZip(ctx context.Context, writer io.
 	if b.ReadOnly {
 		return errors.New("tried to get bundle zip in read only bundle store")
 	}
-	session := sess.GetStudioAnonSession(ctx)
+	session := sess.GetStudioAnonSession()
 
 	app := b.Namespace
 	version := b.Version
@@ -388,6 +388,7 @@ func (b *FileBundleStoreConnection) GetBundleZip(ctx context.Context, writer io.
 
 	var bundle meta.Bundle
 	if err := datasource.PlatformLoadOne(
+		ctx,
 		&bundle,
 		&datasource.PlatformLoadOptions{
 			Fields: []wire.LoadRequestField{

--- a/apps/platform/pkg/bundlestore/platformbundlestore/platformbundlestore.go
+++ b/apps/platform/pkg/bundlestore/platformbundlestore/platformbundlestore.go
@@ -21,7 +21,8 @@ var bundleStoreCache *bundle.BundleStoreCache
 var platformFileConnection file.Connection
 
 var initConnection = sync.OnceValues(func() (file.Connection, error) {
-	return fileadapt.GetFileConnection("uesio/core.bundlestore", sess.GetStudioAnonSession(traceid.NewContext(context.Background())))
+	ctx := traceid.NewContext(context.Background())
+	return fileadapt.GetFileConnection(ctx, "uesio/core.bundlestore", sess.GetStudioAnonSession())
 })
 
 func init() {

--- a/apps/platform/pkg/cmd/migrate.go
+++ b/apps/platform/pkg/cmd/migrate.go
@@ -94,9 +94,9 @@ func migrate(opts *migrations.MigrateOptions) error {
 	ctx := traceid.NewContext(context.Background())
 	slog.InfoContext(ctx, "Running migration(s)")
 
-	anonSession := sess.GetStudioAnonSession(ctx)
+	anonSession := sess.GetStudioAnonSession()
 
-	err := datasource.WithTransaction(anonSession, nil, func(conn wire.Connection) error {
+	err := datasource.WithTransaction(ctx, anonSession, nil, func(conn wire.Connection) error {
 		return conn.Migrate(ctx, opts)
 	})
 	if err != nil {

--- a/apps/platform/pkg/cmd/seed.go
+++ b/apps/platform/pkg/cmd/seed.go
@@ -128,7 +128,7 @@ func runSeeds(ctx context.Context, connection wire.Connection) error {
 		return err
 	}
 
-	return datasource.SaveWithOptions([]datasource.SaveRequest{
+	return datasource.SaveWithOptions(ctx, []datasource.SaveRequest{
 		getPlatformSeedSR(&users),
 		getPlatformSeedSR(&loginmethods),
 		getPlatformSeedSR(&apps),
@@ -151,9 +151,9 @@ func seed(cmd *cobra.Command, args []string) error {
 
 	ignoreSeedFailures, _ := cmd.Flags().GetBool("ignore-failures")
 
-	anonSession := sess.GetStudioAnonSession(ctx)
+	anonSession := sess.GetStudioAnonSession()
 
-	err := datasource.WithTransaction(anonSession, nil, func(conn wire.Connection) error {
+	err := datasource.WithTransaction(ctx, anonSession, nil, func(conn wire.Connection) error {
 		return runSeeds(ctx, conn)
 	})
 	if err != nil {

--- a/apps/platform/pkg/configstore/configstore_test.go
+++ b/apps/platform/pkg/configstore/configstore_test.go
@@ -1,6 +1,7 @@
 package configstore
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -11,7 +12,7 @@ import (
 type TestConfigStore struct {
 }
 
-func (store *TestConfigStore) Get(key string, session *sess.Session) (*meta.ConfigStoreValue, error) {
+func (store *TestConfigStore) Get(ctx context.Context, key string, session *sess.Session) (*meta.ConfigStoreValue, error) {
 	switch key {
 	case "uesio/core.has_value":
 		return &meta.ConfigStoreValue{
@@ -29,10 +30,10 @@ func (store *TestConfigStore) Get(key string, session *sess.Session) (*meta.Conf
 		}, nil
 	}
 }
-func (store *TestConfigStore) GetMany(keys []string, session *sess.Session) (*meta.ConfigStoreValueCollection, error) {
+func (store *TestConfigStore) GetMany(ctx context.Context, keys []string, session *sess.Session) (*meta.ConfigStoreValueCollection, error) {
 	results := meta.ConfigStoreValueCollection{}
 	for _, key := range keys {
-		value, err := store.Get(key, session)
+		value, err := store.Get(ctx, key, session)
 		if err != nil {
 			return nil, err
 		}
@@ -40,11 +41,11 @@ func (store *TestConfigStore) GetMany(keys []string, session *sess.Session) (*me
 	}
 	return &results, nil
 }
-func (store *TestConfigStore) Set(key, value string, session *sess.Session) error {
+func (store *TestConfigStore) Set(ctx context.Context, key, value string, session *sess.Session) error {
 	return nil
 }
 
-func (store *TestConfigStore) Remove(key string, session *sess.Session) error {
+func (store *TestConfigStore) Remove(ctx context.Context, key string, session *sess.Session) error {
 	return nil
 }
 
@@ -113,7 +114,7 @@ func TestGetValue(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := getValueInternal(tt.cv, nil)
+			got, err := getValueInternal(context.Background(), tt.cv, nil)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetValue() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/apps/platform/pkg/configstore/environment/environment.go
+++ b/apps/platform/pkg/configstore/environment/environment.go
@@ -1,6 +1,7 @@
 package environment
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log"
@@ -49,10 +50,10 @@ var configValues = map[string]string{
 	"uesio/core.primary_domain":                   env.GetPrimaryDomain(),
 }
 
-func (cs *ConfigStore) Get(key string, session *sess.Session) (*meta.ConfigStoreValue, error) {
+func (cs *ConfigStore) Get(ctx context.Context, key string, session *sess.Session) (*meta.ConfigStoreValue, error) {
 	value, ok := configValues[key]
 	if !ok {
-		slog.DebugContext(session.Context(), "Config Value not found: "+key)
+		slog.DebugContext(ctx, "Config Value not found: "+key)
 		return nil, nil
 	}
 	return &meta.ConfigStoreValue{
@@ -61,10 +62,10 @@ func (cs *ConfigStore) Get(key string, session *sess.Session) (*meta.ConfigStore
 	}, nil
 }
 
-func (cs *ConfigStore) GetMany(keys []string, session *sess.Session) (*meta.ConfigStoreValueCollection, error) {
+func (cs *ConfigStore) GetMany(ctx context.Context, keys []string, session *sess.Session) (*meta.ConfigStoreValueCollection, error) {
 	results := meta.ConfigStoreValueCollection{}
 	for _, key := range keys {
-		value, err := cs.Get(key, session)
+		value, err := cs.Get(ctx, key, session)
 		if err != nil {
 			return nil, err
 		}
@@ -73,10 +74,10 @@ func (cs *ConfigStore) GetMany(keys []string, session *sess.Session) (*meta.Conf
 	return &results, nil
 }
 
-func (cs *ConfigStore) Set(key, value string, session *sess.Session) error {
+func (cs *ConfigStore) Set(ctx context.Context, key, value string, session *sess.Session) error {
 	return errors.New("you cannot set config values in the environment store")
 }
 
-func (cs *ConfigStore) Remove(key string, session *sess.Session) error {
+func (cs *ConfigStore) Remove(ctx context.Context, key string, session *sess.Session) error {
 	return errors.New("you cannot remove config values from the environment store")
 }

--- a/apps/platform/pkg/configstore/platform/platform.go
+++ b/apps/platform/pkg/configstore/platform/platform.go
@@ -1,6 +1,8 @@
 package environment
 
 import (
+	"context"
+
 	"github.com/thecloudmasters/uesio/pkg/constant/commonfields"
 	"github.com/thecloudmasters/uesio/pkg/datasource"
 	"github.com/thecloudmasters/uesio/pkg/meta"
@@ -12,14 +14,15 @@ import (
 type ConfigStore struct {
 }
 
-func (cs *ConfigStore) Get(key string, session *sess.Session) (*meta.ConfigStoreValue, error) {
+func (cs *ConfigStore) Get(ctx context.Context, key string, session *sess.Session) (*meta.ConfigStoreValue, error) {
 	cv := &meta.ConfigStoreValue{}
 	// Enter into a version context to be able to interact with the uesio/core.secretstorevalue collection
-	versionSession, err := datasource.EnterVersionContext("uesio/core", session, nil)
+	versionSession, err := datasource.EnterVersionContext(ctx, "uesio/core", session, nil)
 	if err != nil {
 		return nil, err
 	}
 	err = datasource.PlatformLoadOne(
+		ctx,
 		cv,
 		&datasource.PlatformLoadOptions{
 			Conditions: []wire.LoadRequestCondition{
@@ -45,14 +48,15 @@ func (cs *ConfigStore) Get(key string, session *sess.Session) (*meta.ConfigStore
 	return cv, nil
 }
 
-func (cs *ConfigStore) GetMany(keys []string, session *sess.Session) (*meta.ConfigStoreValueCollection, error) {
+func (cs *ConfigStore) GetMany(ctx context.Context, keys []string, session *sess.Session) (*meta.ConfigStoreValueCollection, error) {
 	results := meta.ConfigStoreValueCollection{}
 	// Enter into a version context to be able to interact with the uesio/core.configstorevalue collection
-	versionSession, err := datasource.EnterVersionContext("uesio/core", session, nil)
+	versionSession, err := datasource.EnterVersionContext(ctx, "uesio/core", session, nil)
 	if err != nil {
 		return nil, err
 	}
 	err = datasource.PlatformLoad(
+		ctx,
 		&results,
 		&datasource.PlatformLoadOptions{
 			Conditions: []wire.LoadRequestCondition{
@@ -78,29 +82,29 @@ func (cs *ConfigStore) GetMany(keys []string, session *sess.Session) (*meta.Conf
 	return &results, nil
 }
 
-func (cs *ConfigStore) Set(key, value string, session *sess.Session) error {
+func (cs *ConfigStore) Set(ctx context.Context, key, value string, session *sess.Session) error {
 	cv := meta.ConfigStoreValue{
 		Key:   key,
 		Value: value,
 	}
 	// Enter into a version context to be able to interact with the uesio/core.configstorevalue collection
-	versionSession, err := datasource.EnterVersionContext("uesio/core", session, nil)
+	versionSession, err := datasource.EnterVersionContext(ctx, "uesio/core", session, nil)
 	if err != nil {
 		return err
 	}
-	return datasource.PlatformSaveOne(&cv, &wire.SaveOptions{
+	return datasource.PlatformSaveOne(ctx, &cv, &wire.SaveOptions{
 		Upsert: true,
 	}, nil, versionSession)
 }
 
-func (cs *ConfigStore) Remove(key string, session *sess.Session) error {
+func (cs *ConfigStore) Remove(ctx context.Context, key string, session *sess.Session) error {
 	// Enter into a version context to be able to interact with the uesio/core.configstorevalue collection
-	versionSession, err := datasource.EnterVersionContext("uesio/core", session, nil)
+	versionSession, err := datasource.EnterVersionContext(ctx, "uesio/core", session, nil)
 	if err != nil {
 		return err
 	}
 
-	configStoreValue, err := cs.Get(key, session)
+	configStoreValue, err := cs.Get(ctx, key, session)
 	if err != nil {
 		return err
 	}
@@ -109,5 +113,5 @@ func (cs *ConfigStore) Remove(key string, session *sess.Session) error {
 		return nil
 	}
 
-	return datasource.PlatformDeleteOne(configStoreValue, nil, versionSession)
+	return datasource.PlatformDeleteOne(ctx, configStoreValue, nil, versionSession)
 }

--- a/apps/platform/pkg/controller/buildermetadata.go
+++ b/apps/platform/pkg/controller/buildermetadata.go
@@ -26,7 +26,7 @@ func BuilderMetadata(w http.ResponseWriter, r *http.Request) {
 	deps.Wire = nil
 	deps.Collection = nil
 
-	if err := routing.GetBuilderDependencies(namespace, name, deps, session); err != nil {
+	if err := routing.GetBuilderDependencies(r.Context(), namespace, name, deps, session); err != nil {
 		ctlutil.HandleError(r.Context(), w, exceptions.NewBadRequestException("failed getting builder metadata", err))
 		return
 	}

--- a/apps/platform/pkg/controller/bulkbatch.go
+++ b/apps/platform/pkg/controller/bulkbatch.go
@@ -14,7 +14,7 @@ import (
 )
 
 func BulkBatch(w http.ResponseWriter, r *http.Request) {
-	batch, err := bulk.NewBatch(r.Body, mux.Vars(r)["job"], middleware.GetSession(r))
+	batch, err := bulk.NewBatch(r.Context(), r.Body, mux.Vars(r)["job"], middleware.GetSession(r))
 	if err != nil {
 		ctlutil.HandleError(r.Context(), w, err)
 		return

--- a/apps/platform/pkg/controller/bulkjob.go
+++ b/apps/platform/pkg/controller/bulkjob.go
@@ -25,7 +25,7 @@ func BulkJob(w http.ResponseWriter, r *http.Request) {
 	session := middleware.GetSession(r)
 
 	spec := meta.JobSpec(specRequest)
-	jobID, err := bulk.NewJob(&spec, session)
+	jobID, err := bulk.NewJob(r.Context(), &spec, session)
 	if err != nil {
 		ctlutil.HandleError(r.Context(), w, exceptions.NewBadRequestException("failed creating new job", err))
 		return

--- a/apps/platform/pkg/controller/bundleslist.go
+++ b/apps/platform/pkg/controller/bundleslist.go
@@ -29,7 +29,7 @@ func BundlesList(w http.ResponseWriter, r *http.Request) {
 
 	// fetch uesio/studio.bundlelisting records that are published and uesio approved
 	bundleListings := &wire.Collection{}
-	err := datasource.LoadWithError(&wire.LoadOp{
+	err := datasource.LoadWithError(r.Context(), &wire.LoadOp{
 		CollectionName: "uesio/studio.bundlelisting",
 		Collection:     bundleListings,
 		Query:          true,

--- a/apps/platform/pkg/controller/bundlesretrieve.go
+++ b/apps/platform/pkg/controller/bundlesretrieve.go
@@ -14,7 +14,6 @@ import (
 
 func BundlesRetrieve(w http.ResponseWriter, r *http.Request) {
 
-	session := middleware.GetSession(r)
 	vars := mux.Vars(r)
 
 	appID, ok := vars["app"]
@@ -45,7 +44,7 @@ func BundlesRetrieve(w http.ResponseWriter, r *http.Request) {
 	middleware.Set1YearCache(w)
 	ctlutil.AddTrailingStatus(w)
 
-	err = source.GetBundleZip(session.Context(), w, nil)
+	err = source.GetBundleZip(r.Context(), w, nil)
 	if err != nil {
 		// Note - We are streaming result so Http StatusCode will have been set to 200 after
 		// the first Write so we implement custom approach to detecting failure on client

--- a/apps/platform/pkg/controller/bundleversionslist.go
+++ b/apps/platform/pkg/controller/bundleversionslist.go
@@ -31,6 +31,7 @@ func BundleVersionsList(w http.ResponseWriter, r *http.Request) {
 
 	var bundles meta.BundleCollection
 	if err := datasource.PlatformLoad(
+		r.Context(),
 		&bundles,
 		&datasource.PlatformLoadOptions{
 			BatchSize: 5,

--- a/apps/platform/pkg/controller/callbot.go
+++ b/apps/platform/pkg/controller/callbot.go
@@ -26,7 +26,7 @@ func CallListenerBot(w http.ResponseWriter, r *http.Request) {
 
 	session := middleware.GetSession(r)
 
-	returnParams, err := datasource.CallListenerBotInTransaction(namespace, name, params, session)
+	returnParams, err := datasource.CallListenerBotInTransaction(r.Context(), namespace, name, params, session)
 
 	if err != nil {
 		ctlutil.HandleError(r.Context(), w, err)

--- a/apps/platform/pkg/controller/collection.go
+++ b/apps/platform/pkg/controller/collection.go
@@ -31,7 +31,7 @@ func GetCollectionMetadata(w http.ResponseWriter, r *http.Request) {
 	}
 
 	metadataResponse := wire.MetadataCache{}
-	if err := collections.Load(&metadataResponse, session, nil); err != nil {
+	if err := collections.Load(r.Context(), &metadataResponse, session, nil); err != nil {
 		ctlutil.HandleError(r.Context(), w, exceptions.NewBadRequestException("unable to load collection metadata", err))
 		return
 	}

--- a/apps/platform/pkg/controller/collectiondeleteapi.go
+++ b/apps/platform/pkg/controller/collectiondeleteapi.go
@@ -113,7 +113,7 @@ func DeleteRecordApi(w http.ResponseWriter, r *http.Request) {
 		Params:         params,
 	}
 
-	err := datasource.LoadWithError(op, session, nil)
+	err := datasource.LoadWithError(r.Context(), op, session, nil)
 
 	if err != nil {
 		ctlutil.HandleError(r.Context(), w, exceptions.NewBadRequestException("error querying collection records to delete", err))
@@ -128,7 +128,7 @@ func DeleteRecordApi(w http.ResponseWriter, r *http.Request) {
 			Deletes:    collection,
 			Params:     params,
 		}}
-		if err = datasource.HandleSaveRequestErrors(saveRequests, datasource.Save(saveRequests, session)); err != nil {
+		if err = datasource.HandleSaveRequestErrors(saveRequests, datasource.Save(r.Context(), saveRequests, session)); err != nil {
 			ctlutil.HandleError(r.Context(), w, exceptions.NewBadRequestException("delete failed", err))
 			return
 		}

--- a/apps/platform/pkg/controller/createlogin.go
+++ b/apps/platform/pkg/controller/createlogin.go
@@ -17,12 +17,12 @@ func CreateLogin(w http.ResponseWriter, r *http.Request) {
 		ctlutil.HandleError(r.Context(), w, err)
 		return
 	}
-	signupMethod, err := auth.GetSignupMethod(getSignupMethodID(mux.Vars(r)), session)
+	signupMethod, err := auth.GetSignupMethod(r.Context(), getSignupMethodID(mux.Vars(r)), session)
 	if err != nil {
 		ctlutil.HandleError(r.Context(), w, err)
 		return
 	}
-	if err = auth.CreateLogin(signupMethod, payload, session); err != nil {
+	if err = auth.CreateLogin(r.Context(), signupMethod, payload, session); err != nil {
 		ctlutil.HandleError(r.Context(), w, err)
 		return
 	}

--- a/apps/platform/pkg/controller/deleteauthcredentials.go
+++ b/apps/platform/pkg/controller/deleteauthcredentials.go
@@ -23,18 +23,18 @@ func DeleteAuthCredentials(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	integrationName := fmt.Sprintf("%s.%s", vars["namespace"], vars["name"])
 
-	conn, err := datasource.GetPlatformConnection(session, nil)
+	conn, err := datasource.GetPlatformConnection(r.Context(), session, nil)
 	if err != nil {
 		ctlutil.HandleError(r.Context(), w, fmt.Errorf("unable to obtain platform connection: %w", err))
 		return
 	}
-	coreSession, err := datasource.EnterVersionContext("uesio/core", session, conn)
+	coreSession, err := datasource.EnterVersionContext(r.Context(), "uesio/core", session, conn)
 	if err != nil {
 		ctlutil.HandleError(r.Context(), w, fmt.Errorf("unable to obtain core session: %w", err))
 		return
 	}
 
-	credential, err := oauth2.GetIntegrationCredential(user.ID, integrationName, coreSession, conn)
+	credential, err := oauth2.GetIntegrationCredential(r.Context(), user.ID, integrationName, coreSession, conn)
 
 	if err != nil {
 		ctlutil.HandleError(r.Context(), w, fmt.Errorf("unable to retrieve integration credential for user: %w", err))
@@ -47,7 +47,7 @@ func DeleteAuthCredentials(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// If we have a credential, delete it, otherwise, there's nothing to do
-	if err = oauth2.DeleteIntegrationCredential(credential, coreSession, conn); err != nil {
+	if err = oauth2.DeleteIntegrationCredential(r.Context(), credential, coreSession, conn); err != nil {
 		ctlutil.HandleError(r.Context(), w, fmt.Errorf("unable to delete integration credential: %w", err))
 		return
 	}

--- a/apps/platform/pkg/controller/deploy.go
+++ b/apps/platform/pkg/controller/deploy.go
@@ -9,7 +9,7 @@ import (
 )
 
 func Deploy(w http.ResponseWriter, r *http.Request) {
-	if err := deploy.Deploy(r.Body, middleware.GetSession(r)); err != nil {
+	if err := deploy.Deploy(r.Context(), r.Body, middleware.GetSession(r)); err != nil {
 		ctlutil.HandleError(r.Context(), w, err)
 		return
 	}

--- a/apps/platform/pkg/controller/file/componentpack.go
+++ b/apps/platform/pkg/controller/file/componentpack.go
@@ -22,17 +22,17 @@ func ServeComponentPackFile(w http.ResponseWriter, r *http.Request) {
 	session := middleware.GetSession(r)
 
 	componentPack := meta.NewBaseComponentPack(namespace, name)
-	connection, err := datasource.GetPlatformConnection(session, nil)
+	connection, err := datasource.GetPlatformConnection(r.Context(), session, nil)
 	if err != nil {
 		ctlutil.HandleError(r.Context(), w, err)
 		return
 	}
-	if err = bundle.Load(session.Context(), componentPack, nil, session, nil); err != nil {
+	if err = bundle.Load(r.Context(), componentPack, nil, session, nil); err != nil {
 		ctlutil.HandleError(r.Context(), w, err)
 		return
 	}
 
-	rs, fileMeta, err := bundle.GetItemAttachment(session.Context(), componentPack, "dist/"+path, session, connection)
+	rs, fileMeta, err := bundle.GetItemAttachment(r.Context(), componentPack, "dist/"+path, session, connection)
 	if err != nil {
 		ctlutil.HandleError(r.Context(), w, err)
 		return

--- a/apps/platform/pkg/controller/file/font.go
+++ b/apps/platform/pkg/controller/file/font.go
@@ -22,17 +22,17 @@ func ServeFontFile(w http.ResponseWriter, r *http.Request) {
 	session := middleware.GetSession(r)
 
 	font := meta.NewBaseFont(namespace, name)
-	connection, err := datasource.GetPlatformConnection(session, nil)
+	connection, err := datasource.GetPlatformConnection(r.Context(), session, nil)
 	if err != nil {
 		ctlutil.HandleError(r.Context(), w, err)
 		return
 	}
-	if err = bundle.Load(session.Context(), font, nil, session, nil); err != nil {
+	if err = bundle.Load(r.Context(), font, nil, session, nil); err != nil {
 		ctlutil.HandleError(r.Context(), w, err)
 		return
 	}
 
-	rs, fileMeta, err := bundle.GetItemAttachment(session.Context(), font, path, session, connection)
+	rs, fileMeta, err := bundle.GetItemAttachment(r.Context(), font, path, session, connection)
 	if err != nil {
 		ctlutil.HandleError(r.Context(), w, err)
 		return

--- a/apps/platform/pkg/controller/file/serve_file.go
+++ b/apps/platform/pkg/controller/file/serve_file.go
@@ -62,13 +62,13 @@ func respondFile(w http.ResponseWriter, r *http.Request, path string, modified t
 
 func ServeFileContent(file *meta.File, path string, supportsCaching bool, w http.ResponseWriter, r *http.Request) {
 	session := middleware.GetSession(r)
-	connection, err := datasource.GetPlatformConnection(session, nil)
+	connection, err := datasource.GetPlatformConnection(r.Context(), session, nil)
 	if err != nil {
 		ctlutil.HandleError(r.Context(), w, err)
 		return
 	}
 
-	if err := bundle.Load(session.Context(), file, nil, session, connection); err != nil {
+	if err := bundle.Load(r.Context(), file, nil, session, connection); err != nil {
 		ctlutil.HandleError(r.Context(), w, err)
 		return
 	}
@@ -77,7 +77,7 @@ func ServeFileContent(file *meta.File, path string, supportsCaching bool, w http
 		path = file.Path
 	}
 
-	rs, fileMetadata, err := bundle.GetItemAttachment(session.Context(), file, path, session, connection)
+	rs, fileMetadata, err := bundle.GetItemAttachment(r.Context(), file, path, session, connection)
 	if err != nil {
 		ctlutil.HandleError(r.Context(), w, err)
 		return

--- a/apps/platform/pkg/controller/file/userfile.go
+++ b/apps/platform/pkg/controller/file/userfile.go
@@ -51,7 +51,7 @@ func processUploadRequest(r *http.Request) (*meta.UserFileMetadata, error) {
 				return nil, errors.New("no recordid specified")
 			}
 			op.Data = part
-			results, err := filesource.Upload(session.Context(), []*filesource.FileUploadOp{op}, nil, session, op.Params)
+			results, err := filesource.Upload(r.Context(), []*filesource.FileUploadOp{op}, nil, session, op.Params)
 			if err != nil {
 				return nil, err
 			}

--- a/apps/platform/pkg/controller/generate.go
+++ b/apps/platform/pkg/controller/generate.go
@@ -23,7 +23,7 @@ func Generate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s := middleware.GetSession(r)
-	connection, err := datasource.GetPlatformConnection(s, nil)
+	connection, err := datasource.GetPlatformConnection(r.Context(), s, nil)
 	if err != nil {
 		ctlutil.HandleError(r.Context(), w, err)
 		return
@@ -36,7 +36,7 @@ func Generate(w http.ResponseWriter, r *http.Request) {
 	params["appName"] = wsParams["app"]
 	params["workspaceName"] = wsParams["workspacename"]
 
-	_, err = datasource.CallGeneratorBot(retrieve.NewWriterCreator(zipWriter.Create), namespace, name, params, connection, s)
+	_, err = datasource.CallGeneratorBot(r.Context(), retrieve.NewWriterCreator(zipWriter.Create), namespace, name, params, connection, s)
 	if err != nil {
 		ctlutil.HandleError(r.Context(), w, err)
 		return

--- a/apps/platform/pkg/controller/generatetoworkspace.go
+++ b/apps/platform/pkg/controller/generatetoworkspace.go
@@ -28,7 +28,7 @@ func GenerateToWorkspace(w http.ResponseWriter, r *http.Request) {
 	}
 
 	session := middleware.GetSession(r)
-	connection, err := datasource.GetPlatformConnection(session, nil)
+	connection, err := datasource.GetPlatformConnection(r.Context(), session, nil)
 	if err != nil {
 		ctlutil.HandleError(r.Context(), w, err)
 		return
@@ -36,14 +36,14 @@ func GenerateToWorkspace(w http.ResponseWriter, r *http.Request) {
 	respondWithZIP := strings.Contains(r.Header.Get("Accept"), "/zip")
 
 	if respondWithZIP {
-		_, err := deploy.GenerateToWorkspace(namespace, name, params, connection, session, w)
+		_, err := deploy.GenerateToWorkspace(r.Context(), namespace, name, params, connection, session, w)
 		if err != nil {
 			ctlutil.HandleError(r.Context(), w, err)
 		}
 		return
 	}
 
-	response, err := deploy.GenerateToWorkspace(namespace, name, params, connection, session, nil)
+	response, err := deploy.GenerateToWorkspace(r.Context(), namespace, name, params, connection, session, nil)
 	if err != nil {
 		filejson.RespondJSON(w, r, &bot.BotResponse{
 			Success: false,

--- a/apps/platform/pkg/controller/getbotparams.go
+++ b/apps/platform/pkg/controller/getbotparams.go
@@ -20,7 +20,7 @@ func GetBotParams(w http.ResponseWriter, r *http.Request) {
 	metadataType := strings.ToUpper(vars["type"])
 	session := middleware.GetSession(r)
 
-	botParams, err := bot.GetBotParams(namespace, name, metadataType, session)
+	botParams, err := bot.GetBotParams(r.Context(), namespace, name, metadataType, session)
 	if err != nil {
 		ctlutil.HandleError(r.Context(), w, err)
 		return

--- a/apps/platform/pkg/controller/getrouteparams.go
+++ b/apps/platform/pkg/controller/getrouteparams.go
@@ -69,7 +69,7 @@ func GetRouteParams(w http.ResponseWriter, r *http.Request) {
 	name := vars["name"]
 	session := middleware.GetSession(r)
 	loader := func(item meta.BundleableItem) error {
-		return bundle.Load(session.Context(), item, nil, session, nil)
+		return bundle.Load(r.Context(), item, nil, session, nil)
 	}
 	route := meta.NewBaseRoute(namespace, name)
 	if err := loader(route); err != nil {

--- a/apps/platform/pkg/controller/getviewparams.go
+++ b/apps/platform/pkg/controller/getviewparams.go
@@ -62,7 +62,7 @@ func GetViewParams(w http.ResponseWriter, r *http.Request) {
 	name := vars["name"]
 	session := middleware.GetSession(r)
 	loader := func(item meta.BundleableItem) error {
-		return bundle.Load(session.Context(), item, nil, session, nil)
+		return bundle.Load(r.Context(), item, nil, session, nil)
 	}
 	viewParams, err := getParamsForView(namespace, name, loader)
 	if err != nil {

--- a/apps/platform/pkg/controller/integrationaction.go
+++ b/apps/platform/pkg/controller/integrationaction.go
@@ -45,18 +45,18 @@ func RunIntegrationAction(w http.ResponseWriter, r *http.Request) {
 	}
 
 	session := middleware.GetSession(r)
-	connection, err := datasource.GetPlatformConnection(session, nil)
+	connection, err := datasource.GetPlatformConnection(r.Context(), session, nil)
 	if err != nil {
 		ctlutil.HandleError(r.Context(), w, fmt.Errorf("unable to obtain platform connection: %w", err))
 		return
 	}
 
-	ic, err := datasource.GetIntegrationConnection(integrationId, session, connection)
+	ic, err := datasource.GetIntegrationConnection(r.Context(), integrationId, session, connection)
 	if err != nil {
 		ctlutil.HandleError(r.Context(), w, err)
 		return
 	}
-	result, err := datasource.RunIntegrationAction(ic, actionKey, params, connection)
+	result, err := datasource.RunIntegrationAction(r.Context(), ic, actionKey, params, connection)
 	if err != nil {
 		ctlutil.HandleError(r.Context(), w, err)
 		return
@@ -149,7 +149,7 @@ func DescribeIntegrationAction(w http.ResponseWriter, r *http.Request) {
 	}
 
 	session := middleware.GetSession(r)
-	connection, err := datasource.GetPlatformConnection(session, nil)
+	connection, err := datasource.GetPlatformConnection(r.Context(), session, nil)
 	if err != nil {
 		ctlutil.HandleError(r.Context(), w, fmt.Errorf("unable to obtain platform connection: %w", err))
 		return
@@ -157,13 +157,13 @@ func DescribeIntegrationAction(w http.ResponseWriter, r *http.Request) {
 
 	// Load the integration and integration type
 	integrationTypeName := fmt.Sprintf("%s.%s", namespace, name)
-	integrationType, err := datasource.GetIntegrationType(integrationTypeName, session, connection)
+	integrationType, err := datasource.GetIntegrationType(r.Context(), integrationTypeName, session, connection)
 	if err != nil {
 		ctlutil.HandleError(r.Context(), w, err)
 		return
 	}
 	// The action itself MUST exist as a baseline.
-	action, err := datasource.GetIntegrationAction(integrationTypeName, actionKey, session, connection)
+	action, err := datasource.GetIntegrationAction(r.Context(), integrationTypeName, actionKey, session, connection)
 	if err != nil {
 		ctlutil.HandleError(r.Context(), w, err)
 		return
@@ -185,7 +185,7 @@ func DescribeIntegrationAction(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		robot := meta.NewRunActionBot(actionBotNamespace, actionBotName)
-		err = bundle.Load(session.Context(), robot, nil, session, nil)
+		err = bundle.Load(r.Context(), robot, nil, session, nil)
 		if err != nil {
 			ctlutil.HandleError(r.Context(), w, err)
 			return

--- a/apps/platform/pkg/controller/load.go
+++ b/apps/platform/pkg/controller/load.go
@@ -22,7 +22,7 @@ func Load(w http.ResponseWriter, r *http.Request) {
 
 	session := middleware.GetSession(r)
 
-	metadata, err := datasource.Load(batch.Wires, session, nil)
+	metadata, err := datasource.Load(r.Context(), batch.Wires, session, nil)
 	if err != nil {
 		ctlutil.HandleError(r.Context(), w, err)
 		return

--- a/apps/platform/pkg/controller/login.go
+++ b/apps/platform/pkg/controller/login.go
@@ -62,12 +62,12 @@ func processLogin(r *http.Request, session *sess.Session) (*auth.LoginResult, er
 		return nil, exceptions.NewBadRequestException("invalid login request body", err)
 	}
 
-	conn, err := auth.GetAuthConnection(getAuthSourceID(mux.Vars(r)), nil, datasource.GetSiteAdminSession(session))
+	conn, err := auth.GetAuthConnection(r.Context(), getAuthSourceID(mux.Vars(r)), nil, datasource.GetSiteAdminSession(session))
 	if err != nil {
 		return nil, err
 	}
 
-	return conn.Login(loginRequest)
+	return conn.Login(r.Context(), loginRequest)
 }
 
 func handleStandardLogin(w http.ResponseWriter, r *http.Request, session *sess.Session) {
@@ -103,7 +103,7 @@ func SAMLLoginRequestWorkspace(w http.ResponseWriter, r *http.Request) {
 }
 
 func handleSAMLLoginRequest(w http.ResponseWriter, r *http.Request, session *sess.Session) {
-	conn, err := auth.GetAuthConnection(getAuthSourceID(mux.Vars(r)), nil, datasource.GetSiteAdminSession(session))
+	conn, err := auth.GetAuthConnection(r.Context(), getAuthSourceID(mux.Vars(r)), nil, datasource.GetSiteAdminSession(session))
 	if err != nil {
 		ctlutil.HandleError(r.Context(), w, err)
 		return
@@ -134,7 +134,7 @@ func SAMLLoginResponsetWorkspace(w http.ResponseWriter, r *http.Request) {
 }
 
 func handleSAMLLoginResponse(w http.ResponseWriter, r *http.Request, session *sess.Session) {
-	conn, err := auth.GetAuthConnection(getAuthSourceID(mux.Vars(r)), nil, datasource.GetSiteAdminSession(session))
+	conn, err := auth.GetAuthConnection(r.Context(), getAuthSourceID(mux.Vars(r)), nil, datasource.GetSiteAdminSession(session))
 	if err != nil {
 		ctlutil.HandleError(r.Context(), w, err)
 		return
@@ -163,7 +163,7 @@ func handleSAMLLoginResponse(w http.ResponseWriter, r *http.Request, session *se
 		return
 	}
 
-	result, err := conn.LoginServiceProvider(assertion)
+	result, err := conn.LoginServiceProvider(r.Context(), assertion)
 	if err != nil {
 		ctlutil.HandleError(r.Context(), w, err)
 		return
@@ -379,7 +379,7 @@ func CLIToken(w http.ResponseWriter, r *http.Request) {
 	}
 
 	site := requestingSession.GetSite()
-	user, err := auth.GetCachedUserByID(authRequest.UserID, site)
+	user, err := auth.GetCachedUserByID(r.Context(), authRequest.UserID, site)
 	if err != nil {
 		ctlutil.HandleError(r.Context(), w, err)
 		return
@@ -490,7 +490,7 @@ func GetLoginRedirectResponse(r *http.Request, user *meta.User, session *sess.Se
 		return NewLoginResponse(preload.GetUserMergeData(session), redirectPath), nil
 	}
 
-	route, err := routing.GetUserHomeRoute(user, session)
+	route, err := routing.GetUserHomeRoute(r.Context(), user, session)
 	if err != nil {
 		return nil, err
 	}

--- a/apps/platform/pkg/controller/logout.go
+++ b/apps/platform/pkg/controller/logout.go
@@ -21,7 +21,7 @@ func Logout(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	route, err := routing.GetLoginRoute(session)
+	route, err := routing.GetLoginRoute(r.Context(), session)
 	if err != nil {
 		ctlutil.HandleError(r.Context(), w, err)
 		return

--- a/apps/platform/pkg/controller/mergedata.go
+++ b/apps/platform/pkg/controller/mergedata.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"os"
@@ -287,7 +288,7 @@ func getFaviconVersion(site *meta.Site) string {
 	}
 }
 
-func ExecuteIndexTemplate(w http.ResponseWriter, route *meta.Route, preloadmeta *preload.PreloadMetadata, buildMode bool, session *sess.Session) {
+func ExecuteIndexTemplate(ctx context.Context, w http.ResponseWriter, route *meta.Route, preloadmeta *preload.PreloadMetadata, buildMode bool, session *sess.Session) {
 
 	// #2783 Prevent 3rd party sites from iframing Uesio
 	// Add a content security policy header to prevent any other sites from iframing this site
@@ -300,7 +301,7 @@ func ExecuteIndexTemplate(w http.ResponseWriter, route *meta.Route, preloadmeta 
 
 	routingMergeData, err := GetRoutingMergeData(route, preloadmeta, session)
 	if err != nil {
-		ctlutil.HandleError(session.Context(), w, fmt.Errorf("error getting route merge data: %w", err))
+		ctlutil.HandleError(ctx, w, fmt.Errorf("error getting route merge data: %w", err))
 		return
 	}
 
@@ -314,7 +315,7 @@ func ExecuteIndexTemplate(w http.ResponseWriter, route *meta.Route, preloadmeta 
 	}
 
 	if err = indexTemplate.Execute(w, mergeData); err != nil {
-		ctlutil.HandleError(session.Context(), w, fmt.Errorf("error merging template: %w", err))
+		ctlutil.HandleError(ctx, w, fmt.Errorf("error merging template: %w", err))
 		return
 	}
 }

--- a/apps/platform/pkg/controller/namespaces.go
+++ b/apps/platform/pkg/controller/namespaces.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/thecloudmasters/uesio/pkg/controller/ctlutil"
@@ -14,7 +15,7 @@ import (
 	"github.com/thecloudmasters/uesio/pkg/sess"
 )
 
-func getNamespaces(metadataType string, session *sess.Session) ([]string, error) {
+func getNamespaces(ctx context.Context, metadataType string, session *sess.Session) ([]string, error) {
 
 	if metadataType == "" {
 		return session.GetContextNamespaces(), nil
@@ -28,7 +29,7 @@ func getNamespaces(metadataType string, session *sess.Session) ([]string, error)
 		if err != nil {
 			return nil, err
 		}
-		hasSome, err := bundle.HasAny(session.Context(), collection, namespace, nil, session, nil)
+		hasSome, err := bundle.HasAny(ctx, collection, namespace, nil, session, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -46,7 +47,7 @@ func NamespaceList(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	metadatatype := vars["type"]
 
-	namespaces, err := getNamespaces(metadatatype, session)
+	namespaces, err := getNamespaces(r.Context(), metadatatype, session)
 	if err != nil {
 		ctlutil.HandleError(r.Context(), w, err)
 		return

--- a/apps/platform/pkg/controller/oauth/authorize_metadata.go
+++ b/apps/platform/pkg/controller/oauth/authorize_metadata.go
@@ -20,7 +20,7 @@ func GetRedirectMetadata(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	integrationName := fmt.Sprintf("%s.%s", vars["namespace"], vars["name"])
 	session := middleware.GetSession(r)
-	integrationConnection, err := datasource.GetIntegrationConnection(integrationName, session, nil)
+	integrationConnection, err := datasource.GetIntegrationConnection(r.Context(), integrationName, session, nil)
 	if err != nil {
 		ctlutil.HandleError(r.Context(), w, exceptions.NewBadRequestException("invalid integration", err))
 		return

--- a/apps/platform/pkg/controller/resetpassword.go
+++ b/apps/platform/pkg/controller/resetpassword.go
@@ -31,7 +31,7 @@ func ResetPassword(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	_, err = auth.ResetPassword(session.Context(), getAuthSourceID(mux.Vars(r)), payload, site)
+	_, err = auth.ResetPassword(r.Context(), getAuthSourceID(mux.Vars(r)), payload, site)
 	if err != nil {
 		ctlutil.HandleError(r.Context(), w, err)
 		return
@@ -53,7 +53,7 @@ func ConfirmResetPassword(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	user, err := auth.ConfirmResetPassword(session.Context(), getAuthSourceID(mux.Vars(r)), payload, site)
+	user, err := auth.ConfirmResetPassword(r.Context(), getAuthSourceID(mux.Vars(r)), payload, site)
 	if err != nil {
 		ctlutil.HandleError(r.Context(), w, err)
 		return

--- a/apps/platform/pkg/controller/rest.go
+++ b/apps/platform/pkg/controller/rest.go
@@ -50,7 +50,7 @@ func Rest(w http.ResponseWriter, r *http.Request) {
 		Query:          true,
 	}
 
-	err := datasource.LoadWithError(op, session, nil)
+	err := datasource.LoadWithError(r.Context(), op, session, nil)
 	if err != nil {
 		ctlutil.HandleError(r.Context(), w, exceptions.NewBadRequestException("Load Failed", err))
 		return

--- a/apps/platform/pkg/controller/retrieve.go
+++ b/apps/platform/pkg/controller/retrieve.go
@@ -33,7 +33,7 @@ func Retrieve(w http.ResponseWriter, r *http.Request) {
 	file.SetContentDispositionHeader(w, "attachment", fileName)
 	ctlutil.AddTrailingStatus(w)
 
-	if err := bs.GetBundleZip(session.Context(), w, &bundlestore.BundleZipOptions{
+	if err := bs.GetBundleZip(r.Context(), w, &bundlestore.BundleZipOptions{
 		// Only include generated types if we're in a workspace context
 		IncludeGeneratedTypes: session.GetWorkspaceSession() != nil,
 	}); err != nil {

--- a/apps/platform/pkg/controller/robots.go
+++ b/apps/platform/pkg/controller/robots.go
@@ -43,7 +43,7 @@ func Robots(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// If the home route is accessible by a guest, then we need to add it to the allowed paths
-	homeRoute, _ := routing.GetHomeRoute(session)
+	homeRoute, _ := routing.GetHomeRoute(r.Context(), session)
 
 	var routes meta.RouteCollection
 	var files meta.FileCollection
@@ -51,13 +51,13 @@ func Robots(w http.ResponseWriter, r *http.Request) {
 	// Load all public routes to get their paths, along with public files.
 	// We are assuming that a crawler would have a public guest session,
 	// so we can just let our permissions system do the work of finding which routes/files are accessible)
-	err := bundle.LoadAllFromAny(session.Context(), &routes, nil, session, nil)
+	err := bundle.LoadAllFromAny(r.Context(), &routes, nil, session, nil)
 
 	if err != nil || len(routes) == 0 {
 		return
 	}
 
-	err = bundle.LoadAllFromAny(session.Context(), &files, nil, session, nil)
+	err = bundle.LoadAllFromAny(r.Context(), &files, nil, session, nil)
 
 	if err != nil {
 		return

--- a/apps/platform/pkg/controller/save.go
+++ b/apps/platform/pkg/controller/save.go
@@ -22,7 +22,7 @@ func Save(w http.ResponseWriter, r *http.Request) {
 
 	session := middleware.GetSession(r)
 
-	if err := datasource.Save(saveRequestBatch.Wires, session); err != nil {
+	if err := datasource.Save(r.Context(), saveRequestBatch.Wires, session); err != nil {
 		// If the error is a save error still respond
 		if exceptions.IsType[*exceptions.SaveException](err) {
 			filejson.RespondJSON(w, r, &saveRequestBatch)

--- a/apps/platform/pkg/controller/truncate.go
+++ b/apps/platform/pkg/controller/truncate.go
@@ -11,7 +11,7 @@ import (
 
 func Truncate(w http.ResponseWriter, r *http.Request) {
 	session := middleware.GetSession(r)
-	if err := truncate.TruncateWorkspaceData(session.GetTenantID(), session); err != nil {
+	if err := truncate.TruncateWorkspaceData(r.Context(), session.GetTenantID(), session); err != nil {
 		ctlutil.HandleError(r.Context(), w, err)
 	} else {
 		filejson.RespondJSON(w, r, map[string]any{

--- a/apps/platform/pkg/controller/view.go
+++ b/apps/platform/pkg/controller/view.go
@@ -30,7 +30,7 @@ func ViewPreview(buildMode bool) http.HandlerFunc {
 		view := meta.NewBaseView(viewNamespace, viewName)
 
 		// Make sure this is a legit view that we have access to
-		err := bundle.Load(session.Context(), view, nil, session, nil)
+		err := bundle.Load(r.Context(), view, nil, session, nil)
 		if err != nil {
 			HandleErrorRoute(w, r, session, "", "", err, false)
 			return
@@ -48,14 +48,14 @@ func ViewPreview(buildMode bool) http.HandlerFunc {
 			Title:   "Preview: " + view.Name,
 		}
 
-		depsCache, err := routing.GetMetadataDeps(route, session)
+		depsCache, err := routing.GetMetadataDeps(r.Context(), route, session)
 		if err != nil {
 			HandleErrorRoute(w, r, session, "", "", err, false)
 			return
 		}
 
 		if buildMode {
-			err = routing.GetBuilderDependencies(viewNamespace, viewName, depsCache, session)
+			err = routing.GetBuilderDependencies(r.Context(), viewNamespace, viewName, depsCache, session)
 			if err != nil {
 				HandleErrorRoute(w, r, session, "", "", err, false)
 				return
@@ -63,6 +63,6 @@ func ViewPreview(buildMode bool) http.HandlerFunc {
 			route.Title = "Edit: " + view.Name
 		}
 
-		ExecuteIndexTemplate(w, route, depsCache, buildMode, session)
+		ExecuteIndexTemplate(r.Context(), w, route, depsCache, buildMode, session)
 	}
 }

--- a/apps/platform/pkg/controller/viewmetadata.go
+++ b/apps/platform/pkg/controller/viewmetadata.go
@@ -26,7 +26,7 @@ func ViewMetadata(w http.ResponseWriter, r *http.Request) {
 	deps.Wire = nil
 	deps.Collection = nil
 
-	if err := routing.GetViewDependencies(namespace, name, deps, session); err != nil {
+	if err := routing.GetViewDependencies(r.Context(), namespace, name, deps, session); err != nil {
 		ctlutil.HandleError(r.Context(), w, exceptions.NewBadRequestException("failed getting builder metadata", err))
 		return
 	}

--- a/apps/platform/pkg/datasource/appdata.go
+++ b/apps/platform/pkg/datasource/appdata.go
@@ -16,7 +16,7 @@ func GetAppData(ctx context.Context, namespaces []string, connection wire.Connec
 	apps := meta.AppCollection{}
 
 	// Load in App Settings
-	err := PlatformLoad(&apps, &PlatformLoadOptions{
+	err := PlatformLoad(ctx, &apps, &PlatformLoadOptions{
 		Conditions: []wire.LoadRequestCondition{
 			{
 				Field:    commonfields.UniqueKey,
@@ -36,7 +36,7 @@ func GetAppData(ctx context.Context, namespaces []string, connection wire.Connec
 			},
 		},
 		Connection: connection,
-	}, sess.GetStudioAnonSession(ctx))
+	}, sess.GetStudioAnonSession())
 	if err != nil {
 		return nil, err
 	}
@@ -57,9 +57,10 @@ func GetAppData(ctx context.Context, namespaces []string, connection wire.Connec
 }
 
 // QueryAppForWrite queries an app with write access required
-func QueryAppForWrite(value, field string, session *sess.Session, connection wire.Connection) (*meta.App, error) {
+func QueryAppForWrite(ctx context.Context, value, field string, session *sess.Session, connection wire.Connection) (*meta.App, error) {
 	var app meta.App
 	err := PlatformLoadOne(
+		ctx,
 		&app,
 		&PlatformLoadOptions{
 			Connection: connection,

--- a/apps/platform/pkg/datasource/connection.go
+++ b/apps/platform/pkg/datasource/connection.go
@@ -1,6 +1,7 @@
 package datasource
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/thecloudmasters/uesio/pkg/adapt"
@@ -13,7 +14,7 @@ var dataSourceTypesByName = map[string]string{
 	meta.PLATFORM_DATA_SOURCE: "uesio.postgresio",
 }
 
-func GetConnection(dataSourceKey string, session *sess.Session, connection wire.Connection) (wire.Connection, error) {
+func GetConnection(ctx context.Context, dataSourceKey string, session *sess.Session, connection wire.Connection) (wire.Connection, error) {
 
 	// If we were provided a default connection for this datasource,
 	// use that instead
@@ -30,7 +31,7 @@ func GetConnection(dataSourceKey string, session *sess.Session, connection wire.
 	// credentials as the datasource's namespace
 	versionSession := session
 	if session != nil {
-		versionSession, err = EnterVersionContext(namespace, session, connection)
+		versionSession, err = EnterVersionContext(ctx, namespace, session, connection)
 		if err != nil {
 			return nil, err
 		}
@@ -46,10 +47,10 @@ func GetConnection(dataSourceKey string, session *sess.Session, connection wire.
 		return nil, err
 	}
 
-	credentials, err := GetCredentials(adapter.GetCredentials(), versionSession)
+	credentials, err := GetCredentials(ctx, adapter.GetCredentials(), versionSession)
 	if err != nil {
 		return nil, err
 	}
 
-	return adapter.GetConnection(session.Context(), credentials, dataSourceKey)
+	return adapter.GetConnection(ctx, credentials, dataSourceKey)
 }

--- a/apps/platform/pkg/datasource/context.go
+++ b/apps/platform/pkg/datasource/context.go
@@ -1,6 +1,7 @@
 package datasource
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -23,7 +24,7 @@ func GetParamsFromSession(session *sess.Session) map[string]any {
 	return params
 }
 
-func GetContextSessionFromParams(params map[string]any, connection wire.Connection, session *sess.Session) (*sess.Session, error) {
+func GetContextSessionFromParams(ctx context.Context, params map[string]any, connection wire.Connection, session *sess.Session) (*sess.Session, error) {
 	workspaceID := goutils.StringValue(params["workspaceid"])
 	workspace := goutils.StringValue(params["workspacename"])
 	site := goutils.StringValue(params["sitename"])
@@ -32,7 +33,7 @@ func GetContextSessionFromParams(params map[string]any, connection wire.Connecti
 	}
 
 	if workspaceID != "" {
-		return AddWorkspaceContextByID(workspaceID, session, connection)
+		return AddWorkspaceContextByID(ctx, workspaceID, session, connection)
 	}
 
 	app := goutils.StringValue(params["app"])
@@ -42,10 +43,10 @@ func GetContextSessionFromParams(params map[string]any, connection wire.Connecti
 
 	if workspace != "" {
 		workspaceKey := fmt.Sprintf("%s:%s", app, workspace)
-		return AddWorkspaceContextByKey(workspaceKey, session, connection)
+		return AddWorkspaceContextByKey(ctx, workspaceKey, session, connection)
 	}
 
 	siteKey := fmt.Sprintf("%s:%s", app, site)
-	return AddSiteAdminContextByKey(siteKey, session, connection)
+	return AddSiteAdminContextByKey(ctx, siteKey, session, connection)
 
 }

--- a/apps/platform/pkg/datasource/domain.go
+++ b/apps/platform/pkg/datasource/domain.go
@@ -4,16 +4,16 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/go-chi/traceid"
 	"github.com/thecloudmasters/uesio/pkg/meta"
 	"github.com/thecloudmasters/uesio/pkg/sess"
 	"github.com/thecloudmasters/uesio/pkg/tls"
 	"github.com/thecloudmasters/uesio/pkg/types/wire"
 )
 
-func QueryDomainFromSite(siteID string, connection wire.Connection) (*meta.SiteDomain, error) {
+func QueryDomainFromSite(ctx context.Context, siteID string, connection wire.Connection) (*meta.SiteDomain, error) {
 	var sd meta.SiteDomain
 	err := PlatformLoadOne(
+		ctx,
 		&sd,
 		&PlatformLoadOptions{
 			Fields: []wire.LoadRequestField{
@@ -33,7 +33,7 @@ func QueryDomainFromSite(siteID string, connection wire.Connection) (*meta.SiteD
 			BatchSize:  1,
 			Connection: connection,
 		},
-		sess.GetStudioAnonSession(traceid.NewContext(context.Background())),
+		sess.GetStudioAnonSession(),
 	)
 	if err != nil {
 		return nil, err

--- a/apps/platform/pkg/datasource/fetchreferences.go
+++ b/apps/platform/pkg/datasource/fetchreferences.go
@@ -1,6 +1,7 @@
 package datasource
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/thecloudmasters/uesio/pkg/constant/commonfields"
@@ -62,6 +63,7 @@ func processLocalReferences(
 }
 
 func FetchReferences(
+	ctx context.Context,
 	connection wire.Connection,
 	op *wire.SaveOp,
 	session *sess.Session,
@@ -158,7 +160,7 @@ func FetchReferences(
 		}
 	}
 
-	err = HandleReferences(connection, referencedIDCollections, metadata, session, &ReferenceOptions{
+	err = HandleReferences(ctx, connection, referencedIDCollections, metadata, session, &ReferenceOptions{
 		MergeItems:         true,
 		RemoveMissingItems: op.Options != nil && op.Options.IgnoreMissingReferences,
 	})
@@ -166,7 +168,7 @@ func FetchReferences(
 		return err
 	}
 
-	return HandleReferences(connection, referencedUniqueKeyCollections, metadata, session, &ReferenceOptions{
+	return HandleReferences(ctx, connection, referencedUniqueKeyCollections, metadata, session, &ReferenceOptions{
 		MergeItems:         true,
 		RemoveMissingItems: op.Options != nil && op.Options.IgnoreMissingReferences,
 	})

--- a/apps/platform/pkg/datasource/licensing.go
+++ b/apps/platform/pkg/datasource/licensing.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log/slog"
 
-	"github.com/go-chi/traceid"
 	"github.com/thecloudmasters/uesio/pkg/cache"
 	"github.com/thecloudmasters/uesio/pkg/constant/commonfields"
 	"github.com/thecloudmasters/uesio/pkg/meta"
@@ -47,7 +46,7 @@ func getLicenseCache(namespace string) (LicenseMap, bool) {
 	return licenses, true
 }
 
-func GetLicenses(namespace string, connection wire.Connection) (LicenseMap, error) {
+func GetLicenses(ctx context.Context, namespace string, connection wire.Connection) (LicenseMap, error) {
 	// Hardcode the license for uesio/core
 	// This prevents a circular dependency when we try to get
 	// the credentials to load the license data.
@@ -62,9 +61,9 @@ func GetLicenses(namespace string, connection wire.Connection) (LicenseMap, erro
 	if ok {
 		return licenseMap, nil
 	}
-	anonSession := sess.GetStudioAnonSession(traceid.NewContext(context.Background()))
+	anonSession := sess.GetStudioAnonSession()
 	app := meta.App{}
-	err := PlatformLoadOne(&app, &PlatformLoadOptions{
+	err := PlatformLoadOne(ctx, &app, &PlatformLoadOptions{
 		Connection: connection,
 		Fields:     []wire.LoadRequestField{},
 		Conditions: []wire.LoadRequestCondition{
@@ -80,6 +79,7 @@ func GetLicenses(namespace string, connection wire.Connection) (LicenseMap, erro
 	}
 	licenses := meta.LicenseCollection{}
 	err = PlatformLoad(
+		ctx,
 		&licenses,
 		&PlatformLoadOptions{
 			Connection: connection,

--- a/apps/platform/pkg/datasource/load_metadata.go
+++ b/apps/platform/pkg/datasource/load_metadata.go
@@ -1,6 +1,7 @@
 package datasource
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -80,6 +81,7 @@ func getFakeAggregateMetadata(requestField wire.LoadRequestField, collectionMeta
 }
 
 func GetMetadataForLoad(
+	ctx context.Context,
 	op *wire.LoadOp,
 	metadataResponse *wire.MetadataCache,
 	ops []*wire.LoadOp,
@@ -95,7 +97,7 @@ func GetMetadataForLoad(
 		return err
 	}
 
-	err = metadataRequest.Load(metadataResponse, session, connection)
+	err = metadataRequest.Load(ctx, metadataResponse, session, connection)
 	if err != nil {
 
 		return err
@@ -157,7 +159,7 @@ func GetMetadataForLoad(
 			}
 		}
 		if fieldMetadata.IsFormula && fieldMetadata.FormulaMetadata != nil {
-			fieldDeps, err := formula.GetFormulaFields(session.Context(), fieldMetadata.FormulaMetadata.Expression)
+			fieldDeps, err := formula.GetFormulaFields(ctx, fieldMetadata.FormulaMetadata.Expression)
 			if err != nil {
 				return err
 			}
@@ -212,6 +214,7 @@ func getMetadataForViewOnlyField(
 }
 
 func GetMetadataForViewOnlyWire(
+	ctx context.Context,
 	op *wire.LoadOp,
 	metadataResponse *wire.MetadataCache,
 	connection wire.Connection,
@@ -221,7 +224,7 @@ func GetMetadataForViewOnlyWire(
 	for _, requestField := range op.Fields {
 		getMetadataForViewOnlyField(requestField, metadataRequest)
 	}
-	return metadataRequest.Load(metadataResponse, session, connection)
+	return metadataRequest.Load(ctx, metadataResponse, session, connection)
 }
 
 func getMetadataForOrderField(collectionKey string, fieldName string, metadataRequest *MetadataRequest, session *sess.Session) error {

--- a/apps/platform/pkg/datasource/loadprofile.go
+++ b/apps/platform/pkg/datasource/loadprofile.go
@@ -1,17 +1,19 @@
 package datasource
 
 import (
+	"context"
+
 	"github.com/thecloudmasters/uesio/pkg/bundle"
 	"github.com/thecloudmasters/uesio/pkg/meta"
 	"github.com/thecloudmasters/uesio/pkg/sess"
 )
 
-func LoadAndHydrateProfile(profileKey string, session *sess.Session) (*meta.Profile, error) {
+func LoadAndHydrateProfile(ctx context.Context, profileKey string, session *sess.Session) (*meta.Profile, error) {
 	profile, err := meta.NewProfile(profileKey)
 	if err != nil {
 		return nil, err
 	}
-	if err = bundle.Load(session.Context(), profile, nil, session, nil); err != nil {
+	if err = bundle.Load(ctx, profile, nil, session, nil); err != nil {
 		return nil, err
 	}
 	// LoadFromSite in the permission sets for this profile
@@ -20,7 +22,7 @@ func LoadAndHydrateProfile(profileKey string, session *sess.Session) (*meta.Prof
 		if err != nil {
 			return nil, err
 		}
-		if err := bundle.Load(session.Context(), permissionSet, nil, session, nil); err != nil {
+		if err := bundle.Load(ctx, permissionSet, nil, session, nil); err != nil {
 			return nil, err
 		}
 		profile.PermissionSets = append(profile.PermissionSets, *permissionSet)

--- a/apps/platform/pkg/datasource/oldvaluelookups.go
+++ b/apps/platform/pkg/datasource/oldvaluelookups.go
@@ -1,6 +1,7 @@
 package datasource
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"strings"
@@ -63,6 +64,7 @@ func SetUniqueKey(change *wire.ChangeItem) error {
 }
 
 func HandleOldValuesLookup(
+	ctx context.Context,
 	connection wire.Connection,
 	op *wire.SaveOp,
 	session *sess.Session,
@@ -154,7 +156,7 @@ func HandleOldValuesLookup(
 		return nil
 	}
 
-	return LoadLooper(connection, op.CollectionName, idMap, allFields, commonfields.Id, metadata, session, func(item meta.Item, matchIndexes []wire.ReferenceLocator, ID string) error {
+	return LoadLooper(ctx, connection, op.CollectionName, idMap, allFields, commonfields.Id, metadata, session, func(item meta.Item, matchIndexes []wire.ReferenceLocator, ID string) error {
 
 		if item == nil {
 			// This should result in an error, unless we have explicitly indicated that

--- a/apps/platform/pkg/datasource/platformload.go
+++ b/apps/platform/pkg/datasource/platformload.go
@@ -1,6 +1,7 @@
 package datasource
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -41,7 +42,7 @@ func GetLoadRequestFields(fieldStrings []string) []wire.LoadRequestField {
 	return fields
 }
 
-func PlatformLoad(group meta.CollectionableGroup, options *PlatformLoadOptions, session *sess.Session) error {
+func PlatformLoad(ctx context.Context, group meta.CollectionableGroup, options *PlatformLoadOptions, session *sess.Session) error {
 
 	if options == nil {
 		options = &PlatformLoadOptions{}
@@ -50,7 +51,7 @@ func PlatformLoad(group meta.CollectionableGroup, options *PlatformLoadOptions, 
 	if fields == nil {
 		fields = GetLoadRequestFields(group.GetFields())
 	}
-	return doPlatformLoad(&wire.LoadOp{
+	return doPlatformLoad(ctx, &wire.LoadOp{
 		WireName:           "Platform Load: " + options.WireName,
 		CollectionName:     group.GetName(),
 		Collection:         group,
@@ -64,8 +65,8 @@ func PlatformLoad(group meta.CollectionableGroup, options *PlatformLoadOptions, 
 	}, options, session)
 }
 
-func doPlatformLoad(op *wire.LoadOp, options *PlatformLoadOptions, session *sess.Session) error {
-	err := LoadWithError(op, session, &LoadOptions{
+func doPlatformLoad(ctx context.Context, op *wire.LoadOp, options *PlatformLoadOptions, session *sess.Session) error {
+	err := LoadWithError(ctx, op, session, &LoadOptions{
 		Connection: options.Connection,
 	})
 	if err != nil {
@@ -73,18 +74,18 @@ func doPlatformLoad(op *wire.LoadOp, options *PlatformLoadOptions, session *sess
 	}
 
 	if options.LoadAll && op.HasMoreBatches {
-		return doPlatformLoad(op, options, session)
+		return doPlatformLoad(ctx, op, options, session)
 	}
 
 	return nil
 }
 
-func PlatformLoadOne(item meta.CollectionableItem, options *PlatformLoadOptions, session *sess.Session) error {
+func PlatformLoadOne(ctx context.Context, item meta.CollectionableItem, options *PlatformLoadOptions, session *sess.Session) error {
 	collection := &LoadOneCollection{
 		Item: item,
 	}
 
-	if err := PlatformLoad(collection, options, session); err != nil {
+	if err := PlatformLoad(ctx, collection, options, session); err != nil {
 		return err
 	}
 
@@ -102,8 +103,9 @@ func PlatformLoadOne(item meta.CollectionableItem, options *PlatformLoadOptions,
 	return nil
 }
 
-func PlatformLoadByID(item meta.CollectionableItem, id string, session *sess.Session, connection wire.Connection) error {
+func PlatformLoadByID(ctx context.Context, item meta.CollectionableItem, id string, session *sess.Session, connection wire.Connection) error {
 	return PlatformLoadOne(
+		ctx,
 		item,
 		&PlatformLoadOptions{
 			Connection: connection,

--- a/apps/platform/pkg/datasource/platformsave.go
+++ b/apps/platform/pkg/datasource/platformsave.go
@@ -1,6 +1,7 @@
 package datasource
 
 import (
+	"context"
 	"strings"
 
 	"github.com/thecloudmasters/uesio/pkg/meta"
@@ -15,19 +16,19 @@ type PlatformSaveRequest struct {
 	Params     map[string]any
 }
 
-func PlatformDelete(request meta.CollectionableGroup, connection wire.Connection, session *sess.Session) error {
-	return doPlatformSave([]SaveRequest{{
+func PlatformDelete(ctx context.Context, request meta.CollectionableGroup, connection wire.Connection, session *sess.Session) error {
+	return doPlatformSave(ctx, []SaveRequest{{
 		Wire:       "deleteRequest",
 		Collection: request.GetName(),
 		Deletes:    request,
 	}}, connection, session)
 }
 
-func PlatformDeleteOne(item meta.CollectionableItem, connection wire.Connection, session *sess.Session) error {
+func PlatformDeleteOne(ctx context.Context, item meta.CollectionableItem, connection wire.Connection, session *sess.Session) error {
 	collection := &LoadOneCollection{
 		Item: item,
 	}
-	return PlatformDelete(collection, connection, session)
+	return PlatformDelete(ctx, collection, connection, session)
 }
 
 func GetSaveRequestFromPlatformSave(psr PlatformSaveRequest) SaveRequest {
@@ -40,12 +41,12 @@ func GetSaveRequestFromPlatformSave(psr PlatformSaveRequest) SaveRequest {
 	}
 }
 
-func PlatformSaves(psrs []PlatformSaveRequest, connection wire.Connection, session *sess.Session) error {
+func PlatformSaves(ctx context.Context, psrs []PlatformSaveRequest, connection wire.Connection, session *sess.Session) error {
 	requests := make([]SaveRequest, len(psrs))
 	for i := range psrs {
 		requests[i] = GetSaveRequestFromPlatformSave(psrs[i])
 	}
-	return doPlatformSave(requests, connection, session)
+	return doPlatformSave(ctx, requests, connection, session)
 }
 
 func HandleSaveRequestErrors(requests []SaveRequest, err error) error {
@@ -84,19 +85,19 @@ func NewSaveOptions(connection wire.Connection, metadata *wire.MetadataCache) *S
 	}
 }
 
-func doPlatformSave(requests []SaveRequest, connection wire.Connection, session *sess.Session) error {
-	err := SaveWithOptions(requests, session, NewSaveOptions(connection, nil))
+func doPlatformSave(ctx context.Context, requests []SaveRequest, connection wire.Connection, session *sess.Session) error {
+	err := SaveWithOptions(ctx, requests, session, NewSaveOptions(connection, nil))
 	return HandleSaveRequestErrors(requests, err)
 }
 
-func PlatformSave(psr PlatformSaveRequest, connection wire.Connection, session *sess.Session) error {
-	return PlatformSaves([]PlatformSaveRequest{
+func PlatformSave(ctx context.Context, psr PlatformSaveRequest, connection wire.Connection, session *sess.Session) error {
+	return PlatformSaves(ctx, []PlatformSaveRequest{
 		psr,
 	}, connection, session)
 }
 
-func PlatformSaveOne(item meta.CollectionableItem, options *wire.SaveOptions, connection wire.Connection, session *sess.Session) error {
-	return PlatformSave(*GetPlatformSaveOneRequest(item, options), connection, session)
+func PlatformSaveOne(ctx context.Context, item meta.CollectionableItem, options *wire.SaveOptions, connection wire.Connection, session *sess.Session) error {
+	return PlatformSave(ctx, *GetPlatformSaveOneRequest(item, options), connection, session)
 }
 
 func GetPlatformSaveOneRequest(item meta.CollectionableItem, options *wire.SaveOptions) *PlatformSaveRequest {
@@ -108,6 +109,6 @@ func GetPlatformSaveOneRequest(item meta.CollectionableItem, options *wire.SaveO
 	}
 }
 
-func GetPlatformConnection(session *sess.Session, connection wire.Connection) (wire.Connection, error) {
-	return GetConnection(meta.PLATFORM_DATA_SOURCE, session, connection)
+func GetPlatformConnection(ctx context.Context, session *sess.Session, connection wire.Connection) (wire.Connection, error) {
+	return GetConnection(ctx, meta.PLATFORM_DATA_SOURCE, session, connection)
 }

--- a/apps/platform/pkg/datasource/recordpermissions.go
+++ b/apps/platform/pkg/datasource/recordpermissions.go
@@ -1,6 +1,7 @@
 package datasource
 
 import (
+	"context"
 	"fmt"
 
 	"slices"
@@ -68,7 +69,7 @@ func getAccessFields(collectionMetadata *wire.CollectionMetadata, metadata *wire
 
 }
 
-func loadInAccessFieldData(op *wire.SaveOp, connection wire.Connection, session *sess.Session) error {
+func loadInAccessFieldData(ctx context.Context, op *wire.SaveOp, connection wire.Connection, session *sess.Session) error {
 	referencedCollections := wire.ReferenceRegistry{}
 
 	metadata, err := op.GetMetadata()
@@ -117,7 +118,7 @@ func loadInAccessFieldData(op *wire.SaveOp, connection wire.Connection, session 
 		return err
 	}
 
-	return HandleReferences(connection, referencedCollections, metadata, session, &ReferenceOptions{
+	return HandleReferences(ctx, connection, referencedCollections, metadata, session, &ReferenceOptions{
 		MergeItems: true,
 	})
 }
@@ -248,7 +249,7 @@ func handleAccessFieldChange(change *wire.ChangeItem, tokenFuncs []tokenFunc, me
 	return nil
 }
 
-func GenerateRecordChallengeTokens(op *wire.SaveOp, connection wire.Connection, session *sess.Session) error {
+func GenerateRecordChallengeTokens(ctx context.Context, op *wire.SaveOp, connection wire.Connection, session *sess.Session) error {
 
 	collectionMetadata, err := op.GetCollectionMetadata()
 	if err != nil {
@@ -277,7 +278,7 @@ func GenerateRecordChallengeTokens(op *wire.SaveOp, connection wire.Connection, 
 			return nil
 		}
 
-		err := loadInAccessFieldData(op, connection, session)
+		err := loadInAccessFieldData(ctx, op, connection, session)
 		if err != nil {
 			return err
 		}

--- a/apps/platform/pkg/datasource/recordtokens.go
+++ b/apps/platform/pkg/datasource/recordtokens.go
@@ -1,15 +1,17 @@
 package datasource
 
 import (
+	"context"
+
 	"github.com/thecloudmasters/uesio/pkg/adapt"
 	"github.com/thecloudmasters/uesio/pkg/constant/commonfields"
 	"github.com/thecloudmasters/uesio/pkg/sess"
 	"github.com/thecloudmasters/uesio/pkg/types/wire"
 )
 
-func ResetRecordTokens(collection string, session *sess.Session) error {
-	return WithTransaction(session.RemoveWorkspaceContext(), nil, func(conn wire.Connection) error {
-		return resetTokenBatches(&wire.LoadOp{
+func ResetRecordTokens(ctx context.Context, collection string, session *sess.Session) error {
+	return WithTransaction(ctx, session.RemoveWorkspaceContext(), nil, func(conn wire.Connection) error {
+		return resetTokenBatches(ctx, &wire.LoadOp{
 			CollectionName: collection,
 			Collection:     &wire.Collection{},
 			Query:          true,
@@ -23,15 +25,15 @@ func ResetRecordTokens(collection string, session *sess.Session) error {
 	})
 }
 
-func resetTokenBatches(loadOp *wire.LoadOp, session *sess.Session) error {
+func resetTokenBatches(ctx context.Context, loadOp *wire.LoadOp, session *sess.Session) error {
 
 	for {
-		err := LoadWithError(loadOp, session, nil)
+		err := LoadWithError(ctx, loadOp, session, nil)
 		if err != nil {
 			return err
 		}
 
-		err = Save([]SaveRequest{
+		err = Save(ctx, []SaveRequest{
 			{
 				Collection: loadOp.CollectionName,
 				Changes:    loadOp.Collection,

--- a/apps/platform/pkg/datasource/references.go
+++ b/apps/platform/pkg/datasource/references.go
@@ -1,6 +1,7 @@
 package datasource
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -12,6 +13,7 @@ import (
 )
 
 func LoadLooper(
+	ctx context.Context,
 	connection wire.Connection,
 	collectionName string,
 	idMap wire.LocatorMap,
@@ -52,7 +54,7 @@ func LoadLooper(
 
 	op.AttachMetadataCache(metadata)
 
-	err := connection.Load(session.Context(), op, session)
+	err := connection.Load(ctx, op, session)
 	if err != nil {
 		return err
 	}
@@ -96,6 +98,7 @@ type ReferenceOptions struct {
 }
 
 func HandleReferences(
+	ctx context.Context,
 	connection wire.Connection,
 	referencedCollections wire.ReferenceRegistry,
 	metadata *wire.MetadataCache,
@@ -141,7 +144,7 @@ func HandleReferences(
 
 		ref.AddFields(refFields)
 
-		err = LoadLooper(connection, collectionName, ref.IDMap, ref.Fields, ref.GetMatchField(), metadata, session, func(refItem meta.Item, matchIndexes []wire.ReferenceLocator, ID string) error {
+		err = LoadLooper(ctx, connection, collectionName, ref.IDMap, ref.Fields, ref.GetMatchField(), metadata, session, func(refItem meta.Item, matchIndexes []wire.ReferenceLocator, ID string) error {
 
 			// This is a weird situation.
 			// It means we found a value that we didn't ask for.
@@ -212,6 +215,7 @@ func HandleReferences(
 }
 
 func HandleMultiCollectionReferences(
+	ctx context.Context,
 	connection wire.Connection,
 	referencedCollections wire.ReferenceRegistry,
 	metadata *wire.MetadataCache,
@@ -241,7 +245,7 @@ func HandleMultiCollectionReferences(
 		},
 	})
 
-	err := LoadLooper(connection, constant.CommonCollection, common.IDMap, common.Fields, common.GetMatchField(), metadata, session, func(refItem meta.Item, matchIndexes []wire.ReferenceLocator, ID string) error {
+	err := LoadLooper(ctx, connection, constant.CommonCollection, common.IDMap, common.Fields, common.GetMatchField(), metadata, session, func(refItem meta.Item, matchIndexes []wire.ReferenceLocator, ID string) error {
 
 		// This is a weird situation.
 		// It means we found a value that we didn't ask for.
@@ -291,5 +295,5 @@ func HandleMultiCollectionReferences(
 		}
 	}
 
-	return multiCollectionsRefs.Load(metadata, session, nil)
+	return multiCollectionsRefs.Load(ctx, metadata, session, nil)
 }

--- a/apps/platform/pkg/datasource/referencesgroup.go
+++ b/apps/platform/pkg/datasource/referencesgroup.go
@@ -1,6 +1,7 @@
 package datasource
 
 import (
+	"context"
 	"errors"
 
 	"github.com/thecloudmasters/uesio/pkg/adapt"
@@ -10,13 +11,13 @@ import (
 	"github.com/thecloudmasters/uesio/pkg/types/wire"
 )
 
-func loadData(op *wire.LoadOp, connection wire.Connection, session *sess.Session, index int) error {
+func loadData(ctx context.Context, op *wire.LoadOp, connection wire.Connection, session *sess.Session, index int) error {
 
 	if index == adapt.MAX_ITER_REF_GROUP {
 		return errors.New("you have reached the maximum limit of reference group")
 	}
 
-	err := connection.Load(session.Context(), op, session)
+	err := connection.Load(ctx, op, session)
 	if err != nil {
 		return err
 	}
@@ -25,10 +26,11 @@ func loadData(op *wire.LoadOp, connection wire.Connection, session *sess.Session
 		return nil
 	}
 
-	return loadData(op, connection, session, index+1)
+	return loadData(ctx, op, connection, session, index+1)
 }
 
 func HandleReferencesGroup(
+	ctx context.Context,
 	connection wire.Connection,
 	collection meta.Group,
 	referencedGroupCollections wire.ReferenceGroupRegistry,
@@ -96,7 +98,7 @@ func HandleReferencesGroup(
 
 	for _, op := range ops {
 		op.AttachMetadataCache(metadata)
-		err := loadData(op, connection, session, 0)
+		err := loadData(ctx, op, connection, session, 0)
 		if err != nil {
 			return err
 		}

--- a/apps/platform/pkg/datasource/siteadmincontext_test.go
+++ b/apps/platform/pkg/datasource/siteadmincontext_test.go
@@ -1,7 +1,6 @@
 package datasource
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -28,14 +27,14 @@ func TestGetSiteAdminSession(t *testing.T) {
 			UniqueKey: "luigi/foo:prod",
 		},
 	}
-	sessWithWorkspaceContext := sess.New(context.Background(), originalUser, originalSite).SetWorkspaceSession(sess.NewWorkspaceSession(
+	sessWithWorkspaceContext := sess.New(originalUser, originalSite).SetWorkspaceSession(sess.NewWorkspaceSession(
 		&ws,
 		originalUser,
 		"uesio/some.profile",
 		&meta.PermissionSet{},
 	))
-	sessWithSiteAdminContext := sess.New(context.Background(), originalUser, originalSite).SetSiteAdminSession(sess.NewSiteSession(otherSite, originalUser))
-	plainSession := sess.New(context.Background(), originalUser, originalSite)
+	sessWithSiteAdminContext := sess.New(originalUser, originalSite).SetSiteAdminSession(sess.NewSiteSession(otherSite, originalUser))
+	plainSession := sess.New(originalUser, originalSite)
 	tests := []struct {
 		name       string
 		input      *sess.Session

--- a/apps/platform/pkg/datasource/transaction.go
+++ b/apps/platform/pkg/datasource/transaction.go
@@ -1,49 +1,51 @@
 package datasource
 
 import (
+	"context"
+
 	"github.com/thecloudmasters/uesio/pkg/sess"
 	"github.com/thecloudmasters/uesio/pkg/types/wire"
 )
 
-func WithTransaction(session *sess.Session, existingConn wire.Connection, fn func(conn wire.Connection) error) error {
-	conn, err := GetPlatformConnection(session, existingConn)
+func WithTransaction(ctx context.Context, session *sess.Session, existingConn wire.Connection, fn func(conn wire.Connection) error) error {
+	conn, err := GetPlatformConnection(ctx, session, existingConn)
 	if err != nil {
 		return err
 	}
-	err = conn.BeginTransaction(session.Context())
+	err = conn.BeginTransaction(ctx)
 	if err != nil {
 		return err
 	}
 	err = fn(conn)
 	if err != nil {
-		rbErr := conn.RollbackTransaction(session.Context())
+		rbErr := conn.RollbackTransaction(ctx)
 		if rbErr != nil {
 			return rbErr
 		}
 		return err
 	}
-	return conn.CommitTransaction(session.Context())
+	return conn.CommitTransaction(ctx)
 }
 
-func WithTransactionResult[T any](session *sess.Session, existingConn wire.Connection, fn func(conn wire.Connection) (T, error)) (T, error) {
+func WithTransactionResult[T any](ctx context.Context, session *sess.Session, existingConn wire.Connection, fn func(conn wire.Connection) (T, error)) (T, error) {
 	var result T
-	conn, err := GetPlatformConnection(session, existingConn)
+	conn, err := GetPlatformConnection(ctx, session, existingConn)
 	if err != nil {
 		return result, err
 	}
-	err = conn.BeginTransaction(session.Context())
+	err = conn.BeginTransaction(ctx)
 	if err != nil {
 		return result, err
 	}
 	result, err = fn(conn)
 	if err != nil {
-		rbErr := conn.RollbackTransaction(session.Context())
+		rbErr := conn.RollbackTransaction(ctx)
 		if rbErr != nil {
 			return result, rbErr
 		}
 		return result, err
 	}
-	err = conn.CommitTransaction(session.Context())
+	err = conn.CommitTransaction(ctx)
 	if err != nil {
 		return result, err
 	}

--- a/apps/platform/pkg/datasource/upsertlookups.go
+++ b/apps/platform/pkg/datasource/upsertlookups.go
@@ -1,6 +1,7 @@
 package datasource
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/thecloudmasters/uesio/pkg/constant/commonfields"
@@ -10,6 +11,7 @@ import (
 )
 
 func HandleUpsertLookup(
+	ctx context.Context,
 	connection wire.Connection,
 	op *wire.SaveOp,
 	session *sess.Session,
@@ -55,7 +57,7 @@ func HandleUpsertLookup(
 		return err
 	}
 
-	return LoadLooper(connection, op.CollectionName, idMap, []wire.LoadRequestField{
+	return LoadLooper(ctx, connection, op.CollectionName, idMap, []wire.LoadRequestField{
 		{
 			ID: commonfields.Id,
 		},

--- a/apps/platform/pkg/datasource/versioncontext.go
+++ b/apps/platform/pkg/datasource/versioncontext.go
@@ -1,6 +1,8 @@
 package datasource
 
 import (
+	"context"
+
 	"github.com/thecloudmasters/uesio/pkg/bundle"
 	"github.com/thecloudmasters/uesio/pkg/constant"
 	"github.com/thecloudmasters/uesio/pkg/sess"
@@ -8,14 +10,14 @@ import (
 	"github.com/thecloudmasters/uesio/pkg/types/wire"
 )
 
-func addVersionContext(app, version string, session *sess.Session, connection wire.Connection) error {
+func addVersionContext(ctx context.Context, app, version string, session *sess.Session, connection wire.Connection) error {
 
-	bundleDef, err := bundle.GetVersionBundleDef(session.Context(), app, version, connection)
+	bundleDef, err := bundle.GetVersionBundleDef(ctx, app, version, connection)
 	if err != nil {
 		return err
 	}
 
-	licenseMap, err := GetLicenses(app, connection)
+	licenseMap, err := GetLicenses(ctx, app, connection)
 	if err != nil {
 		return err
 	}
@@ -27,7 +29,7 @@ func addVersionContext(app, version string, session *sess.Session, connection wi
 
 }
 
-func AddVersionContext(app, version string, session *sess.Session, connection wire.Connection) (*sess.Session, error) {
+func AddVersionContext(ctx context.Context, app, version string, session *sess.Session, connection wire.Connection) (*sess.Session, error) {
 	site := session.GetSite()
 	perms := session.GetSitePermissions()
 
@@ -40,10 +42,10 @@ func AddVersionContext(app, version string, session *sess.Session, connection wi
 		return nil, exceptions.NewForbiddenException("your profile does not allow you to work with versions")
 	}
 	sessClone := session.RemoveWorkspaceContext()
-	return sessClone, addVersionContext(app, version, sessClone, connection)
+	return sessClone, addVersionContext(ctx, app, version, sessClone, connection)
 }
 
-func EnterVersionContext(app string, session *sess.Session, connection wire.Connection) (*sess.Session, error) {
+func EnterVersionContext(ctx context.Context, app string, session *sess.Session, connection wire.Connection) (*sess.Session, error) {
 	// We don't need to enter into a version context for our own app
 	if app == session.GetContextAppName() {
 		return session, nil
@@ -54,5 +56,5 @@ func EnterVersionContext(app string, session *sess.Session, connection wire.Conn
 		return nil, err
 	}
 	sessClone := session.Clone()
-	return sessClone, addVersionContext(app, version, sessClone, connection)
+	return sessClone, addVersionContext(ctx, app, version, sessClone, connection)
 }

--- a/apps/platform/pkg/deploy/createsite.go
+++ b/apps/platform/pkg/deploy/createsite.go
@@ -1,6 +1,7 @@
 package deploy
 
 import (
+	"context"
 	"errors"
 	"strings"
 
@@ -50,7 +51,7 @@ func NewCreateSiteOptions(params map[string]any) (*CreateSiteOptions, error) {
 	}, nil
 }
 
-func CreateSite(options *CreateSiteOptions, connection wire.Connection, session *sess.Session) (*meta.Site, error) {
+func CreateSite(ctx context.Context, options *CreateSiteOptions, connection wire.Connection, session *sess.Session) (*meta.Site, error) {
 
 	if options == nil {
 		return nil, errors.New("invalid create options")
@@ -61,7 +62,7 @@ func CreateSite(options *CreateSiteOptions, connection wire.Connection, session 
 	subdomain := options.Subdomain
 	version := options.Version
 
-	app, err := datasource.QueryAppForWrite(appName, commonfields.UniqueKey, session, connection)
+	app, err := datasource.QueryAppForWrite(ctx, appName, commonfields.UniqueKey, session, connection)
 	if err != nil {
 		return nil, exceptions.NewForbiddenException("you do not have permission to create bundles for app " + appName)
 	}
@@ -90,13 +91,13 @@ func CreateSite(options *CreateSiteOptions, connection wire.Connection, session 
 	}
 
 	// First, create the site.
-	err = datasource.PlatformSaveOne(site, nil, connection, session)
+	err = datasource.PlatformSaveOne(ctx, site, nil, connection, session)
 	if err != nil {
 		return nil, err
 	}
 
 	// Second, create the domain.
-	err = datasource.PlatformSaveOne(domain, nil, connection, session)
+	err = datasource.PlatformSaveOne(ctx, domain, nil, connection, session)
 	if err != nil {
 		return nil, err
 	}

--- a/apps/platform/pkg/featureflagstore/platform/platform.go
+++ b/apps/platform/pkg/featureflagstore/platform/platform.go
@@ -1,6 +1,7 @@
 package environment
 
 import (
+	"context"
 	"errors"
 
 	"github.com/thecloudmasters/uesio/pkg/datasource"
@@ -11,14 +12,15 @@ import (
 
 type FeatureFlagStore struct{}
 
-func (ffs *FeatureFlagStore) GetMany(user string, session *sess.Session) (*meta.FeatureFlagAssignmentCollection, error) {
+func (ffs *FeatureFlagStore) GetMany(ctx context.Context, user string, session *sess.Session) (*meta.FeatureFlagAssignmentCollection, error) {
 	// Enter into a version context to be able to interact with the uesio/core.secretstorevalue collection
-	versionSession, err := datasource.EnterVersionContext("uesio/core", session, nil)
+	versionSession, err := datasource.EnterVersionContext(ctx, "uesio/core", session, nil)
 	if err != nil {
 		return nil, err
 	}
 	assignments := &meta.FeatureFlagAssignmentCollection{}
 	err = datasource.PlatformLoad(
+		ctx,
 		assignments,
 		&datasource.PlatformLoadOptions{
 			Fields: []wire.LoadRequestField{
@@ -45,14 +47,15 @@ func (ffs *FeatureFlagStore) GetMany(user string, session *sess.Session) (*meta.
 	return assignments, nil
 }
 
-func (ffs *FeatureFlagStore) Get(key, user string, session *sess.Session) (*meta.FeatureFlagAssignment, error) {
+func (ffs *FeatureFlagStore) Get(ctx context.Context, key, user string, session *sess.Session) (*meta.FeatureFlagAssignment, error) {
 	// Enter into a version context to be able to interact with the uesio/core.secretstorevalue collection
-	versionSession, err := datasource.EnterVersionContext("uesio/core", session, nil)
+	versionSession, err := datasource.EnterVersionContext(ctx, "uesio/core", session, nil)
 	if err != nil {
 		return nil, err
 	}
 	assignments := meta.FeatureFlagAssignmentCollection{}
 	err = datasource.PlatformLoad(
+		ctx,
 		&assignments,
 		&datasource.PlatformLoadOptions{
 			Fields: []wire.LoadRequestField{
@@ -91,13 +94,13 @@ func (ffs *FeatureFlagStore) Get(key, user string, session *sess.Session) (*meta
 	return nil, nil
 }
 
-func (ffs *FeatureFlagStore) Set(key, user string, value any, session *sess.Session) error {
+func (ffs *FeatureFlagStore) Set(ctx context.Context, key, user string, value any, session *sess.Session) error {
 	// Enter into a version context to be able to interact with the uesio/core.secretstorevalue collection
-	versionSession, err := datasource.EnterVersionContext("uesio/core", session, nil)
+	versionSession, err := datasource.EnterVersionContext(ctx, "uesio/core", session, nil)
 	if err != nil {
 		return err
 	}
-	return datasource.PlatformSaveOne(&meta.FeatureFlagAssignment{
+	return datasource.PlatformSaveOne(ctx, &meta.FeatureFlagAssignment{
 		Flag:  key,
 		Value: value,
 		User: &meta.User{
@@ -108,14 +111,14 @@ func (ffs *FeatureFlagStore) Set(key, user string, value any, session *sess.Sess
 	}, nil, versionSession)
 }
 
-func (ffs *FeatureFlagStore) Remove(key, user string, session *sess.Session) error {
+func (ffs *FeatureFlagStore) Remove(ctx context.Context, key, user string, session *sess.Session) error {
 	// Enter into a version context to be able to interact with the uesio/core.featureflagvalue collection
-	versionSession, err := datasource.EnterVersionContext("uesio/core", session, nil)
+	versionSession, err := datasource.EnterVersionContext(ctx, "uesio/core", session, nil)
 	if err != nil {
 		return err
 	}
 
-	assignment, err := ffs.Get(key, user, session)
+	assignment, err := ffs.Get(ctx, key, user, session)
 	if err != nil {
 		return err
 	}
@@ -124,5 +127,5 @@ func (ffs *FeatureFlagStore) Remove(key, user string, session *sess.Session) err
 		return nil
 	}
 
-	return datasource.PlatformDeleteOne(assignment, nil, versionSession)
+	return datasource.PlatformDeleteOne(ctx, assignment, nil, versionSession)
 }

--- a/apps/platform/pkg/filesource/delete.go
+++ b/apps/platform/pkg/filesource/delete.go
@@ -14,6 +14,7 @@ import (
 func Delete(ctx context.Context, userFileID string, session *sess.Session) error {
 	userFile := meta.UserFileMetadata{}
 	err := datasource.PlatformLoadOne(
+		ctx,
 		&userFile,
 		&datasource.PlatformLoadOptions{
 			Conditions: []wire.LoadRequestCondition{
@@ -34,7 +35,7 @@ func Delete(ctx context.Context, userFileID string, session *sess.Session) error
 	fieldID := userFile.FieldID
 
 	metadataResponse := &wire.MetadataCache{}
-	err = datasource.GetMetadataResponse(metadataResponse, collectionID, fieldID, session)
+	err = datasource.GetMetadataResponse(ctx, metadataResponse, collectionID, fieldID, session)
 	if err != nil {
 		return err
 	}
@@ -44,7 +45,7 @@ func Delete(ctx context.Context, userFileID string, session *sess.Session) error
 		return err
 	}
 
-	err = datasource.PlatformDeleteOne(&userFile, nil, session)
+	err = datasource.PlatformDeleteOne(ctx, &userFile, nil, session)
 	if err != nil {
 		return err
 	}
@@ -55,7 +56,7 @@ func Delete(ctx context.Context, userFileID string, session *sess.Session) error
 			return errors.New("can only delete files attached to FILE fields")
 		}
 
-		err = datasource.Save([]datasource.SaveRequest{
+		err = datasource.Save(ctx, []datasource.SaveRequest{
 			{
 				Collection: collectionID,
 				Wire:       "filefieldupdate",

--- a/apps/platform/pkg/filesource/download.go
+++ b/apps/platform/pkg/filesource/download.go
@@ -18,6 +18,7 @@ func DownloadAttachment(ctx context.Context, recordID string, path string, sessi
 
 	userFile := &meta.UserFileMetadata{}
 	err := datasource.PlatformLoadOne(
+		ctx,
 		userFile,
 		&datasource.PlatformLoadOptions{
 			Conditions: []wire.LoadRequestCondition{
@@ -44,6 +45,7 @@ func Download(ctx context.Context, userFileID string, session *sess.Session) (io
 
 	userFile := &meta.UserFileMetadata{}
 	err := datasource.PlatformLoadOne(
+		ctx,
 		userFile,
 		&datasource.PlatformLoadOptions{
 			Fields: []wire.LoadRequestField{
@@ -95,7 +97,7 @@ func DownloadItem(ctx context.Context, userFile *meta.UserFileMetadata, session 
 		return nil, nil, errors.New("no file provided")
 	}
 
-	conn, err := fileadapt.GetFileConnection(userFile.FileSourceID, session)
+	conn, err := fileadapt.GetFileConnection(ctx, userFile.FileSourceID, session)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/apps/platform/pkg/integ/bedrock/bedrock.go
+++ b/apps/platform/pkg/integ/bedrock/bedrock.go
@@ -1,6 +1,7 @@
 package bedrock
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -22,8 +23,8 @@ type Connection struct {
 
 type ModelHandler interface {
 	Hydrate(ic *wire.IntegrationConnection, options map[string]any) error
-	Invoke() (result any, err error)
-	Stream() (stream *integ.Stream, err error)
+	Invoke(ctx context.Context) (result any, err error)
+	Stream(ctx context.Context) (stream *integ.Stream, err error)
 }
 
 const CLAUDE_3_5_HAIKU_MODEL_ID = "us.anthropic.claude-3-5-haiku-20241022-v1:0"
@@ -55,7 +56,7 @@ func getHandler(ic *wire.IntegrationConnection, params map[string]any) (ModelHan
 }
 
 // RunAction implements the system bot interface
-func RunAction(bot *meta.Bot, ic *wire.IntegrationConnection, actionName string, params map[string]any) (any, error) {
+func RunAction(ctx context.Context, bot *meta.Bot, ic *wire.IntegrationConnection, actionName string, params map[string]any) (any, error) {
 
 	handler, err := getHandler(ic, params)
 	if err != nil {
@@ -64,9 +65,9 @@ func RunAction(bot *meta.Bot, ic *wire.IntegrationConnection, actionName string,
 
 	switch strings.ToLower(actionName) {
 	case "invokemodel":
-		return handler.Invoke()
+		return handler.Invoke(ctx)
 	case "streammodel":
-		return handler.Stream()
+		return handler.Stream(ctx)
 	}
 
 	return nil, errors.New("invalid action name for Bedrock integration")

--- a/apps/platform/pkg/integ/bedrock/claude.go
+++ b/apps/platform/pkg/integ/bedrock/claude.go
@@ -1,6 +1,7 @@
 package bedrock
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -64,8 +65,8 @@ func (cmh *ClaudeModelHandler) RecordUsage(inputTokens, outputTokens int64) {
 	usage.RegisterEvent("OUTPUT_TOKENS", "INTEGRATION", integrationKey, outputTokens, session)
 }
 
-func (cmh *ClaudeModelHandler) Invoke() (result any, err error) {
-	cfg, err := creds.GetAWSConfig(cmh.ic.Context(), cmh.ic.GetCredentials())
+func (cmh *ClaudeModelHandler) Invoke(ctx context.Context) (result any, err error) {
+	cfg, err := creds.GetAWSConfig(ctx, cmh.ic.GetCredentials())
 	if err != nil {
 		return nil, err
 	}
@@ -74,7 +75,7 @@ func (cmh *ClaudeModelHandler) Invoke() (result any, err error) {
 		bedrock.WithConfig(cfg),
 	)
 
-	message, err := client.Messages.New(cmh.ic.Context(), cmh.options)
+	message, err := client.Messages.New(ctx, cmh.options)
 	if err != nil {
 		return nil, handleBedrockError(err)
 	}
@@ -85,8 +86,8 @@ func (cmh *ClaudeModelHandler) Invoke() (result any, err error) {
 
 }
 
-func (cmh *ClaudeModelHandler) Stream() (*integ.Stream, error) {
-	cfg, err := creds.GetAWSConfig(cmh.ic.Context(), cmh.ic.GetCredentials())
+func (cmh *ClaudeModelHandler) Stream(ctx context.Context) (*integ.Stream, error) {
+	cfg, err := creds.GetAWSConfig(ctx, cmh.ic.GetCredentials())
 	if err != nil {
 		return nil, err
 	}
@@ -102,7 +103,7 @@ func (cmh *ClaudeModelHandler) Stream() (*integ.Stream, error) {
 		defer close(outputStream.Err())
 		defer close(outputStream.Done())
 
-		stream := client.Messages.NewStreaming(cmh.ic.Context(), cmh.options)
+		stream := client.Messages.NewStreaming(ctx, cmh.options)
 
 		for stream.Next() {
 			event := stream.Current()

--- a/apps/platform/pkg/integ/bedrock/stability.go
+++ b/apps/platform/pkg/integ/bedrock/stability.go
@@ -1,6 +1,7 @@
 package bedrock
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 
@@ -63,8 +64,8 @@ func (smh *StabilityModelHandler) RecordUsage() {
 	usage.RegisterEvent("IMAGE_GENERATION", "INTEGRATION", integrationKey, 0, session)
 }
 
-func (smh *StabilityModelHandler) Invoke() (result any, err error) {
-	cfg, err := creds.GetAWSConfig(smh.ic.Context(), smh.ic.GetCredentials())
+func (smh *StabilityModelHandler) Invoke(ctx context.Context) (result any, err error) {
+	cfg, err := creds.GetAWSConfig(ctx, smh.ic.GetCredentials())
 	if err != nil {
 		return nil, err
 	}
@@ -85,7 +86,7 @@ func (smh *StabilityModelHandler) Invoke() (result any, err error) {
 		Accept:      aws.String("application/json"),
 	}
 
-	output, err := client.InvokeModel(smh.ic.Context(), input, smh.GetClientOptions(input))
+	output, err := client.InvokeModel(ctx, input, smh.GetClientOptions(input))
 	if err != nil {
 		return nil, err
 	}
@@ -96,7 +97,7 @@ func (smh *StabilityModelHandler) Invoke() (result any, err error) {
 
 }
 
-func (utmh *StabilityModelHandler) Stream() (stream *integ.Stream, err error) {
+func (utmh *StabilityModelHandler) Stream(ctx context.Context) (stream *integ.Stream, err error) {
 	return nil, errors.New("streaming is not supported for the stability model handler")
 }
 

--- a/apps/platform/pkg/integ/bedrock/uesiotest.go
+++ b/apps/platform/pkg/integ/bedrock/uesiotest.go
@@ -1,6 +1,7 @@
 package bedrock
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -20,7 +21,7 @@ func (utmh *UesioTestModelHandler) Hydrate(ic *wire.IntegrationConnection, param
 	return nil
 }
 
-func (utmh *UesioTestModelHandler) Invoke() (result any, err error) {
+func (utmh *UesioTestModelHandler) Invoke(ctx context.Context) (result any, err error) {
 	body, err := json.MarshalIndent(utmh.options, "", "  ")
 	if err != nil {
 		return nil, err
@@ -29,6 +30,6 @@ func (utmh *UesioTestModelHandler) Invoke() (result any, err error) {
 	return content, nil
 }
 
-func (utmh *UesioTestModelHandler) Stream() (stream *integ.Stream, err error) {
+func (utmh *UesioTestModelHandler) Stream(ctx context.Context) (stream *integ.Stream, err error) {
 	return nil, errors.New("streaming is not supported for the uesio test handler")
 }

--- a/apps/platform/pkg/integ/bedrock/uesiotestanthropic.go
+++ b/apps/platform/pkg/integ/bedrock/uesiotestanthropic.go
@@ -1,6 +1,7 @@
 package bedrock
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -23,7 +24,7 @@ func (utamh *UesioTestAnthropicModelHandler) Hydrate(ic *wire.IntegrationConnect
 	return cmh.Hydrate(ic, params)
 }
 
-func (utamh *UesioTestAnthropicModelHandler) Invoke() (any, error) {
+func (utamh *UesioTestAnthropicModelHandler) Invoke(ctx context.Context) (any, error) {
 	body, err := json.MarshalIndent(utamh.cmh.options, "", "  ")
 	if err != nil {
 		return nil, err
@@ -43,6 +44,6 @@ func (utamh *UesioTestAnthropicModelHandler) Invoke() (any, error) {
 
 }
 
-func (utamh *UesioTestAnthropicModelHandler) Stream() (stream *integ.Stream, err error) {
+func (utamh *UesioTestAnthropicModelHandler) Stream(ctx context.Context) (stream *integ.Stream, err error) {
 	return nil, errors.New("streaming is not supported for the uesio test anthropic handler")
 }

--- a/apps/platform/pkg/limits/limits.go
+++ b/apps/platform/pkg/limits/limits.go
@@ -1,6 +1,7 @@
 package limits
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/thecloudmasters/uesio/pkg/featureflagstore"
@@ -9,12 +10,12 @@ import (
 
 const limitNameMaxDomainsPerUser = "uesio/studio.max_domains_per_user"
 
-func GetLimitDomainsPerUser(user string, session *sess.Session) (int, error) {
-	return GetNumericLimit(limitNameMaxDomainsPerUser, user, session)
+func GetLimitDomainsPerUser(ctx context.Context, user string, session *sess.Session) (int, error) {
+	return GetNumericLimit(ctx, limitNameMaxDomainsPerUser, user, session)
 }
 
-func GetNumericLimit(numericLimitName, user string, session *sess.Session) (int, error) {
-	flag, err := featureflagstore.GetFeatureFlag(numericLimitName, session, user)
+func GetNumericLimit(ctx context.Context, numericLimitName, user string, session *sess.Session) (int, error) {
+	flag, err := featureflagstore.GetFeatureFlag(ctx, numericLimitName, session, user)
 	if err != nil {
 		return 0, err
 	}

--- a/apps/platform/pkg/merge/merge_test.go
+++ b/apps/platform/pkg/merge/merge_test.go
@@ -1,7 +1,6 @@
 package merge
 
 import (
-	"context"
 	"errors"
 	"reflect"
 	"regexp"
@@ -86,8 +85,8 @@ var studioSiteWithoutSubdomain = &meta.Site{
 	App:    studioApp,
 }
 
-var studioSession = sess.New(context.Background(), studioUser, studioSite)
-var studioSessionWithoutSubdomain = sess.New(context.Background(), studioUser, studioSiteWithoutSubdomain)
+var studioSession = sess.New(studioUser, studioSite)
+var studioSessionWithoutSubdomain = sess.New(studioUser, studioSiteWithoutSubdomain)
 
 func Test_serverMergeFuncs(t *testing.T) {
 

--- a/apps/platform/pkg/oauth2/authorizationcode_test.go
+++ b/apps/platform/pkg/oauth2/authorizationcode_test.go
@@ -42,7 +42,7 @@ func TestAuthorizationCodeFlow(t *testing.T) {
 	var requestAsserts func(t *testing.T, request *http.Request)
 
 	integrationName := "luigi/foo.bar"
-	session := sess.New(context.Background(), nil, nil)
+	session := sess.New(nil, nil)
 
 	// set up a mock server to handle our test requests
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -146,7 +146,7 @@ func TestAuthorizationCodeFlow(t *testing.T) {
 			assert.Equal(t, []string{"scope1 scope2"}, queryVals["scope"])
 			stateObject, err := UnmarshalState(redirectMeta.State)
 			assert.Nil(t, err)
-			gotToken, err := ExchangeAuthorizationCodeForAccessToken(session.Context(), tt.credentials, host, sampleAuthCode, stateObject)
+			gotToken, err := ExchangeAuthorizationCodeForAccessToken(context.Background(), tt.credentials, host, sampleAuthCode, stateObject)
 			assert.Equal(t, tt.wantAccessToken, gotToken.AccessToken)
 			assert.Equal(t, tt.wantRefreshToken, gotToken.RefreshToken)
 		})

--- a/apps/platform/pkg/oauth2/integrationcredential.go
+++ b/apps/platform/pkg/oauth2/integrationcredential.go
@@ -1,6 +1,7 @@
 package oauth2
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -86,7 +87,7 @@ func BuildIntegrationCredential(integrationName string, userId string, token *oa
 }
 
 // UpsertIntegrationCredential performs an upsert on the provided integration credential item
-func UpsertIntegrationCredential(integrationCredential *wire.Item, coreSession *sess.Session, platformConn wire.Connection) error {
+func UpsertIntegrationCredential(ctx context.Context, integrationCredential *wire.Item, coreSession *sess.Session, platformConn wire.Connection) error {
 	integrationCredential.SetField(commonfields.UpdatedAt, time.Now().Unix())
 	requests := []datasource.SaveRequest{
 		{
@@ -99,12 +100,12 @@ func UpsertIntegrationCredential(integrationCredential *wire.Item, coreSession *
 			Params: datasource.GetParamsFromSession(coreSession),
 		},
 	}
-	return datasource.SaveWithOptions(requests, coreSession, datasource.NewSaveOptions(platformConn, nil))
+	return datasource.SaveWithOptions(ctx, requests, coreSession, datasource.NewSaveOptions(platformConn, nil))
 
 }
 
 // DeleteIntegrationCredential deletes a provided integration credential
-func DeleteIntegrationCredential(integrationCredential *wire.Item, coreSession *sess.Session, platformConn wire.Connection) error {
+func DeleteIntegrationCredential(ctx context.Context, integrationCredential *wire.Item, coreSession *sess.Session, platformConn wire.Connection) error {
 	requests := []datasource.SaveRequest{
 		{
 			Collection: IntegrationCredentialCollection,
@@ -116,13 +117,13 @@ func DeleteIntegrationCredential(integrationCredential *wire.Item, coreSession *
 			Params: datasource.GetParamsFromSession(coreSession),
 		},
 	}
-	return datasource.SaveWithOptions(requests, coreSession, datasource.NewSaveOptions(platformConn, nil))
+	return datasource.SaveWithOptions(ctx, requests, coreSession, datasource.NewSaveOptions(platformConn, nil))
 
 }
 
 // GetIntegrationCredential retrieves any existing integration credential record for the provided user / integration
 func GetIntegrationCredential(
-	userId, integrationName string, coreSession *sess.Session, connection wire.Connection,
+	ctx context.Context, userId, integrationName string, coreSession *sess.Session, connection wire.Connection,
 ) (*wire.Item, error) {
 	integrationCredentials := &wire.Collection{}
 	fetchIntegrationCredentialOp := &wire.LoadOp{
@@ -160,6 +161,7 @@ func GetIntegrationCredential(
 		},
 	}
 	if err := datasource.LoadWithError(
+		ctx,
 		fetchIntegrationCredentialOp,
 		coreSession,
 		&datasource.LoadOptions{

--- a/apps/platform/pkg/oauth2/state_test.go
+++ b/apps/platform/pkg/oauth2/state_test.go
@@ -1,7 +1,6 @@
 package oauth2
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -41,14 +40,14 @@ func TestStateMarshaling(t *testing.T) {
 		},
 		Name: "prod",
 	}
-	sessWithWorkspaceContext := sess.New(context.Background(), user, site).SetWorkspaceSession(sess.NewWorkspaceSession(
+	sessWithWorkspaceContext := sess.New(user, site).SetWorkspaceSession(sess.NewWorkspaceSession(
 		&ws,
 		user,
 		"",
 		nil,
 	))
-	sessWithSiteAdminContext := sess.New(context.Background(), user, site).SetSiteAdminSession(sess.NewSiteSession(otherSite, user))
-	plainSession := sess.New(context.Background(), user, site)
+	sessWithSiteAdminContext := sess.New(user, site).SetSiteAdminSession(sess.NewSiteSession(otherSite, user))
+	plainSession := sess.New(user, site)
 
 	stateWithWorkspace := (&State{
 		Nonce:           "123",

--- a/apps/platform/pkg/oauth2/transport_test.go
+++ b/apps/platform/pkg/oauth2/transport_test.go
@@ -1,6 +1,7 @@
 package oauth2
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -72,7 +73,7 @@ func TestTransport_setAuthHeader(t1 *testing.T) {
 	for _, tt := range tests {
 		t1.Run(tt.name, func(t1 *testing.T) {
 			// dummy request
-			r, _ := http.NewRequest(http.MethodGet, "https://localhost:8080", nil)
+			r, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://localhost:8080", nil)
 			invoked := false
 			onAuthHeaderSet := func(token *oauth2.Token, authHeader string) {
 				invoked = true

--- a/apps/platform/pkg/secretstore/environment/environment.go
+++ b/apps/platform/pkg/secretstore/environment/environment.go
@@ -1,6 +1,7 @@
 package environment
 
 import (
+	"context"
 	"errors"
 	"os"
 
@@ -24,7 +25,7 @@ var secretValues = map[string]string{
 	"uesio/core.db_database":            os.Getenv("UESIO_DB_DATABASE"),
 }
 
-func (ss *SecretStore) Get(key string, session *sess.Session) (*meta.SecretStoreValue, error) {
+func (ss *SecretStore) Get(ctx context.Context, key string, session *sess.Session) (*meta.SecretStoreValue, error) {
 	value, ok := secretValues[key]
 	if !ok {
 		return nil, exceptions.NewNotFoundException("secret value not found: " + key)
@@ -35,10 +36,10 @@ func (ss *SecretStore) Get(key string, session *sess.Session) (*meta.SecretStore
 	}, nil
 }
 
-func (ss *SecretStore) Set(key, value string, session *sess.Session) error {
+func (ss *SecretStore) Set(ctx context.Context, key, value string, session *sess.Session) error {
 	return errors.New("you cannot set secret values in the environment store")
 }
 
-func (ss *SecretStore) Remove(key string, session *sess.Session) error {
+func (ss *SecretStore) Remove(ctx context.Context, key string, session *sess.Session) error {
 	return errors.New("you cannot remove secret values in the environment store")
 }

--- a/apps/platform/pkg/secretstore/platform/platform.go
+++ b/apps/platform/pkg/secretstore/platform/platform.go
@@ -1,6 +1,8 @@
 package environment
 
 import (
+	"context"
+
 	"github.com/thecloudmasters/uesio/pkg/constant/commonfields"
 	"github.com/thecloudmasters/uesio/pkg/datasource"
 	"github.com/thecloudmasters/uesio/pkg/meta"
@@ -12,14 +14,15 @@ import (
 type SecretStore struct {
 }
 
-func (ss *SecretStore) Get(key string, session *sess.Session) (*meta.SecretStoreValue, error) {
+func (ss *SecretStore) Get(ctx context.Context, key string, session *sess.Session) (*meta.SecretStoreValue, error) {
 	s := &meta.SecretStoreValue{}
 	// Enter into a version context to be able to interact with the uesio/core.secretstorevalue collection
-	versionSession, err := datasource.EnterVersionContext("uesio/core", session, nil)
+	versionSession, err := datasource.EnterVersionContext(ctx, "uesio/core", session, nil)
 	if err != nil {
 		return nil, err
 	}
 	if err = datasource.PlatformLoadOne(
+		ctx,
 		s,
 		&datasource.PlatformLoadOptions{
 			Conditions: []wire.LoadRequestCondition{
@@ -41,29 +44,29 @@ func (ss *SecretStore) Get(key string, session *sess.Session) (*meta.SecretStore
 	return s, nil
 }
 
-func (ss *SecretStore) Set(key, value string, session *sess.Session) error {
+func (ss *SecretStore) Set(ctx context.Context, key, value string, session *sess.Session) error {
 	s := meta.SecretStoreValue{
 		Key:   key,
 		Value: value,
 	}
 	// Enter into a version context to be able to interact with the uesio/core.secretstorevalue collection
-	versionSession, err := datasource.EnterVersionContext("uesio/core", session, nil)
+	versionSession, err := datasource.EnterVersionContext(ctx, "uesio/core", session, nil)
 	if err != nil {
 		return err
 	}
-	return datasource.PlatformSaveOne(&s, &wire.SaveOptions{
+	return datasource.PlatformSaveOne(ctx, &s, &wire.SaveOptions{
 		Upsert: true,
 	}, nil, versionSession)
 }
 
-func (ss *SecretStore) Remove(key string, session *sess.Session) error {
+func (ss *SecretStore) Remove(ctx context.Context, key string, session *sess.Session) error {
 	// Enter into a version context to be able to interact with the uesio/core.configstorevalue collection
-	versionSession, err := datasource.EnterVersionContext("uesio/core", session, nil)
+	versionSession, err := datasource.EnterVersionContext(ctx, "uesio/core", session, nil)
 	if err != nil {
 		return err
 	}
 
-	secretStoreValue, err := ss.Get(key, session)
+	secretStoreValue, err := ss.Get(ctx, key, session)
 	if err != nil {
 		if exceptions.IsNotFoundException(err) {
 			return nil
@@ -74,5 +77,5 @@ func (ss *SecretStore) Remove(key string, session *sess.Session) error {
 		return nil
 	}
 
-	return datasource.PlatformDeleteOne(secretStoreValue, nil, versionSession)
+	return datasource.PlatformDeleteOne(ctx, secretStoreValue, nil, versionSession)
 }

--- a/apps/platform/pkg/sess/anon.go
+++ b/apps/platform/pkg/sess/anon.go
@@ -1,13 +1,11 @@
 package sess
 
 import (
-	"context"
-
 	"github.com/thecloudmasters/uesio/pkg/meta"
 )
 
-func GetAnonSession(ctx context.Context, site *meta.Site) *Session {
-	s := New(ctx, &meta.User{
+func GetAnonSession(site *meta.Site) *Session {
+	s := New(&meta.User{
 		BuiltIn: meta.BuiltIn{
 			UniqueKey: meta.BootUsername,
 		},
@@ -20,11 +18,11 @@ func GetAnonSession(ctx context.Context, site *meta.Site) *Session {
 }
 
 func GetAnonSessionFrom(session *Session) *Session {
-	return GetAnonSession(session.Context(), session.GetSite())
+	return GetAnonSession(session.GetSite())
 }
 
-func GetStudioAnonSession(ctx context.Context) *Session {
-	return GetAnonSession(ctx, studioSite)
+func GetStudioAnonSession() *Session {
+	return GetAnonSession(studioSite)
 }
 
 var studioSite *meta.Site

--- a/apps/platform/pkg/sess/session.go
+++ b/apps/platform/pkg/sess/session.go
@@ -1,21 +1,19 @@
 package sess
 
 import (
-	"context"
 	"sort"
 
 	"github.com/thecloudmasters/uesio/pkg/meta"
 )
 
-func New(ctx context.Context, user *meta.User, site *meta.Site) *Session {
-	return NewWithAuthToken(ctx, user, site, "")
+func New(user *meta.User, site *meta.Site) *Session {
+	return NewWithAuthToken(user, site, "")
 }
 
-func NewWithAuthToken(ctx context.Context, user *meta.User, site *meta.Site, authToken string) *Session {
+func NewWithAuthToken(user *meta.User, site *meta.Site, authToken string) *Session {
 	return &Session{
 		authToken:   authToken,
 		siteSession: NewSiteSession(site, user),
-		ctx:         ctx,
 	}
 }
 
@@ -129,21 +127,6 @@ type Session struct {
 	siteAdminSession *SiteSession
 	versionSession   *VersionSession
 	tokens           TokenMap
-	// Original comment from when context property was added to Session in https://github.com/ues-io/uesio/pull/3619/files#diff-b50d36d253129bd263753674a60b24374b3b91b19cd0b492aa4c0d700bf1c885R28:
-	// attach the Go context to the session so that we can access the context from basically anywhere.
-	// This was done because it was deemed less invasive than refactoring all of our code to pass a context around,
-	// since we already have a Session basically everywhere.
-	// Ideally, we would have a context.Context in virtually all of our Go method calls,
-	// but I leave that for another day, since it would be very time-consuming to refactor all of our Go method calls.
-	// TODO (not from original comment): We need to eliminate this, refactor and pass a context through the API flow. Currently, session & connection have context but some places do not
-	// have session and connection can sometimes be nil. We also have some things on background contexts (e.g., platform file connection) that are involved in
-	// request processing which results in having multiple contexts involved in a request leading to confusion but more importantly, potentially unexpected outcomes.
-	ctx context.Context
-}
-
-// Context returns the session's associated Go Context
-func (s *Session) Context() context.Context {
-	return s.ctx
 }
 
 func (s *Session) SetLabels(labels map[string]string) {

--- a/apps/platform/pkg/translate/translate.go
+++ b/apps/platform/pkg/translate/translate.go
@@ -1,6 +1,7 @@
 package translate
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/thecloudmasters/uesio/pkg/bundle"
@@ -9,7 +10,7 @@ import (
 	"github.com/thecloudmasters/uesio/pkg/sess"
 )
 
-func GetTranslatedLabels(session *sess.Session) (map[string]string, error) {
+func GetTranslatedLabels(ctx context.Context, session *sess.Session) (map[string]string, error) {
 
 	if session.HasLabels() {
 		return session.GetLabels(), nil
@@ -17,14 +18,14 @@ func GetTranslatedLabels(session *sess.Session) (map[string]string, error) {
 	userLanguage := session.GetContextUser().Language
 
 	var labels meta.LabelCollection
-	err := bundle.LoadAllFromAny(session.Context(), &labels, nil, session, nil)
+	err := bundle.LoadAllFromAny(ctx, &labels, nil, session, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load labels: %w", err)
 	}
 
 	var translations meta.TranslationCollection
 	if userLanguage != "" {
-		err = bundle.LoadAllFromAny(session.Context(), &translations, &bundlestore.GetAllItemsOptions{
+		err = bundle.LoadAllFromAny(ctx, &translations, &bundlestore.GetAllItemsOptions{
 			Conditions: meta.BundleConditions{
 				"uesio/studio.language": userLanguage,
 			},

--- a/apps/platform/pkg/truncate/truncate.go
+++ b/apps/platform/pkg/truncate/truncate.go
@@ -1,6 +1,7 @@
 package truncate
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/thecloudmasters/uesio/pkg/constant"
@@ -10,7 +11,7 @@ import (
 	"github.com/thecloudmasters/uesio/pkg/types/wire"
 )
 
-func TruncateWorkspaceData(tenantID string, session *sess.Session) error {
+func TruncateWorkspaceData(ctx context.Context, tenantID string, session *sess.Session) error {
 
 	if tenantID == "" {
 		return exceptions.NewInvalidParamException("required parameter not provided in session", "tenant id")
@@ -24,8 +25,8 @@ func TruncateWorkspaceData(tenantID string, session *sess.Session) error {
 		return exceptions.NewForbiddenException("you must be a studio workspace admin to truncate workspace data")
 	}
 
-	err := datasource.WithTransaction(session, nil, func(conn wire.Connection) error {
-		return conn.TruncateTenantData(session.Context(), tenantID)
+	err := datasource.WithTransaction(ctx, session, nil, func(conn wire.Connection) error {
+		return conn.TruncateTenantData(ctx, tenantID)
 	})
 	if err != nil {
 		return fmt.Errorf("unable to truncate workspace data: %w", err)

--- a/apps/platform/pkg/types/wire/integration.go
+++ b/apps/platform/pkg/types/wire/integration.go
@@ -1,8 +1,6 @@
 package wire
 
 import (
-	"context"
-
 	"github.com/thecloudmasters/uesio/pkg/meta"
 	"github.com/thecloudmasters/uesio/pkg/sess"
 )
@@ -29,10 +27,6 @@ type IntegrationConnection struct {
 	integrationType *meta.IntegrationType
 	credentials     *Credentials
 	platformConn    Connection
-}
-
-func (ic *IntegrationConnection) Context() context.Context {
-	return ic.session.Context()
 }
 
 func (ic *IntegrationConnection) GetSession() *sess.Session {

--- a/apps/platform/pkg/usage/usage.go
+++ b/apps/platform/pkg/usage/usage.go
@@ -1,6 +1,7 @@
 package usage
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -12,7 +13,7 @@ import (
 
 type UsageHandler interface {
 	Set(key string, size int64) error
-	ApplyBatch(session *sess.Session) error
+	ApplyBatch(ctx context.Context, session *sess.Session) error
 }
 
 var usageHandlerMap = map[string]UsageHandler{}
@@ -35,10 +36,12 @@ func init() {
 }
 
 func RegisterUsageHandler(name string, handler UsageHandler) {
+	// TODO: This needs to be synchronized!
 	usageHandlerMap[name] = handler
 }
 
 func getActiveHandler() UsageHandler {
+	// TODO: This needs to be synchronized!
 	return usageHandlerMap[activeHandler]
 }
 
@@ -61,6 +64,6 @@ func RegisterEvent(actiontype, metadatatype, metadataname string, size int64, se
 
 }
 
-func ApplyBatch(session *sess.Session) error {
-	return getActiveHandler().ApplyBatch(session)
+func ApplyBatch(ctx context.Context, session *sess.Session) error {
+	return getActiveHandler().ApplyBatch(ctx, session)
 }

--- a/apps/platform/pkg/usage/usage_common/usage_common.go
+++ b/apps/platform/pkg/usage/usage_common/usage_common.go
@@ -1,6 +1,7 @@
 package usage_common
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -11,7 +12,7 @@ import (
 	"github.com/thecloudmasters/uesio/pkg/types/wire"
 )
 
-func SaveBatch(usage meta.UsageCollection, session *sess.Session) error {
+func SaveBatch(ctx context.Context, usage meta.UsageCollection, session *sess.Session) error {
 
 	if len(usage) == 0 {
 		return nil
@@ -30,12 +31,12 @@ func SaveBatch(usage meta.UsageCollection, session *sess.Session) error {
 		},
 	}
 
-	err := datasource.SaveWithOptions(requests, session, nil)
+	err := datasource.SaveWithOptions(ctx, requests, session, nil)
 	if err != nil {
 		return fmt.Errorf("failed to update usage events: %w : %v", err, len(usage))
 	}
 
-	slog.InfoContext(session.Context(), fmt.Sprintf("successfully processed %d usage events", len(usage)))
+	slog.InfoContext(ctx, fmt.Sprintf("successfully processed %d usage events", len(usage)))
 	return nil
 
 }

--- a/apps/platform/pkg/usage/usage_memory/usage_memory.go
+++ b/apps/platform/pkg/usage/usage_memory/usage_memory.go
@@ -1,6 +1,7 @@
 package usage_memory
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -23,7 +24,7 @@ func init() {
 
 type MemoryUsageHandler struct{}
 
-func (pcuh *MemoryUsageHandler) ApplyBatch(session *sess.Session) error {
+func (pcuh *MemoryUsageHandler) ApplyBatch(ctx context.Context, session *sess.Session) error {
 
 	items := usageCache.GetAll()
 
@@ -37,7 +38,7 @@ func (pcuh *MemoryUsageHandler) ApplyBatch(session *sess.Session) error {
 		changes = append(changes, usageItem)
 	}
 
-	err := usage_common.SaveBatch(changes, session)
+	err := usage_common.SaveBatch(ctx, changes, session)
 	if err != nil {
 		return err
 	}

--- a/apps/platform/pkg/usage/usage_redis/usage_redis.go
+++ b/apps/platform/pkg/usage/usage_redis/usage_redis.go
@@ -1,6 +1,7 @@
 package usage_redis
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"strconv"
@@ -17,13 +18,13 @@ const KEYS_SET_NAME = "USAGE_KEYS"
 
 type RedisUsageHandler struct{}
 
-func (ruh *RedisUsageHandler) ApplyBatch(session *sess.Session) error {
+func (ruh *RedisUsageHandler) ApplyBatch(ctx context.Context, session *sess.Session) error {
 
 	conn := cache.GetRedisConn()
 	defer func(conn redis.Conn) {
 		err := conn.Close()
 		if err != nil {
-			slog.ErrorContext(session.Context(), err.Error())
+			slog.ErrorContext(ctx, err.Error())
 		}
 	}(conn)
 
@@ -36,7 +37,7 @@ func (ruh *RedisUsageHandler) ApplyBatch(session *sess.Session) error {
 	}
 
 	if len(keys) == 0 {
-		slog.InfoContext(session.Context(), "job completed, no usage events to process")
+		slog.InfoContext(ctx, "job completed, no usage events to process")
 		return nil
 	}
 
@@ -58,7 +59,7 @@ func (ruh *RedisUsageHandler) ApplyBatch(session *sess.Session) error {
 		changes = append(changes, usageItem)
 	}
 
-	err = usage_common.SaveBatch(changes, session)
+	err = usage_common.SaveBatch(ctx, changes, session)
 	if err != nil {
 		return err
 	}

--- a/apps/platform/pkg/usage/usage_worker/usage_worker.go
+++ b/apps/platform/pkg/usage/usage_worker/usage_worker.go
@@ -23,7 +23,7 @@ func UsageWorker(ctx context.Context) error {
 		return fmt.Errorf("unable to obtain a system session to use for usage events job: %w", err)
 	}
 
-	err = usage.ApplyBatch(session)
+	err = usage.ApplyBatch(ctx, session)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# What does this PR do?

Eliminates the `Context` property on `sess.Session` and adjusts function signatures to explicitly accept a `context.Context` as their first parameter throughout the entire codebase.

# What does this PR not do?

Solve all of the underlying issues in/around context (e.g., logging with context). There are still more PRs yet to come on improving context propagation, session propagation, logging, etc.

# Details

Over time, determing which `context.Context` to use within a particular section of the code has become incredibly difficult to discern.  In some cases, there may be a minimum of 4 choices of where to get context from depending on the needs of the code block in question. For example:

1. *http.Request->Context()
2. session->Context()
3. elevatedSession->Context()
4. connection->Context()

In theory, the underlying context returned from any of these "should" be the same, but in practice, this is NOT the case. For example, [platform bundle store file connection](https://github.com/ues-io/uesio/blob/main/apps/platform/pkg/bundlestore/platformbundlestore/platformbundlestore.go#L24) is a singleton and maintained a context property prior to #5091.  Calling [conn.Context()](https://github.com/ues-io/uesio/commit/46381d74c3a7c8b8cf1c854be3d6d935cc9c37e5#diff-31a3d3e69d6ed09ac7b2a4409cfbcc1caa6bb0ba0b237cf58bf7da1042e373f5L8-L11) would return a background context (file connections would get "their" context from from `session.Context()` for the session that was passed in to GetFileConnection but in the case of platform file connection, it was a [background](https://github.com/ues-io/uesio/compare/chore/eliminate-context-from-session?expand=1#diff-16971ea768419532d103234986b08d1264e7fb42c99162b2d6956d1b2af9bf3aL24) context.  Then, in some cases, file based operations would utilize their context (which may or may not be the same as the session context or even the request context) instead of using the current "request context."

Another challenge faced is when a session is elevated to an admin/anon/studio/etc. type of session.  In this case, sometimes the context from the original session (which should be the same as the request context) was passed through, but in other cases, a new [background](https://github.com/ues-io/uesio/compare/chore/eliminate-context-from-session?expand=1#diff-bd250eddb4e2d7d291ca898d89c19f83533ecae079fe4bcedd3c260cfa3f4ee5L27) context was created.

The net of all this is that the initial request context did not flow end-to-end which could lead to unexpected outcomes in terms of data consistency, etc.

This PR is the next step towards closing all these gaps and ensures that the original request context is always passed through the entire request lifecycle and there is no longer any confusion of where to get "context" from because there is only ever one place to get it.

More specifically:

1) If a function receives a `*http.Request` (e.g., a controller function), it should always use `r.Context()` and never have a function argument of `context.Context` to eliminate any ambiguity of where to get context from.
2) If a function requires a context, it should always have a `context.Context` as its first parameter and use it

There is one exception to this rule and that is for "bots".  Bots must maintain/track a context inside of their struct due to the way that `go` passes control over to `goja` and then `goja` calls back in to `go`. These are short lived instances of bot API structs and are always `hydrated` with the correct context just prior to running.

One additional benefit of eliminating context from our structs is that we are a step closer to being able to "pool" some of our more expensive structs - we can't do this yet because these structs still maintain a session inside of them but we are a step closer.

Bottom Line: Context now flows end-to-end in a request lifecycle and there is no more ambiguity of where to get context from (at least I hope there isn't 😄 ).

# Testing

ci & e2e will cover.
