### PR TITLE
chore: improve file action icon and file preview display

### DIFF
--- a/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/fileimage/fileimage.tsx
+++ b/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/fileimage/fileimage.tsx
@@ -23,7 +23,7 @@ interface EditButtonsProps {
 }
 
 const StyleDefaults = Object.freeze({
-  root: ["relative", "group"],
+  root: ["group", "grid", "[grid-template-areas:'overlay']", "w-[fit-content]"],
   actionicon: [
     "group-hover:block",
     "cursor-pointer",
@@ -31,14 +31,16 @@ const StyleDefaults = Object.freeze({
     "text-white",
     "backdrop-brightness-75",
     "hidden",
-    "absolute",
     "top-0",
     "m-2",
     "leading-none",
+    "[grid-area:overlay]",
+    "[align-self:start]",
   ],
-  image: ["w-full"],
-  editicon: ["right-0"],
-  deleteicon: ["left-0"],
+  contentcontainer: ["[grid-area:overlay]"],
+  image: ["max-w-full", "h-auto"],
+  editicon: ["[justify-self:end]"],
+  deleteicon: ["[justify-self:start]"],
   nofile: ["flex", "bg-slate-100", "justify-center"],
   nofileicon: ["text-4xl", "p-8", "text-slate-400"],
 })
@@ -82,15 +84,18 @@ const Image = ({
   fileInfo?: FileImageProps["fileInfo"]
   classes: Record<string, string>
   context: definition.UtilityProps["context"]
-}) =>
-  fileInfo ? (
-    // eslint-disable-next-line jsx-a11y/alt-text -- TODO See https://github.com/ues-io/uesio/issues/4489
-    <img className={classes.image} src={fileInfo.url} />
-  ) : (
-    <div className={classes.nofile}>
-      <Icon className={classes.nofileicon} context={context} icon="person" />
-    </div>
-  )
+}) => (
+  <div className={classes.contentcontainer}>
+    {fileInfo ? (
+      // eslint-disable-next-line jsx-a11y/alt-text -- TODO See https://github.com/ues-io/uesio/issues/4489
+      <img className={classes.image} src={fileInfo.url} />
+    ) : (
+      <div className={classes.nofile}>
+        <Icon className={classes.nofileicon} context={context} icon="person" />
+      </div>
+    )}
+  </div>
+)
 
 const FileImage: definition.UtilityComponent<FileImageProps> = (props) => {
   const { context, mode, fileInfo, accept, onUpload, onDelete, readonly } =
@@ -112,6 +117,7 @@ const FileImage: definition.UtilityComponent<FileImageProps> = (props) => {
       uploadLabelId={uploadLabelId}
       deleteLabelId={deleteLabelId}
     >
+      <Image fileInfo={fileInfo} classes={classes} context={context} />
       <EditButtons
         context={context}
         mode={mode}
@@ -120,7 +126,6 @@ const FileImage: definition.UtilityComponent<FileImageProps> = (props) => {
         uploadLabelId={uploadLabelId}
         deleteLabelId={deleteLabelId}
       />
-      <Image fileInfo={fileInfo} classes={classes} context={context} />
     </UploadArea>
   ) : (
     <div className={classes.root}>

--- a/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/filevideo/filevideo.tsx
+++ b/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/filevideo/filevideo.tsx
@@ -31,17 +31,24 @@ const Video = ({
   autoplay?: FileVideoProps["autoplay"]
   muted?: FileVideoProps["muted"]
   fileUrl?: string
-}) =>
-  fileInfo ? (
-    <video autoPlay={autoplay || true} muted={muted || true}>
-      <source src={fileUrl} />
-      Your browser does not support the video tag.
-    </video>
-  ) : (
-    <div className={classes.nofile}>
-      <Icon className={classes.nofileicon} context={context} icon="movie" />
-    </div>
-  )
+}) => (
+  <div className={classes.contentcontainer}>
+    {fileInfo ? (
+      <video
+        className={classes.image}
+        autoPlay={autoplay || true}
+        muted={muted || true}
+      >
+        <source src={fileUrl} />
+        Your browser does not support the video tag.
+      </video>
+    ) : (
+      <div className={classes.nofile}>
+        <Icon className={classes.nofileicon} context={context} icon="movie" />
+      </div>
+    )}
+  </div>
+)
 
 const FileVideo: definition.UtilityComponent<FileVideoProps> = (props) => {
   const {
@@ -74,14 +81,6 @@ const FileVideo: definition.UtilityComponent<FileVideoProps> = (props) => {
       uploadLabelId={uploadLabelId}
       deleteLabelId={deleteLabelId}
     >
-      <EditButtons
-        context={context}
-        mode={mode}
-        fileInfo={fileInfo}
-        classes={classes}
-        uploadLabelId={uploadLabelId}
-        deleteLabelId={deleteLabelId}
-      />
       <Video
         fileInfo={fileInfo}
         classes={classes}
@@ -89,6 +88,14 @@ const FileVideo: definition.UtilityComponent<FileVideoProps> = (props) => {
         autoplay={autoplay}
         muted={muted}
         fileUrl={fileUrl}
+      />
+      <EditButtons
+        context={context}
+        mode={mode}
+        fileInfo={fileInfo}
+        classes={classes}
+        uploadLabelId={uploadLabelId}
+        deleteLabelId={deleteLabelId}
       />
     </UploadArea>
   ) : (


### PR DESCRIPTION
# What does this PR do?

1. Fixes the display of "images" for file fields when using "Image" or "Preview" `displayAs` that was causing the image to take up 100% of available space even when the image itself was not that wide. This caused images narrower than the available width to "stretch" resulting in distored images.  Videos did not apply `width: 100%` but images did.
2. Fixes the display of the "delete" and "edit" action icons for file fields when `displayAs` is IMAGE/VIDEO/PREVIEW on Videos (and Images per item 1 above) to ensure that the icons are contained within the displayed image/video and not at 100% of the parent container width. For example, if a video was only 300px wide, but the container was 1000px wide, the "edit" icon was on the far right of the container making it more difficult for the user to even notice since it was 700px away from the video.  With the change in images per item 1 where it will only take up what it needs up to 100% of the parent, the icons will be contained in the image just like they will for video.

The UI/UX around "PREVIEW/IMAGE/VIDEO" is less than ideal as it's not obvious that the image/video is an actual drop-target and the icons are difficult to see especially when it's a darker image/video.  More work coming in subsequent PRs but this PR fixes a couple of the issues.

# Testing

Manually tested that icons are in the correct place.
