### PR TITLE
fix: cli login

### DIFF
--- a/apps/cli/pkg/command/login.go
+++ b/apps/cli/pkg/command/login.go
@@ -11,7 +11,7 @@ func Login() error {
 
 	fmt.Println("Logging in...")
 
-	user, err := auth.Login()
+	user, err := auth.LoginWithOptions(true)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# What does this PR do?

Fixes a regression that resulted in every command requiring the user to go through the login process in order to complete the command.

In prior PRs, #5033 & #5072, work was done to improve login and part of that was to eliminate the "auth check" as it really should be unnecessary.  However, it actually is necessary, at least for now, for a few reasons:

1. All commands go through `auth.Login` including the `Login` command itself. With the `Check` removed, every command was going through the entire login process even if there was a token present.
2. `Check` will always return a user (barring any unforeseen failure), although the user may be the `Guest`. If the user returned is `Guest`, there is no user logged in so we need to process a login cycle.
3. Due to the fact that we return "errors" in various different ways currently (e.g., HTTP status codes, embedded in `wire.errors` property, `Location` header, etc. if we allowed any user to continue with the CLI (except for `Guest`), they would encounter error messages that would be incredibly difficult to discern for them.  Note that even if the user has permission, the difficulty to discern certain error messages exist, this only mitigates the situation where the error is really "you don't have permission" but they otherwise get an error message that mentions nothing about permissions in certain situations.

Given all the above, this PR:

1. Always does a `Check` when `auth.Login` is called
2. If the user is `Guest`, continues with the login
3. If the user does not have `WorkspaceAdminPerm`, displays an error indicating that the user does not have permission to the CLI
4. After a successful login, the user may not have `WorkspaceAdminPerm` so we repeat that check to ensure they have permission and display error if not.  The prior versions of the CLI would check for `(currentUser.Profile == "uesio/studio.standard" || currentUser.Profile == "uesio/studio.admin")` but this could result in a false positive since profiles may be adjusted from their defaults and not contain `WorkspaceAdminPerm.`  Additionally, the prior versions of the CLI would do the check when starting a `Login` based on the result of `Check` but would not repeat the permission check after the actual login.  This PR closes that gap.
5. "Skips" the auth check & permission check login when the `Login` command itself is being executed. The user is asking us to login, so we should do that and avoid the `no-op` even if we have a current active token that has permission.  This avoids the user having to `logout` and then `login` and is consistent with other CLIs `login` command(s).

# Testing

Manually tested and confirmed.
