### PR TITLE
feat: add file d/l button to files

### DIFF
--- a/apps/platform/pkg/controller/file/serve_file.go
+++ b/apps/platform/pkg/controller/file/serve_file.go
@@ -26,6 +26,14 @@ var unsafeChars = initUnsafeChars()
 const separatorStr = string(filepath.Separator)
 
 func respondFile(w http.ResponseWriter, r *http.Request, path string, modified time.Time, stream io.ReadSeeker) {
+	respondFileInternal(w, r, path, "inline", modified, stream)
+}
+
+func responseFileAttachment(w http.ResponseWriter, r *http.Request, path string, modified time.Time, stream io.ReadSeeker) {
+	respondFileInternal(w, r, path, "attachment", modified, stream)
+}
+
+func respondFileInternal(w http.ResponseWriter, r *http.Request, path string, disposition string, modified time.Time, stream io.ReadSeeker) {
 	if stream == nil {
 		resp := make(map[string]string)
 		resp["message"] = "Resource Not Found"
@@ -54,7 +62,10 @@ func respondFile(w http.ResponseWriter, r *http.Request, path string, modified t
 		// that we have non-user types of files that go through this path as well. In short,
 		// being explicit here to correct the invalid header value but more thought is needed
 		// on this.
-		SetContentDispositionHeader(w, "inline", path)
+		if disposition == "" {
+			disposition = "inline"
+		}
+		SetContentDispositionHeader(w, disposition, path)
 	}
 
 	http.ServeContent(w, r, filename, modified, stream)

--- a/apps/platform/pkg/controller/file/userfile.go
+++ b/apps/platform/pkg/controller/file/userfile.go
@@ -90,6 +90,7 @@ func DownloadUserFile(w http.ResponseWriter, r *http.Request) {
 	query := r.URL.Query()
 	userFileID := query.Get("userfileid")
 	version := query.Get("version")
+	attachment := query.Get("attachment")
 	if userFileID == "" {
 		ctlutil.HandleError(r.Context(), w, exceptions.NewBadRequestException("missing required query parameter: userfileid", nil))
 		return
@@ -107,7 +108,11 @@ func DownloadUserFile(w http.ResponseWriter, r *http.Request) {
 		middleware.SetNoCache(w)
 	}
 
-	respondFile(w, r, userFile.Path(), userFile.LastModified(), rs)
+	if attachment == "true" {
+		responseFileAttachment(w, r, userFile.Path(), userFile.LastModified(), rs)
+	} else {
+		respondFile(w, r, userFile.Path(), userFile.LastModified(), rs)
+	}
 }
 
 func DownloadAttachment(w http.ResponseWriter, r *http.Request) {

--- a/libs/apps/uesio/appkit/bundle/components/tile_file.yaml
+++ b/libs/apps/uesio/appkit/bundle/components/tile_file.yaml
@@ -23,6 +23,18 @@ definition:
                   components:
                     - uesio/io.button:
                         uesio.variant: uesio/appkit.itemaction
+                        icon: file_download
+                        tooltip: Download
+                        signals:
+                          - signal: route/REDIRECT
+                            # NOTE: attachment should be a parameter to $UserFile{} but we currently only
+                            # support single parameters to merge expressions.
+                            # TODO: Add support for multiple parameters to merge expressions and then update
+                            # $UserFile to take parameter, ideally an options object for future flexibility
+                            # to control attachment vs. inline.
+                            path: $UserFile{}&attachment=true
+                    - uesio/io.button:
+                        uesio.variant: uesio/appkit.itemaction
                         icon: delete
                         tooltip: Delete
                         signals:

--- a/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/field/field.tsx
+++ b/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/field/field.tsx
@@ -298,7 +298,7 @@ const Field: definition.UtilityComponent<FieldProps> = (props) => {
       content = <TimestampField {...common} />
       break
     case "FILE":
-      content = <FileField {...common} displayAs={displayAs} />
+      content = <FileField {...common} displayAs={displayAs} attachment={true} />
       break
     case "USER":
       content = <UserField {...common} options={user} refoptions={reference} />

--- a/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/field/file.tsx
+++ b/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/field/file.tsx
@@ -11,6 +11,7 @@ interface FileUtilityProps {
   mode?: context.FieldMode
   record: wire.WireRecord
   displayAs?: string
+  attachment?: boolean
 }
 
 const StyleDefaults = Object.freeze({
@@ -26,7 +27,7 @@ const StyleDefaults = Object.freeze({
 })
 
 const FileField: definition.UtilityComponent<FileUtilityProps> = (props) => {
-  const { displayAs, context, mode, id, value, record, fieldId, variant } =
+  const { displayAs, context, mode, id, value, record, fieldId, variant, attachment } =
     props
 
   const classes = styles.useUtilityStyleTokens(StyleDefaults, props)
@@ -59,6 +60,7 @@ const FileField: definition.UtilityComponent<FileUtilityProps> = (props) => {
       recordId={recordId}
       collectionId={collectionId}
       fieldId={fieldId}
+      attachment={attachment}
     />
   )
 }

--- a/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/userfile/userfile.tsx
+++ b/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/userfile/userfile.tsx
@@ -19,6 +19,7 @@ interface UserFileUtilityProps {
   onChange?: (value: string) => void
   accept?: string
   textOptions?: TextOptions
+  attachment?: boolean
 }
 
 const UserFile: definition.UtilityComponent<UserFileUtilityProps> = (props) => {
@@ -34,6 +35,7 @@ const UserFile: definition.UtilityComponent<UserFileUtilityProps> = (props) => {
     displayAs,
     textOptions,
     variant,
+    attachment,
   } = props
 
   const userFileId = userFile?.[collection.ID_FIELD]
@@ -73,7 +75,7 @@ const UserFile: definition.UtilityComponent<UserFileUtilityProps> = (props) => {
   }
 
   const fileModDate = userFile?.[collection.UPDATED_AT_FIELD]
-  const fileUrl = api.file.getUserFileURL(context, userFileId, fileModDate)
+  const fileUrl = api.file.getUserFileURL(context, userFileId, fileModDate, attachment)
 
   const fileInfo: FileInfo | undefined =
     userFile && fileUrl

--- a/libs/ui/src/hooks/fileapi.ts
+++ b/libs/ui/src/hooks/fileapi.ts
@@ -20,9 +20,10 @@ const getUserFileURL = (
   context: Context,
   userfileid: string | undefined,
   fileVersion?: string,
+  attachment?: boolean,
 ) => {
   if (!userfileid) return ""
-  return platform.getUserFileURL(context, userfileid, fileVersion)
+  return platform.getUserFileURL(context, userfileid, fileVersion, attachment)
 }
 
 const getAttachmentURL = (

--- a/libs/ui/src/platform/platform.ts
+++ b/libs/ui/src/platform/platform.ts
@@ -429,6 +429,7 @@ const platform = {
     context: Context,
     userfileid: string,
     fileVersion?: string,
+    attachment?: boolean,
   ) => {
     const prefix = getPrefix(context)
     const fileVersionParam = fileVersion
@@ -436,7 +437,7 @@ const platform = {
       : ""
     return `${prefix}/userfiles/download?userfileid=${encodeURIComponent(
       userfileid,
-    )}${fileVersionParam}`
+    )}${fileVersionParam}${attachment ? "&attachment=true" : ""}`
   },
   getAttachmentURL: (
     context: Context,


### PR DESCRIPTION
# What does this PR do?

In some recent PRs (e.g., #4989), the UI was significantly improved related to displaying files/attachments/file fields. In that process, the "download file" button was lost in certain situations.

1. Adds a "download file" button to `tile_file`
2. Changes the behavior of "downloading a file" on `file fields` and `tile_file` to use content-disposition of attachment

# Testing

Manually confirmed downloads as attachment vs. inline.

Closed #4895 
