### PR TITLE
chore: use current context instead of context.Background

### DIFF
--- a/apps/platform/pkg/auth/auth.go
+++ b/apps/platform/pkg/auth/auth.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/crewjam/saml"
 	"github.com/crewjam/saml/samlsp"
-	"github.com/go-chi/traceid"
 	"github.com/thecloudmasters/uesio/pkg/bundle"
 	"github.com/thecloudmasters/uesio/pkg/configstore"
 	"github.com/thecloudmasters/uesio/pkg/constant/commonfields"
@@ -73,7 +72,7 @@ func GetAuthConnection(ctx context.Context, authSourceID string, connection wire
 		return nil, err
 	}
 
-	credentials, err := datasource.GetCredentials(context.Background(), authSource.Credentials, versionSession)
+	credentials, err := datasource.GetCredentials(ctx, authSource.Credentials, versionSession)
 	if err != nil {
 		return nil, err
 	}
@@ -164,7 +163,7 @@ func GetSiteFromHost(ctx context.Context, host string) (*meta.Site, error) {
 	site.Subdomain = subdomain
 	site.Scheme = tls.ServeAppDefaultScheme()
 
-	bundleDef, err := bundle.GetSiteBundleDef(traceid.NewContext(context.Background()), site, nil)
+	bundleDef, err := bundle.GetSiteBundleDef(ctx, site, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/apps/platform/pkg/auth/google/googleauth.go
+++ b/apps/platform/pkg/auth/google/googleauth.go
@@ -53,7 +53,7 @@ func (c *Connection) callListenerBot(ctx context.Context, botKey string, payload
 		return err
 	}
 
-	_, err = datasource.CallListenerBot(context.Background(), namespace, name, payload, c.connection, c.session)
+	_, err = datasource.CallListenerBot(ctx, namespace, name, payload, c.connection, c.session)
 	if err != nil {
 		return err
 	}

--- a/apps/platform/pkg/auth/platform/platform.go
+++ b/apps/platform/pkg/auth/platform/platform.go
@@ -101,7 +101,7 @@ func (c *Connection) callListenerBot(ctx context.Context, botKey, code string, p
 		return err
 	}
 
-	_, err = datasource.CallListenerBot(context.Background(), namespace, name, payload, c.connection, c.session)
+	_, err = datasource.CallListenerBot(ctx, namespace, name, payload, c.connection, c.session)
 	if err != nil {
 		return err
 	}

--- a/apps/platform/pkg/controller/bundlesretrieve.go
+++ b/apps/platform/pkg/controller/bundlesretrieve.go
@@ -42,7 +42,7 @@ func BundlesRetrieve(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/zip")
 	file.SetContentDispositionHeader(w, "attachment", version+".zip")
 	middleware.Set1YearCache(w)
-	ctlutil.AddTrailingStatus(w)
+	ctlutil.AddTrailingStatusContext(r.Context(), w)
 
 	err = source.GetBundleZip(r.Context(), w, nil)
 	if err != nil {

--- a/apps/platform/pkg/controller/ctlutil/errors.go
+++ b/apps/platform/pkg/controller/ctlutil/errors.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 
 	"github.com/go-chi/httplog/v3"
-	"github.com/go-chi/traceid"
 	httputil "github.com/thecloudmasters/uesio/pkg/http"
 )
 
@@ -54,10 +53,6 @@ func HandleTrailingError(ctx context.Context, w http.ResponseWriter, err error) 
 	// a middleware HandleError utility (or similar) that can update context with error and
 	// write out the error.
 	httputil.HandleTrailingError(ctx, w, err)
-}
-
-func AddTrailingStatus(w http.ResponseWriter) {
-	AddTrailingStatusContext(traceid.NewContext(context.Background()), w)
 }
 
 func AddTrailingStatusContext(ctx context.Context, w http.ResponseWriter) {

--- a/apps/platform/pkg/controller/retrieve.go
+++ b/apps/platform/pkg/controller/retrieve.go
@@ -31,7 +31,7 @@ func Retrieve(w http.ResponseWriter, r *http.Request) {
 	fileName := strings.ReplaceAll(fmt.Sprintf("uesio_retrieve_%s_%s_%s.zip", appName, versionName, time.Now().Format(time.RFC3339)), ":", "_")
 	w.Header().Set("Content-Type", "application/zip")
 	file.SetContentDispositionHeader(w, "attachment", fileName)
-	ctlutil.AddTrailingStatus(w)
+	ctlutil.AddTrailingStatusContext(r.Context(), w)
 
 	if err := bs.GetBundleZip(r.Context(), w, &bundlestore.BundleZipOptions{
 		// Only include generated types if we're in a workspace context


### PR DESCRIPTION
# What does this PR do?

Replace use of `context.Background` with the `current context` when its available.  The only things really remaining that use `context.Background` are:

1. Singletons
2. Tests
3. Scheduled jobs

# Testing

ci & e2e will cover.
