### PR TITLE
chore: avoid file image & video component re-renders

### DIFF
--- a/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/fileimage/fileimage.tsx
+++ b/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/fileimage/fileimage.tsx
@@ -74,7 +74,15 @@ const EditButtons: definition.UtilityComponent<EditButtonsProps> = (props) => {
   )
 }
 
-const Image = ({ fileInfo, classes, context }: {fileInfo?: FileImageProps["fileInfo"], classes: Record<string, string>, context: definition.UtilityProps["context"]}) => (
+const Image = ({
+  fileInfo,
+  classes,
+  context,
+}: {
+  fileInfo?: FileImageProps["fileInfo"]
+  classes: Record<string, string>
+  context: definition.UtilityProps["context"]
+}) =>
   fileInfo ? (
     // eslint-disable-next-line jsx-a11y/alt-text -- TODO See https://github.com/ues-io/uesio/issues/4489
     <img className={classes.image} src={fileInfo.url} />
@@ -83,7 +91,6 @@ const Image = ({ fileInfo, classes, context }: {fileInfo?: FileImageProps["fileI
       <Icon className={classes.nofileicon} context={context} icon="person" />
     </div>
   )
-)
 
 const FileImage: definition.UtilityComponent<FileImageProps> = (props) => {
   const { context, mode, fileInfo, accept, onUpload, onDelete, readonly } =

--- a/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/fileimage/fileimage.tsx
+++ b/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/fileimage/fileimage.tsx
@@ -74,6 +74,17 @@ const EditButtons: definition.UtilityComponent<EditButtonsProps> = (props) => {
   )
 }
 
+const Image = ({ fileInfo, classes, context }: {fileInfo?: FileImageProps["fileInfo"], classes: Record<string, string>, context: definition.UtilityProps["context"]}) => (
+  fileInfo ? (
+    // eslint-disable-next-line jsx-a11y/alt-text -- TODO See https://github.com/ues-io/uesio/issues/4489
+    <img className={classes.image} src={fileInfo.url} />
+  ) : (
+    <div className={classes.nofile}>
+      <Icon className={classes.nofileicon} context={context} icon="person" />
+    </div>
+  )
+)
+
 const FileImage: definition.UtilityComponent<FileImageProps> = (props) => {
   const { context, mode, fileInfo, accept, onUpload, onDelete, readonly } =
     props
@@ -83,16 +94,6 @@ const FileImage: definition.UtilityComponent<FileImageProps> = (props) => {
   const uploadLabelId = nanoid()
   const deleteLabelId = nanoid()
   const isEditMode = !readonly && mode === "EDIT"
-
-  const Image = () =>
-    fileInfo ? (
-      // eslint-disable-next-line jsx-a11y/alt-text -- TODO See https://github.com/ues-io/uesio/issues/4489
-      <img className={classes.image} src={fileInfo.url} />
-    ) : (
-      <div className={classes.nofile}>
-        <Icon className={classes.nofileicon} context={context} icon="person" />
-      </div>
-    )
 
   return isEditMode ? (
     <UploadArea
@@ -112,11 +113,11 @@ const FileImage: definition.UtilityComponent<FileImageProps> = (props) => {
         uploadLabelId={uploadLabelId}
         deleteLabelId={deleteLabelId}
       />
-      <Image />
+      <Image fileInfo={fileInfo} classes={classes} context={context} />
     </UploadArea>
   ) : (
     <div className={classes.root}>
-      <Image />
+      <Image fileInfo={fileInfo} classes={classes} context={context} />
     </div>
   )
 }

--- a/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/filevideo/filevideo.tsx
+++ b/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/filevideo/filevideo.tsx
@@ -17,6 +17,26 @@ interface FileVideoProps {
   readonly?: boolean
 }
 
+const Video = ({ fileInfo, classes, context, autoplay, muted, fileUrl }: {
+  fileInfo?: FileVideoProps["fileInfo"], 
+  classes: Record<string, string>, 
+  context: definition.UtilityProps["context"],
+  autoplay?: FileVideoProps["autoplay"],
+  muted?: FileVideoProps["muted"],
+  fileUrl?: string
+}) => (
+  fileInfo ? (
+    <video autoPlay={autoplay || true} muted={muted || true}>
+      <source src={fileUrl} />
+      Your browser does not support the video tag.
+    </video>
+  ) : (
+    <div className={classes.nofile}>
+      <Icon className={classes.nofileicon} context={context} icon="movie" />
+    </div>
+  )
+)
+
 const FileVideo: definition.UtilityComponent<FileVideoProps> = (props) => {
   const {
     mode,
@@ -38,18 +58,6 @@ const FileVideo: definition.UtilityComponent<FileVideoProps> = (props) => {
   const deleteLabelId = nanoid()
   const isEditMode = !readonly && mode === "EDIT"
 
-  const Video = () =>
-    fileInfo ? (
-      <video autoPlay={autoplay || true} muted={muted || true}>
-        <source src={fileUrl} />
-        Your browser does not support the video tag.
-      </video>
-    ) : (
-      <div className={classes.nofile}>
-        <Icon className={classes.nofileicon} context={context} icon="movie" />
-      </div>
-    )
-
   return isEditMode ? (
     <UploadArea
       onUpload={onUpload}
@@ -68,11 +76,11 @@ const FileVideo: definition.UtilityComponent<FileVideoProps> = (props) => {
         uploadLabelId={uploadLabelId}
         deleteLabelId={deleteLabelId}
       />
-      <Video />
+      <Video fileInfo={fileInfo} classes={classes} context={context} autoplay={autoplay} muted={muted} fileUrl={fileUrl} />
     </UploadArea>
   ) : (
     <div className={classes.root}>
-      <Video />
+      <Video fileInfo={fileInfo} classes={classes} context={context} autoplay={autoplay} muted={muted} fileUrl={fileUrl} />
     </div>
   )
 }

--- a/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/filevideo/filevideo.tsx
+++ b/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/filevideo/filevideo.tsx
@@ -17,14 +17,21 @@ interface FileVideoProps {
   readonly?: boolean
 }
 
-const Video = ({ fileInfo, classes, context, autoplay, muted, fileUrl }: {
-  fileInfo?: FileVideoProps["fileInfo"], 
-  classes: Record<string, string>, 
-  context: definition.UtilityProps["context"],
-  autoplay?: FileVideoProps["autoplay"],
-  muted?: FileVideoProps["muted"],
+const Video = ({
+  fileInfo,
+  classes,
+  context,
+  autoplay,
+  muted,
+  fileUrl,
+}: {
+  fileInfo?: FileVideoProps["fileInfo"]
+  classes: Record<string, string>
+  context: definition.UtilityProps["context"]
+  autoplay?: FileVideoProps["autoplay"]
+  muted?: FileVideoProps["muted"]
   fileUrl?: string
-}) => (
+}) =>
   fileInfo ? (
     <video autoPlay={autoplay || true} muted={muted || true}>
       <source src={fileUrl} />
@@ -35,7 +42,6 @@ const Video = ({ fileInfo, classes, context, autoplay, muted, fileUrl }: {
       <Icon className={classes.nofileicon} context={context} icon="movie" />
     </div>
   )
-)
 
 const FileVideo: definition.UtilityComponent<FileVideoProps> = (props) => {
   const {
@@ -76,11 +82,25 @@ const FileVideo: definition.UtilityComponent<FileVideoProps> = (props) => {
         uploadLabelId={uploadLabelId}
         deleteLabelId={deleteLabelId}
       />
-      <Video fileInfo={fileInfo} classes={classes} context={context} autoplay={autoplay} muted={muted} fileUrl={fileUrl} />
+      <Video
+        fileInfo={fileInfo}
+        classes={classes}
+        context={context}
+        autoplay={autoplay}
+        muted={muted}
+        fileUrl={fileUrl}
+      />
     </UploadArea>
   ) : (
     <div className={classes.root}>
-      <Video fileInfo={fileInfo} classes={classes} context={context} autoplay={autoplay} muted={muted} fileUrl={fileUrl} />
+      <Video
+        fileInfo={fileInfo}
+        classes={classes}
+        context={context}
+        autoplay={autoplay}
+        muted={muted}
+        fileUrl={fileUrl}
+      />
     </div>
   )
 }


### PR DESCRIPTION
# What does this PR do?

Fixes a regression introduced in #5100 that resulted in unnecessary FileImage & FileVideo component re-renders.

# Testing

Manually confirmed no unnecessary re-renders.
