### PR TITLE
chore: ensure mode & readonly are honored on file fields

### DIFF
--- a/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/field/file.tsx
+++ b/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/field/file.tsx
@@ -13,6 +13,7 @@ interface FileUtilityProps {
   record: wire.WireRecord
   displayAs?: string
   setValue: FieldValueSetter
+  readonly?: boolean  
 }
 
 const StyleDefaults = Object.freeze({
@@ -38,6 +39,7 @@ const FileField: definition.UtilityComponent<FileUtilityProps> = (props) => {
     fieldId,
     variant,
     setValue,
+    readonly,
   } = props
 
   const classes = styles.useUtilityStyleTokens(StyleDefaults, props)
@@ -70,6 +72,7 @@ const FileField: definition.UtilityComponent<FileUtilityProps> = (props) => {
       recordId={recordId}
       collectionId={collectionId}
       fieldId={fieldId}
+      readonly={readonly}
     />
   )
 }

--- a/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/file/file.tsx
+++ b/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/file/file.tsx
@@ -26,6 +26,7 @@ interface FileUtilityProps {
   onPreview?: () => void
   onDownload?: () => void
   accept?: string
+  readonly?: boolean
 }
 
 const StyleDefaults = Object.freeze({
@@ -50,6 +51,7 @@ const File: definition.UtilityComponent<FileUtilityProps> = (props) => {
     onDownload,
     accept,
     mode,
+    readonly,
   } = props
 
   const classes = styles.useUtilityStyleTokens(
@@ -59,7 +61,7 @@ const File: definition.UtilityComponent<FileUtilityProps> = (props) => {
   )
 
   const uploadLabelId = nanoid()
-
+  const isEditMode = !readonly && mode === "EDIT"
   const fileInputRef = useRef<HTMLInputElement>(null)
 
   const menuItems: MenuItem[] = [
@@ -91,7 +93,7 @@ const File: definition.UtilityComponent<FileUtilityProps> = (props) => {
 
   return (
     <>
-      {mode === "EDIT" && (
+      {isEditMode && (
         <UploadArea
           onUpload={fileInfo?.isAttachment ? undefined : onUpload}
           context={context}

--- a/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/fileimage/fileimage.tsx
+++ b/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/fileimage/fileimage.tsx
@@ -12,6 +12,7 @@ interface FileImageProps {
   onUpload: (files: FileList | null) => void
   onDelete?: () => void
   accept?: string
+  readonly?: boolean
 }
 
 interface EditButtonsProps {
@@ -74,14 +75,30 @@ const EditButtons: definition.UtilityComponent<EditButtonsProps> = (props) => {
 }
 
 const FileImage: definition.UtilityComponent<FileImageProps> = (props) => {
-  const { context, mode, fileInfo, accept, onUpload, onDelete } = props
+  const { context, mode, fileInfo, accept, onUpload, onDelete, readonly } = props
 
   const classes = styles.useUtilityStyleTokens(StyleDefaults, props)
 
   const uploadLabelId = nanoid()
   const deleteLabelId = nanoid()
+  const isEditMode = !readonly && mode === "EDIT"
 
-  return (
+  const Image = () => (
+      fileInfo ? (
+        // eslint-disable-next-line jsx-a11y/alt-text -- TODO See https://github.com/ues-io/uesio/issues/4489
+        <img className={classes.image} src={fileInfo.url} />
+      ) : (
+        <div className={classes.nofile}>
+          <Icon
+            className={classes.nofileicon}
+            context={context}
+            icon="person"
+          />
+        </div>
+      )
+  )
+
+  return isEditMode ? (
     <UploadArea
       onUpload={onUpload}
       onDelete={onDelete}
@@ -99,19 +116,12 @@ const FileImage: definition.UtilityComponent<FileImageProps> = (props) => {
         uploadLabelId={uploadLabelId}
         deleteLabelId={deleteLabelId}
       />
-      {fileInfo ? (
-        // eslint-disable-next-line jsx-a11y/alt-text -- TODO See https://github.com/ues-io/uesio/issues/4489
-        <img className={classes.image} src={fileInfo.url} />
-      ) : (
-        <div className={classes.nofile}>
-          <Icon
-            className={classes.nofileicon}
-            context={context}
-            icon="person"
-          />
-        </div>
-      )}
+      <Image />
     </UploadArea>
+  ) : (
+    <div className={classes.root}>
+      <Image />
+    </div>
   )
 }
 

--- a/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/filepreview/filepreview.tsx
+++ b/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/filepreview/filepreview.tsx
@@ -12,6 +12,7 @@ interface FilePreviewProps {
   onPreview?: () => void
   onDownload?: () => void
   accept?: string
+  readonly?: boolean
 }
 
 const FilePreview: definition.UtilityComponent<FilePreviewProps> = (props) => {

--- a/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/filetext/filetext.tsx
+++ b/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/filetext/filetext.tsx
@@ -19,23 +19,32 @@ interface FileTextProps {
   displayAs?: string
   textOptions?: TextOptions
   onChange?: (value: string) => void
+  readonly?: boolean
 }
 
 const FileText: definition.UtilityComponent<FileTextProps> = (props) => {
-  const { context, userFile, textOptions, mode, displayAs, onChange } = props
+  const {
+    context,
+    userFile,
+    textOptions,
+    mode,
+    displayAs,
+    onChange,
+    readonly,
+  } = props
 
   const language = displayAs === "MARKDOWN" ? "markdown" : textOptions?.language
   const typeDefinitionFileURIs = textOptions?.typeDefinitionFileURIs
   const theme = textOptions?.theme
-
+  const isEditMode = !readonly && mode === "EDIT" && onChange
   const content = api.file.useUserFile(context, userFile)
 
-  if (displayAs === "MARKDOWN" && mode !== "EDIT") {
+  if (displayAs === "MARKDOWN") {
     return (
       <MarkDownField
         context={context}
         value={content}
-        mode={mode}
+        mode={isEditMode ? mode : "READ"}
         setValue={onChange}
         variant={props.variant}
         theme={theme}
@@ -47,7 +56,7 @@ const FileText: definition.UtilityComponent<FileTextProps> = (props) => {
     <CodeField
       context={context}
       value={content || ""}
-      mode={mode}
+      mode={isEditMode ? mode : "READ"}
       language={language}
       setValue={onChange}
       typeDefinitionFileURIs={typeDefinitionFileURIs}

--- a/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/filevideo/filevideo.tsx
+++ b/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/filevideo/filevideo.tsx
@@ -14,6 +14,7 @@ interface FileVideoProps {
   accept?: string
   muted?: boolean
   autoplay?: boolean
+  readonly?: boolean
 }
 
 const FileVideo: definition.UtilityComponent<FileVideoProps> = (props) => {
@@ -26,6 +27,7 @@ const FileVideo: definition.UtilityComponent<FileVideoProps> = (props) => {
     onUpload,
     onDelete,
     accept,
+    readonly,
   } = props
 
   const fileUrl = fileInfo?.url
@@ -34,8 +36,22 @@ const FileVideo: definition.UtilityComponent<FileVideoProps> = (props) => {
 
   const uploadLabelId = nanoid()
   const deleteLabelId = nanoid()
+  const isEditMode = !readonly && mode === "EDIT"  
 
-  return (
+  const Video = () => (
+      fileInfo ? (
+        <video autoPlay={autoplay || true} muted={muted || true}>
+          <source src={fileUrl} />
+          Your browser does not support the video tag.
+        </video>
+      ) : (
+        <div className={classes.nofile}>
+          <Icon className={classes.nofileicon} context={context} icon="movie" />
+        </div>
+      )
+  )
+
+  return isEditMode ? (
     <UploadArea
       onUpload={onUpload}
       onDelete={onDelete}
@@ -53,17 +69,12 @@ const FileVideo: definition.UtilityComponent<FileVideoProps> = (props) => {
         uploadLabelId={uploadLabelId}
         deleteLabelId={deleteLabelId}
       />
-      {fileInfo ? (
-        <video autoPlay={autoplay || true} muted={muted || true}>
-          <source src={fileUrl} />
-          Your browser does not support the video tag.
-        </video>
-      ) : (
-        <div className={classes.nofile}>
-          <Icon className={classes.nofileicon} context={context} icon="movie" />
-        </div>
-      )}
+      <Video />
     </UploadArea>
+  ) : (
+    <div className={classes.root}>
+      <Video />
+    </div>
   )
 }
 

--- a/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/userfile/userfile.tsx
+++ b/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/userfile/userfile.tsx
@@ -19,6 +19,7 @@ interface UserFileUtilityProps {
   onChange?: (value: string) => void
   accept?: string
   textOptions?: TextOptions
+  readonly?: boolean
 }
 
 const UserFile: definition.UtilityComponent<UserFileUtilityProps> = (props) => {
@@ -34,6 +35,7 @@ const UserFile: definition.UtilityComponent<UserFileUtilityProps> = (props) => {
     displayAs,
     textOptions,
     variant,
+    readonly,
   } = props
 
   const userFileId = userFile?.[collection.ID_FIELD]
@@ -122,6 +124,7 @@ const UserFile: definition.UtilityComponent<UserFileUtilityProps> = (props) => {
     accept,
     displayAs,
     variant,
+    readonly,
   }
 
   switch (displayAs) {


### PR DESCRIPTION
# What does this PR do?

None of the "file field" components were honoring "readonly" and several did not correctly honor "field mode".  For example, FileImage & FileVideo would not display the "hover" buttons for "delete" and "edit/change", but they were inside of an UploadArea so the user could still drop a different file resulting in a change when the field was either read-only or mode !== "EDIT".

Additionally, when a file was text/markdown and FileText was used, the `onChange` handler is not passed so even when it should be in "EDIT" mode, the data was not saved.  

This PR:

1. Ensures all file related components correctly honor read-only and "mode".
2. Ensures an onChange handler is provided to FileText, otherwise applies "READ" mode - A subsequent PR will address ensuring that onChange is passed
3. If displayAs is "MARKDOWN", always use MarkdownField component - the prior code would only use it when mode was READ but the MarkdownField component handles mode and displays accordingly.

More PRs are coming to address #2 and other related issues with file fields.

# Testing

Manually tested all scenarios and confirmed.
