### PR TITLE
fix: ensure record is updated when file changes in file field

### DIFF
--- a/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/field/file.tsx
+++ b/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/field/file.tsx
@@ -28,8 +28,17 @@ const StyleDefaults = Object.freeze({
 })
 
 const FileField: definition.UtilityComponent<FileUtilityProps> = (props) => {
-  const { displayAs, context, mode, id, value, record, fieldId, variant, setValue } =
-    props
+  const {
+    displayAs,
+    context,
+    mode,
+    id,
+    value,
+    record,
+    fieldId,
+    variant,
+    setValue,
+  } = props
 
   const classes = styles.useUtilityStyleTokens(StyleDefaults, props)
 

--- a/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/field/file.tsx
+++ b/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/field/file.tsx
@@ -1,6 +1,7 @@
 import { definition, context, wire, styles } from "@uesio/ui"
 import { UserFileMetadata } from "../../components/field/field"
 import UserFile from "../userfile/userfile"
+import { FieldValueSetter } from "../../components/field/field"
 
 interface FileUtilityProps {
   path: string
@@ -11,6 +12,7 @@ interface FileUtilityProps {
   mode?: context.FieldMode
   record: wire.WireRecord
   displayAs?: string
+  setValue: FieldValueSetter
 }
 
 const StyleDefaults = Object.freeze({
@@ -26,7 +28,7 @@ const StyleDefaults = Object.freeze({
 })
 
 const FileField: definition.UtilityComponent<FileUtilityProps> = (props) => {
-  const { displayAs, context, mode, id, value, record, fieldId, variant } =
+  const { displayAs, context, mode, id, value, record, fieldId, variant, setValue } =
     props
 
   const classes = styles.useUtilityStyleTokens(StyleDefaults, props)
@@ -49,10 +51,10 @@ const FileField: definition.UtilityComponent<FileUtilityProps> = (props) => {
       userFile={userFile}
       context={context}
       onUpload={async (response) => {
-        record.set(fieldId, response)
+        setValue(response)
       }}
       onDelete={async () => {
-        record.set(fieldId, "")
+        setValue(null)
       }}
       mode={mode}
       variant={variant}


### PR DESCRIPTION
# What does this PR do?

Ensures that the record for a "file" field is correctly updated when the file is changed (deleted or changed).

Previously, the record value was updated but the change wasn't fully tracked resulting in "changes" being empty.

Historically, "files" used to use wire functionality, however when the change was made for them to use wire functionality, this code wasn't updated to update the wire.

# Testing

Tested manually and confirmed that the wire is updated as expected and changes reflect the corresponding change that was made.

ci & e2e will cover rest.
