### PR TITLE
chore: add context to log messages

### DIFF
--- a/apps/platform/main.go
+++ b/apps/platform/main.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"context"
 	"log/slog"
 	"mime"
 	"os"
 
+	"github.com/go-chi/traceid"
 	"github.com/thecloudmasters/uesio/pkg/bot"
 	"github.com/thecloudmasters/uesio/pkg/usage/usage_memory"
 	"github.com/thecloudmasters/uesio/pkg/usage/usage_redis"
@@ -92,8 +94,9 @@ func init() {
 }
 
 func main() {
-	if err := cmd.Execute(); err != nil {
-		slog.Error(err.Error())
+	ctx := traceid.NewContext(context.Background())
+	if err := cmd.Execute(ctx); err != nil {
+		slog.ErrorContext(ctx, err.Error())
 		os.Exit(1)
 	}
 	os.Exit(0)

--- a/apps/platform/pkg/adapt/postgresio/migrate.go
+++ b/apps/platform/pkg/adapt/postgresio/migrate.go
@@ -53,15 +53,15 @@ func getConnectionString(credentials *wire.Credentials) (string, error) {
 func (c *Connection) Migrate(ctx context.Context, options *migrations.MigrateOptions) error {
 	if options.Down {
 		if options.Number >= 1 {
-			slog.Info(fmt.Sprintf("Reverting %d previously-run migrations", options.Number))
+			slog.InfoContext(ctx, fmt.Sprintf("Reverting %d previously-run migrations", options.Number))
 		} else {
-			slog.Info("Reverting all previously-run migrations")
+			slog.InfoContext(ctx, "Reverting all previously-run migrations")
 		}
 	} else {
 		if options.Number >= 1 {
-			slog.Info(fmt.Sprintf("Running next %d migrations", options.Number))
+			slog.InfoContext(ctx, fmt.Sprintf("Running next %d migrations", options.Number))
 		} else {
-			slog.Info("Running migrations")
+			slog.InfoContext(ctx, "Running migrations")
 		}
 	}
 	migrationsDir := getMigrationsDirectory()

--- a/apps/platform/pkg/adapt/postgresio/subscribe.go
+++ b/apps/platform/pkg/adapt/postgresio/subscribe.go
@@ -7,7 +7,7 @@ import (
 
 // Subscribe establishes a subscription on a channel,
 // and will invoke a function whenever a message is received on the channel
-func (c *Connection) Subscribe(ctx context.Context, channelName string, handler func(payload string)) error {
+func (c *Connection) Subscribe(ctx context.Context, channelName string, handler func(ctx context.Context, payload string)) error {
 	conn, err := c.GetPGConn(ctx)
 	if err != nil {
 		return fmt.Errorf("unable to acquire PG connection for subscription: %s", err.Error())
@@ -24,6 +24,6 @@ func (c *Connection) Subscribe(ctx context.Context, channelName string, handler 
 		if waitErr != nil {
 			return waitErr
 		}
-		handler(notification.Payload)
+		handler(ctx, notification.Payload)
 	}
 }

--- a/apps/platform/pkg/adapt/postgresio/truncate.go
+++ b/apps/platform/pkg/adapt/postgresio/truncate.go
@@ -15,7 +15,7 @@ const (
 )
 
 func (c *Connection) TruncateTenantData(ctx context.Context, tenantID string) error {
-	slog.Info("Truncating all data from tenant: " + tenantID)
+	slog.InfoContext(ctx, "Truncating all data from tenant: "+tenantID)
 
 	batch := &pgx.Batch{}
 
@@ -25,7 +25,7 @@ func (c *Connection) TruncateTenantData(ctx context.Context, tenantID string) er
 	err := c.SendBatch(ctx, batch)
 	if err != nil {
 		msg := fmt.Sprintf("error truncating data from tenant '%s': %s", tenantID, err.Error())
-		slog.Error(msg)
+		slog.ErrorContext(ctx, msg)
 		return errors.New(msg)
 	}
 

--- a/apps/platform/pkg/auth/auth.go
+++ b/apps/platform/pkg/auth/auth.go
@@ -185,7 +185,7 @@ func GetSiteFromHost(ctx context.Context, host string) (*meta.Site, error) {
 func getSiteFromDomain(ctx context.Context, domainType, domainValue string) (*meta.Site, error) {
 
 	// Get Cache site info for the host
-	site, ok := getHostCache(domainType, domainValue)
+	site, ok := getHostCache(ctx, domainType, domainValue)
 	if ok {
 
 		return site, nil

--- a/apps/platform/pkg/auth/cache.go
+++ b/apps/platform/pkg/auth/cache.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -41,13 +42,13 @@ func setUserCache(userUniqueKey string, site *meta.Site, user *meta.User) error 
 	return userCache.Set(GetUserCacheKey(userUniqueKey, site), &clonedUser)
 }
 
-func getUserCache(userUniqueKey string, site *meta.Site) (*meta.User, bool) {
+func getUserCache(ctx context.Context, userUniqueKey string, site *meta.Site) (*meta.User, bool) {
 	user, err := userCache.Get(GetUserCacheKey(userUniqueKey, site))
 	if err != nil {
 		if errors.Is(err, cache.ErrKeyNotFound) {
 			return nil, false
 		} else {
-			slog.Error(fmt.Sprintf("error getting user for key [%s] from cache: %v", userUniqueKey, err))
+			slog.ErrorContext(ctx, fmt.Sprintf("error getting user for key [%s] from cache: %v", userUniqueKey, err))
 			return nil, false
 		}
 	}
@@ -61,13 +62,13 @@ func setHostCache(domainType, domainValue string, site *meta.Site) error {
 	return hostCache.Set(getHostKey(domainType, domainValue), site)
 }
 
-func getHostCache(domainType, domainValue string) (*meta.Site, bool) {
+func getHostCache(ctx context.Context, domainType, domainValue string) (*meta.Site, bool) {
 	site, err := hostCache.Get(getHostKey(domainType, domainValue))
 	if err != nil {
 		if errors.Is(err, cache.ErrKeyNotFound) {
 			return nil, false
 		} else {
-			slog.Error(fmt.Sprintf("error getting site for domain type [%s] and value [%s] from cache: %v", domainType, domainValue, err))
+			slog.ErrorContext(ctx, fmt.Sprintf("error getting site for domain type [%s] and value [%s] from cache: %v", domainType, domainValue, err))
 			return nil, false
 		}
 	}

--- a/apps/platform/pkg/auth/session.go
+++ b/apps/platform/pkg/auth/session.go
@@ -58,7 +58,7 @@ func HydrateUserPermissions(ctx context.Context, user *meta.User, session *sess.
 func GetCachedUserByID(ctx context.Context, userid string, site *meta.Site) (*meta.User, error) {
 
 	// Get Cache site info for the host
-	cachedUser, ok := getUserCache(userid, site)
+	cachedUser, ok := getUserCache(ctx, userid, site)
 	if ok {
 		return cachedUser, nil
 	}

--- a/apps/platform/pkg/bundle/cache.go
+++ b/apps/platform/pkg/bundle/cache.go
@@ -1,6 +1,7 @@
 package bundle
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -36,13 +37,13 @@ func NewBundleStoreCache(entryExpiration, cleanupFrequency time.Duration) *Bundl
 	}
 }
 
-func (bsc *BundleStoreCache) GetFileListFromCache(basePath string) ([]file.Metadata, bool) {
+func (bsc *BundleStoreCache) GetFileListFromCache(ctx context.Context, basePath string) ([]file.Metadata, bool) {
 	files, err := bsc.fileListCache.Get(basePath)
 	if err != nil {
 		if errors.Is(err, cache.ErrKeyNotFound) {
 			return nil, false
 		} else {
-			slog.Error(fmt.Sprintf("error getting file list for path [%s] from cache: %v", basePath, err))
+			slog.ErrorContext(ctx, fmt.Sprintf("error getting file list for path [%s] from cache: %v", basePath, err))
 			return nil, false
 		}
 	}
@@ -61,14 +62,14 @@ func (bsc *BundleStoreCache) getBundleDefCacheKey(namespace, version string) str
 	return fmt.Sprintf("%s|%s", namespace, version)
 }
 
-func (bsc *BundleStoreCache) GetItemFromCache(namespace, version, bundleGroupName, key string) (meta.BundleableItem, bool) {
+func (bsc *BundleStoreCache) GetItemFromCache(ctx context.Context, namespace, version, bundleGroupName, key string) (meta.BundleableItem, bool) {
 	cacheKey := bsc.getItemCacheKey(namespace, version, bundleGroupName, key)
 	entry, err := bsc.bundleEntryCache.Get(cacheKey)
 	if err != nil {
 		if errors.Is(err, cache.ErrKeyNotFound) {
 			return nil, false
 		} else {
-			slog.Error(fmt.Sprintf("error getting bundle entry for key [%s] from cache: %v", cacheKey, err))
+			slog.ErrorContext(ctx, fmt.Sprintf("error getting bundle entry for key [%s] from cache: %v", cacheKey, err))
 			return nil, false
 		}
 	}
@@ -83,14 +84,14 @@ func (bsc *BundleStoreCache) InvalidateCacheItem(namespace, version, groupName, 
 	return bsc.bundleEntryCache.Del(bsc.getItemCacheKey(namespace, version, groupName, itemKey))
 }
 
-func (bsc *BundleStoreCache) GetBundleDefFromCache(namespace, version string) (*meta.BundleDef, bool) {
+func (bsc *BundleStoreCache) GetBundleDefFromCache(ctx context.Context, namespace, version string) (*meta.BundleDef, bool) {
 	cacheKey := bsc.getBundleDefCacheKey(namespace, version)
 	entry, err := bsc.bundleDefCache.Get(cacheKey)
 	if err != nil {
 		if errors.Is(err, cache.ErrKeyNotFound) {
 			return nil, false
 		} else {
-			slog.Error(fmt.Sprintf("error getting bundle def for key [%s] from cache: %v", cacheKey, err))
+			slog.ErrorContext(ctx, fmt.Sprintf("error getting bundle def for key [%s] from cache: %v", cacheKey, err))
 			return nil, false
 		}
 	}

--- a/apps/platform/pkg/bundlestore/filebundlestore/filebundlestore.go
+++ b/apps/platform/pkg/bundlestore/filebundlestore/filebundlestore.go
@@ -33,7 +33,7 @@ type FileBundleStoreConnection struct {
 
 func (b *FileBundleStoreConnection) getFilePathsAtBasePath(ctx context.Context, basePath string) ([]file.Metadata, error) {
 	if b.Cache != nil {
-		cachedKeys, ok := b.Cache.GetFileListFromCache(basePath)
+		cachedKeys, ok := b.Cache.GetFileListFromCache(ctx, basePath)
 		if ok {
 			return cachedKeys, nil
 		}
@@ -90,7 +90,7 @@ func (b *FileBundleStoreConnection) GetItem(ctx context.Context, item meta.Bundl
 	}
 
 	if b.Cache != nil {
-		if cachedItem, ok := b.Cache.GetItemFromCache(b.Namespace, b.Version, fullCollectionName, key); ok {
+		if cachedItem, ok := b.Cache.GetItemFromCache(ctx, b.Namespace, b.Version, fullCollectionName, key); ok {
 			if !b.AllowPrivate && !cachedItem.IsPublic() {
 				message := fmt.Sprintf("metadata item: %s is not public", key)
 				return exceptions.NewForbiddenException(message)
@@ -293,7 +293,7 @@ func (b *FileBundleStoreConnection) DeleteBundle(ctx context.Context) error {
 func (b *FileBundleStoreConnection) GetBundleDef(ctx context.Context) (*meta.BundleDef, error) {
 
 	if b.Cache != nil {
-		if cachedItem, ok := b.Cache.GetBundleDefFromCache(b.Namespace, b.Version); ok {
+		if cachedItem, ok := b.Cache.GetBundleDefFromCache(ctx, b.Namespace, b.Version); ok {
 			return cachedItem, nil
 		}
 	}

--- a/apps/platform/pkg/bundlestore/workspacebundlestore/workspacebundlecacheutils.go
+++ b/apps/platform/pkg/bundlestore/workspacebundlestore/workspacebundlecacheutils.go
@@ -49,12 +49,12 @@ func setupPlatformSubscription(ctx context.Context) {
 	s := getMinimumViableSession()
 	conn, err := datasource.GetPlatformConnection(ctx, s, nil)
 	if err != nil {
-		slog.Error("unable to establish platform connection! " + err.Error())
+		slog.ErrorContext(ctx, "unable to establish platform connection! "+err.Error())
 		panic("unable to establish platform connection!")
 	}
 
 	if err = conn.Subscribe(ctx, WorkspaceMetadataChangesChannel, handleWorkspaceMetadataChange); err != nil {
-		slog.Error("unable to subscribe on channel! " + err.Error())
+		slog.ErrorContext(ctx, "unable to subscribe on channel! "+err.Error())
 		panic("unable to subscribe on channel!")
 	}
 }
@@ -90,15 +90,15 @@ func getMinimumViableSession() *sess.Session {
 	return s
 }
 
-func handleWorkspaceMetadataChange(payload string) {
+func handleWorkspaceMetadataChange(ctx context.Context, payload string) {
 	var wmc WorkspaceMetadataChange
 	unmarshalErr := json.Unmarshal([]byte(payload), &wmc)
 	if unmarshalErr != nil {
-		slog.Error("unable to unmarshal workspace metadata change payload: " + unmarshalErr.Error())
+		slog.ErrorContext(ctx, "unable to unmarshal workspace metadata change payload: "+unmarshalErr.Error())
 	} else {
 		for _, itemKey := range wmc.ChangedItems {
 			if err := bundleStoreCache.InvalidateCacheItem(wmc.AppName, wmc.WorkspaceID, wmc.CollectionName, itemKey); err != nil {
-				slog.Error("unable to purge workspace metadata cache key: " + err.Error())
+				slog.ErrorContext(ctx, "unable to purge workspace metadata cache key: "+err.Error())
 			}
 		}
 	}

--- a/apps/platform/pkg/bundlestore/workspacebundlestore/workspacebundlestore.go
+++ b/apps/platform/pkg/bundlestore/workspacebundlestore/workspacebundlestore.go
@@ -153,7 +153,7 @@ func (b *WorkspaceBundleStoreConnection) GetItem(ctx context.Context, item meta.
 
 	// First check the cache
 	if bundleStoreCache != nil {
-		if cachedItem, ok := bundleStoreCache.GetItemFromCache(b.Namespace, b.getWorkspaceCacheKey(), collectionName, itemUniqueKey); ok {
+		if cachedItem, ok := bundleStoreCache.GetItemFromCache(ctx, b.Namespace, b.getWorkspaceCacheKey(), collectionName, itemUniqueKey); ok {
 			return meta.Copy(item, cachedItem)
 		}
 	}

--- a/apps/platform/pkg/cmd/migrate.go
+++ b/apps/platform/pkg/cmd/migrate.go
@@ -7,7 +7,6 @@ import (
 	"log/slog"
 	"strconv"
 
-	"github.com/go-chi/traceid"
 	"github.com/spf13/cobra"
 
 	"github.com/thecloudmasters/uesio/pkg/datasource"
@@ -25,7 +24,7 @@ func init() {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// by default run all 'up' migrations
 			opts := newMigrateUpOptions()
-			return migrate(&opts)
+			return migrate(cmd.Context(), &opts)
 		},
 	}
 
@@ -49,7 +48,7 @@ func init() {
 				}
 				opts.Number = num
 			}
-			return migrate(&opts)
+			return migrate(cmd.Context(), &opts)
 		},
 	}
 	downCmd.Flags().Bool("all", false, "Apply all down migrations")
@@ -68,7 +67,7 @@ func init() {
 				}
 				opts.Number = num
 			}
-			return migrate(&opts)
+			return migrate(cmd.Context(), &opts)
 		},
 	}
 	migrateCmd.AddCommand(upCmd)
@@ -90,8 +89,7 @@ func newMigrateDownOptions() migrations.MigrateOptions {
 	}
 }
 
-func migrate(opts *migrations.MigrateOptions) error {
-	ctx := traceid.NewContext(context.Background())
+func migrate(ctx context.Context, opts *migrations.MigrateOptions) error {
 	slog.InfoContext(ctx, "Running migration(s)")
 
 	anonSession := sess.GetStudioAnonSession()

--- a/apps/platform/pkg/cmd/root.go
+++ b/apps/platform/pkg/cmd/root.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"context"
+
 	"github.com/spf13/cobra"
 )
 
@@ -12,6 +14,6 @@ var rootCmd = &cobra.Command{
 }
 
 // Execute is used as entrypoint to the cobra commands
-func Execute() error {
-	return rootCmd.Execute()
+func Execute(ctx context.Context) error {
+	return rootCmd.ExecuteContext(ctx)
 }

--- a/apps/platform/pkg/cmd/seed.go
+++ b/apps/platform/pkg/cmd/seed.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/go-chi/traceid"
 	"github.com/spf13/cobra"
 
 	"github.com/thecloudmasters/uesio/pkg/auth"
@@ -146,7 +145,7 @@ func runSeeds(ctx context.Context, connection wire.Connection) error {
 }
 
 func seed(cmd *cobra.Command, args []string) error {
-	ctx := traceid.NewContext(context.Background())
+	ctx := cmd.Context()
 	slog.InfoContext(ctx, "Running seeds")
 
 	ignoreSeedFailures, _ := cmd.Flags().GetBool("ignore-failures")

--- a/apps/platform/pkg/cmd/worker.go
+++ b/apps/platform/pkg/cmd/worker.go
@@ -18,8 +18,9 @@ func init() {
 	})
 }
 
-func runJobs(*cobra.Command, []string) error {
-	slog.Info("Running Uesio worker process")
-	worker.ScheduleJobs()
+func runJobs(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+	slog.InfoContext(ctx, "Running Uesio worker process")
+	worker.ScheduleJobs(ctx)
 	return nil
 }

--- a/apps/platform/pkg/controller/file/serve_file.go
+++ b/apps/platform/pkg/controller/file/serve_file.go
@@ -84,8 +84,8 @@ func ServeFileContent(file *meta.File, path string, supportsCaching bool, w http
 	}
 	defer rs.Close()
 
-	usage.RegisterEvent("DOWNLOAD", "FILESOURCE", filesource.PLATFORM_FILE_SOURCE, 0, session)
-	usage.RegisterEvent("DOWNLOAD_BYTES", "FILESOURCE", filesource.PLATFORM_FILE_SOURCE, fileMetadata.ContentLength(), session)
+	usage.RegisterEvent(r.Context(), "DOWNLOAD", "FILESOURCE", filesource.PLATFORM_FILE_SOURCE, 0, session)
+	usage.RegisterEvent(r.Context(), "DOWNLOAD_BYTES", "FILESOURCE", filesource.PLATFORM_FILE_SOURCE, fileMetadata.ContentLength(), session)
 
 	if supportsCaching {
 		middleware.Set1YearCache(w)

--- a/apps/platform/pkg/controller/route.go
+++ b/apps/platform/pkg/controller/route.go
@@ -167,7 +167,7 @@ func handleRedirectAPIRoute(w http.ResponseWriter, r *http.Request, route *meta.
 }
 
 func getRouteAPIResult(ctx context.Context, route *meta.Route, session *sess.Session) (*preload.RouteMergeData, error) {
-	usage.RegisterEvent("LOAD", "ROUTE", route.GetKey(), 0, session)
+	usage.RegisterEvent(ctx, "LOAD", "ROUTE", route.GetKey(), 0, session)
 	depsCache, err := routing.GetMetadataDeps(ctx, route, session)
 	if err != nil {
 		return nil, err
@@ -346,7 +346,7 @@ func fetchRoute(w http.ResponseWriter, r *http.Request, session *sess.Session, n
 }
 
 func ServeRouteInternal(w http.ResponseWriter, r *http.Request, session *sess.Session, path string, route *meta.Route) {
-	usage.RegisterEvent("LOAD", "ROUTE", route.GetKey(), 0, session)
+	usage.RegisterEvent(r.Context(), "LOAD", "ROUTE", route.GetKey(), 0, session)
 	var err error
 	switch route.Type {
 	case "redirect":

--- a/apps/platform/pkg/datasource/licensing.go
+++ b/apps/platform/pkg/datasource/licensing.go
@@ -33,13 +33,13 @@ func setLicenseCache(namespace string, licenses LicenseMap) error {
 	return licenseCache.Set(namespace, licenses)
 }
 
-func getLicenseCache(namespace string) (LicenseMap, bool) {
+func getLicenseCache(ctx context.Context, namespace string) (LicenseMap, bool) {
 	licenses, err := licenseCache.Get(namespace)
 	if err != nil {
 		if errors.Is(err, cache.ErrKeyNotFound) {
 			return nil, false
 		} else {
-			slog.Error(fmt.Sprintf("error getting licenses for namespace [%s] from cache: %v", namespace, err))
+			slog.ErrorContext(ctx, fmt.Sprintf("error getting licenses for namespace [%s] from cache: %v", namespace, err))
 			return nil, false
 		}
 	}
@@ -57,7 +57,7 @@ func GetLicenses(ctx context.Context, namespace string, connection wire.Connecti
 			},
 		}, nil
 	}
-	licenseMap, ok := getLicenseCache(namespace)
+	licenseMap, ok := getLicenseCache(ctx, namespace)
 	if ok {
 		return licenseMap, nil
 	}

--- a/apps/platform/pkg/datasource/load.go
+++ b/apps/platform/pkg/datasource/load.go
@@ -180,8 +180,8 @@ func queryOp(ctx context.Context, op *wire.LoadOp, ops []*wire.LoadOp, metadata 
 
 	integrationName := collectionMetadata.GetIntegrationName()
 
-	usage.RegisterEvent("LOAD", "COLLECTION", collectionKey, 0, session)
-	usage.RegisterEvent("LOAD", "DATASOURCE", integrationName, 0, session)
+	usage.RegisterEvent(ctx, "LOAD", "COLLECTION", collectionKey, 0, session)
+	usage.RegisterEvent(ctx, "LOAD", "DATASOURCE", integrationName, 0, session)
 
 	// Mutate the conditions immediately before handing off to the load implementations
 	op.Conditions = activeConditions

--- a/apps/platform/pkg/datasource/save.go
+++ b/apps/platform/pkg/datasource/save.go
@@ -241,8 +241,8 @@ func SaveOp(ctx context.Context, op *wire.SaveOp, connection wire.Connection, se
 		}
 	}
 
-	usage.RegisterEvent("SAVE", "COLLECTION", collectionKey, 0, session)
-	usage.RegisterEvent("SAVE", "DATASOURCE", integrationName, 0, session)
+	usage.RegisterEvent(ctx, "SAVE", "COLLECTION", collectionKey, 0, session)
+	usage.RegisterEvent(ctx, "SAVE", "DATASOURCE", integrationName, 0, session)
 
 	if !isExternalIntegrationSave {
 		err = GenerateRecordChallengeTokens(ctx, op, connection, session)

--- a/apps/platform/pkg/filesource/download.go
+++ b/apps/platform/pkg/filesource/download.go
@@ -109,8 +109,8 @@ func DownloadItem(ctx context.Context, userFile *meta.UserFileMetadata, session 
 		return nil, nil, err
 	}
 
-	usage.RegisterEvent("DOWNLOAD", "FILESOURCE", userFile.FileSourceID, 0, session)
-	usage.RegisterEvent("DOWNLOAD_BYTES", "FILESOURCE", userFile.FileSourceID, userFile.ContentLength(), session)
+	usage.RegisterEvent(ctx, "DOWNLOAD", "FILESOURCE", userFile.FileSourceID, 0, session)
+	usage.RegisterEvent(ctx, "DOWNLOAD_BYTES", "FILESOURCE", userFile.FileSourceID, userFile.ContentLength(), session)
 
 	return r, userFile, nil
 }

--- a/apps/platform/pkg/filesource/upload.go
+++ b/apps/platform/pkg/filesource/upload.go
@@ -161,8 +161,8 @@ func Upload(ctx context.Context, ops []*FileUploadOp, connection wire.Connection
 				}
 				written := writtenResults[i]
 				ufur.Meta.FileContentLength = written
-				usage.RegisterEvent("UPLOAD", "FILESOURCE", ufur.Meta.FileSourceID, 0, session)
-				usage.RegisterEvent("UPLOAD_BYTES", "FILESOURCE", ufur.Meta.FileSourceID, written, session)
+				usage.RegisterEvent(ctx, "UPLOAD", "FILESOURCE", ufur.Meta.FileSourceID, 0, session)
+				usage.RegisterEvent(ctx, "UPLOAD_BYTES", "FILESOURCE", ufur.Meta.FileSourceID, written, session)
 			}
 
 			return nil

--- a/apps/platform/pkg/integ/bedrock/claude.go
+++ b/apps/platform/pkg/integ/bedrock/claude.go
@@ -88,11 +88,11 @@ func (cmh *ClaudeModelHandler) Hydrate(ic *wire.IntegrationConnection, params ma
 	return nil
 }
 
-func (cmh *ClaudeModelHandler) RecordUsage(inputTokens, outputTokens int64) {
+func (cmh *ClaudeModelHandler) RecordUsage(ctx context.Context, inputTokens, outputTokens int64) {
 	integrationKey := cmh.ic.GetIntegration().GetKey()
 	session := cmh.ic.GetSession()
-	usage.RegisterEvent("INPUT_TOKENS", "INTEGRATION", integrationKey, inputTokens, session)
-	usage.RegisterEvent("OUTPUT_TOKENS", "INTEGRATION", integrationKey, outputTokens, session)
+	usage.RegisterEvent(ctx, "INPUT_TOKENS", "INTEGRATION", integrationKey, inputTokens, session)
+	usage.RegisterEvent(ctx, "OUTPUT_TOKENS", "INTEGRATION", integrationKey, outputTokens, session)
 }
 
 func (cmh *ClaudeModelHandler) Invoke(ctx context.Context) (result any, err error) {
@@ -110,7 +110,7 @@ func (cmh *ClaudeModelHandler) Invoke(ctx context.Context) (result any, err erro
 		return nil, handleBedrockError(err)
 	}
 
-	cmh.RecordUsage(message.Usage.InputTokens, message.Usage.OutputTokens)
+	cmh.RecordUsage(ctx, message.Usage.InputTokens, message.Usage.OutputTokens)
 
 	return cmh.GetInvokeResult(message)
 
@@ -145,7 +145,7 @@ func (cmh *ClaudeModelHandler) Stream(ctx context.Context) (*integ.Stream, error
 					outputStream.Err() <- err
 					return
 				}
-				cmh.RecordUsage(metrics.InputTokens, metrics.OutputTokens)
+				cmh.RecordUsage(ctx, metrics.InputTokens, metrics.OutputTokens)
 			}
 		}
 		err := stream.Err()

--- a/apps/platform/pkg/integ/bedrock/stability.go
+++ b/apps/platform/pkg/integ/bedrock/stability.go
@@ -58,10 +58,10 @@ func (smh *StabilityModelHandler) Hydrate(ic *wire.IntegrationConnection, params
 	return nil
 }
 
-func (smh *StabilityModelHandler) RecordUsage() {
+func (smh *StabilityModelHandler) RecordUsage(ctx context.Context) {
 	integrationKey := smh.ic.GetIntegration().GetKey()
 	session := smh.ic.GetSession()
-	usage.RegisterEvent("IMAGE_GENERATION", "INTEGRATION", integrationKey, 0, session)
+	usage.RegisterEvent(ctx, "IMAGE_GENERATION", "INTEGRATION", integrationKey, 0, session)
 }
 
 func (smh *StabilityModelHandler) Invoke(ctx context.Context) (result any, err error) {
@@ -91,7 +91,7 @@ func (smh *StabilityModelHandler) Invoke(ctx context.Context) (result any, err e
 		return nil, err
 	}
 
-	smh.RecordUsage()
+	smh.RecordUsage(ctx)
 
 	return smh.GetInvokeResult(output.Body)
 

--- a/apps/platform/pkg/integ/openai/openai.go
+++ b/apps/platform/pkg/integ/openai/openai.go
@@ -88,8 +88,8 @@ func (c *connection) autoCompleteDefault(ctx context.Context, options *AutoCompl
 		return nil, err
 	}
 
-	usage.RegisterEvent("INPUT_TOKENS", "INTEGRATION", c.integration.GetKey(), int64(resp.Usage.PromptTokens), c.session)
-	usage.RegisterEvent("OUTPUT_TOKENS", "INTEGRATION", c.integration.GetKey(), int64(resp.Usage.CompletionTokens), c.session)
+	usage.RegisterEvent(ctx, "INPUT_TOKENS", "INTEGRATION", c.integration.GetKey(), int64(resp.Usage.PromptTokens), c.session)
+	usage.RegisterEvent(ctx, "OUTPUT_TOKENS", "INTEGRATION", c.integration.GetKey(), int64(resp.Usage.CompletionTokens), c.session)
 
 	outputs := []string{}
 
@@ -121,8 +121,8 @@ func (c *connection) autoCompleteChat(ctx context.Context, options *AutoComplete
 		return nil, err
 	}
 
-	usage.RegisterEvent("INPUT_TOKENS", "INTEGRATION", c.integration.GetKey(), int64(resp.Usage.PromptTokens), c.session)
-	usage.RegisterEvent("OUTPUT_TOKENS", "INTEGRATION", c.integration.GetKey(), int64(resp.Usage.CompletionTokens), c.session)
+	usage.RegisterEvent(ctx, "INPUT_TOKENS", "INTEGRATION", c.integration.GetKey(), int64(resp.Usage.PromptTokens), c.session)
+	usage.RegisterEvent(ctx, "OUTPUT_TOKENS", "INTEGRATION", c.integration.GetKey(), int64(resp.Usage.CompletionTokens), c.session)
 
 	var outputs []string
 

--- a/apps/platform/pkg/middleware/gzip.go
+++ b/apps/platform/pkg/middleware/gzip.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"context"
 	"log/slog"
 	"net/http"
 
@@ -16,11 +17,11 @@ var gzipContentTypesAllowList = []string{
 	"image/vnd.microsoft.icon",
 }
 
-func GZip() func(http.Handler) http.Handler {
+func GZip(ctx context.Context) func(http.Handler) http.Handler {
 	// apply gzip encoding for specific content types. Don't bother with PNG/JPEG/WOFF which are already compressed
 	gzipWrapper, err := gziphandler.GzipHandlerWithOpts(gziphandler.ContentTypes(gzipContentTypesAllowList))
 	if err != nil {
-		slog.Error(err.Error())
+		slog.ErrorContext(ctx, err.Error())
 		return nil
 	}
 	return gzipWrapper

--- a/apps/platform/pkg/middleware/logging.go
+++ b/apps/platform/pkg/middleware/logging.go
@@ -57,13 +57,13 @@ func RequestLogger(logger *slog.Logger, logFormat *httplog.Schema) func(next htt
 				// other logging options (e.g., Skip).
 				if ld := getLogData(ctx); ld != nil {
 					if s := ld.GetSession(); s != nil {
-						usage.RegisterEvent("REQUEST_COUNT", "REQUEST", "ALL", 1, s)
+						usage.RegisterEvent(r.Context(), "REQUEST_COUNT", "REQUEST", "ALL", 1, s)
 						ingressBytes := computeApproximateRequestSize(r, br)
 						if ingressBytes > 0 {
-							usage.RegisterEvent("INGRESS_BYTES", "DATA_TRANSFER", "ALL", ingressBytes, s)
+							usage.RegisterEvent(r.Context(), "INGRESS_BYTES", "DATA_TRANSFER", "ALL", ingressBytes, s)
 						}
 						if ww.BytesWritten() > 0 {
-							usage.RegisterEvent("EGRESS_BYTES", "DATA_TRANSFER", "ALL", int64(ww.BytesWritten()), s)
+							usage.RegisterEvent(r.Context(), "EGRESS_BYTES", "DATA_TRANSFER", "ALL", int64(ww.BytesWritten()), s)
 						}
 					}
 				}

--- a/apps/platform/pkg/preload/mergetypes.go
+++ b/apps/platform/pkg/preload/mergetypes.go
@@ -92,6 +92,9 @@ func (md MergeData) String() string {
 	serialized, err := json.MarshalIndent(md, "        ", "  ")
 	//json, err := json.Marshal(md)
 	if err != nil {
+		// Intentionally not using ErrorContext since we have no way to obtain one
+		// TODO: Consider a panic here - returning "" for something that is expected to be marshalled likely
+		// isn't the best option
 		slog.Error(err.Error())
 		return ""
 	}

--- a/apps/platform/pkg/types/wire/connection.go
+++ b/apps/platform/pkg/types/wire/connection.go
@@ -20,5 +20,5 @@ type Connection interface {
 	CommitTransaction(context.Context) error
 	RollbackTransaction(context.Context) error
 	Publish(ctx context.Context, channelName, payload string) error
-	Subscribe(ctx context.Context, channelName string, handler func(payload string)) error
+	Subscribe(ctx context.Context, channelName string, handler func(ctx context.Context, payload string)) error
 }

--- a/apps/platform/pkg/usage/usage.go
+++ b/apps/platform/pkg/usage/usage.go
@@ -12,7 +12,7 @@ import (
 )
 
 type UsageHandler interface {
-	Set(key string, size int64) error
+	Set(ctx context.Context, key string, size int64) error
 	ApplyBatch(ctx context.Context, session *sess.Session) error
 }
 
@@ -45,7 +45,7 @@ func getActiveHandler() UsageHandler {
 	return usageHandlerMap[activeHandler]
 }
 
-func RegisterEvent(actiontype, metadatatype, metadataname string, size int64, session *sess.Session) error {
+func RegisterEvent(ctx context.Context, actiontype, metadatatype, metadataname string, size int64, session *sess.Session) error {
 
 	user := session.GetSiteUser()
 
@@ -60,7 +60,7 @@ func RegisterEvent(actiontype, metadatatype, metadataname string, size int64, se
 	currentTime := time.Now()
 	key := fmt.Sprintf("event:%s:%s:%s:%s:%s:%s", session.GetSiteTenantID(), user.ID, currentTime.Format("2006-01-02"), actiontype, metadatatype, metadataname)
 
-	return getActiveHandler().Set(key, size)
+	return getActiveHandler().Set(ctx, key, size)
 
 }
 

--- a/apps/platform/pkg/usage/usage_common/usage_common.go
+++ b/apps/platform/pkg/usage/usage_common/usage_common.go
@@ -41,14 +41,14 @@ func SaveBatch(ctx context.Context, usage meta.UsageCollection, session *sess.Se
 
 }
 
-func GetUsageItem(key string, value int64) *meta.Usage {
+func GetUsageItem(ctx context.Context, key string, value int64) *meta.Usage {
 	// Make sure the value was actually there
 	if key == "nil" {
 		return nil
 	}
 	keyParts := strings.Split(key, ":")
 	if len(keyParts) != 9 {
-		slog.Error("usage key did not match expected pattern: " + key)
+		slog.ErrorContext(ctx, "usage key did not match expected pattern: "+key)
 		return nil
 	}
 

--- a/apps/platform/pkg/usage/usage_memory/usage_memory.go
+++ b/apps/platform/pkg/usage/usage_memory/usage_memory.go
@@ -31,7 +31,7 @@ func (pcuh *MemoryUsageHandler) ApplyBatch(ctx context.Context, session *sess.Se
 	changes := meta.UsageCollection{}
 
 	for key, value := range items {
-		usageItem := usage_common.GetUsageItem(key, value)
+		usageItem := usage_common.GetUsageItem(ctx, key, value)
 		if usageItem == nil {
 			continue
 		}
@@ -51,11 +51,11 @@ func (pcuh *MemoryUsageHandler) ApplyBatch(ctx context.Context, session *sess.Se
 
 }
 
-func (pcuh *MemoryUsageHandler) Set(key string, size int64) error {
+func (pcuh *MemoryUsageHandler) Set(ctx context.Context, key string, size int64) error {
 	value, err := usageCache.Get(key)
 	if err != nil {
 		if !errors.Is(err, cache.ErrKeyNotFound) {
-			slog.Error(fmt.Sprintf("error getting usage for key [%s] from cache: %v", key, err))
+			slog.ErrorContext(ctx, fmt.Sprintf("error getting usage for key [%s] from cache: %v", key, err))
 		}
 		value = 0
 	}

--- a/apps/platform/pkg/usage/usage_redis/usage_redis.go
+++ b/apps/platform/pkg/usage/usage_redis/usage_redis.go
@@ -52,7 +52,7 @@ func (ruh *RedisUsageHandler) ApplyBatch(ctx context.Context, session *sess.Sess
 
 	for i, key := range keys {
 		total, _ := strconv.ParseInt(values[i], 10, 64)
-		usageItem := usage_common.GetUsageItem(key, total)
+		usageItem := usage_common.GetUsageItem(ctx, key, total)
 		if usageItem == nil {
 			continue
 		}
@@ -75,7 +75,7 @@ func (ruh *RedisUsageHandler) ApplyBatch(ctx context.Context, session *sess.Sess
 	return nil
 }
 
-func (ruh *RedisUsageHandler) Set(key string, size int64) error {
+func (ruh *RedisUsageHandler) Set(ctx context.Context, key string, size int64) error {
 	go setRedisUsage(key, size)
 	return nil
 }


### PR DESCRIPTION
# What does this PR do?

1. Adds `Context` to log messages - all `slog` calls now use the `XXXContext` variant with the exception of two (2) calls to `slog.Error` where it would not have been possible to obtain a context to apply without some significant refactoring.  So we're not 100% but we're pretty close now 😄 
2. Refactors platform `cmd` package to create a context with traceid in `main()` and flow that context to commands so that start to finish on a cmd, we have a single traceid - http requests, background jobs, etc. will have their own traceid.

# What this PR does not do?

Address some of the ways in which we "ignore" errors, log a message and return a value instead of a typed error so that higher level functions can evaluate how to handle. We make some assumptions in certain places in the code that shouldn't be made at the lowest of levels. This results in having to pass "Context" much farther down in the call stack then normally necessary.  Future PRs will improve around this and then context can stay at the higher levels and not passed to helper functions.

# Testing

Tested manually and confirmed traceid is logged with every log message.
