### PR TITLE
fix: ensure `useUserFile` correctly detects and honors `uesio/core.data` value

### DIFF
--- a/libs/ui/src/hooks/fileapi.ts
+++ b/libs/ui/src/hooks/fileapi.ts
@@ -48,6 +48,7 @@ const useUserFile = (
   const fileUrl = getUserFileURL(context, userFileId, updatedAt)
   useEffect(() => {
     if (data || !fileUrl) {
+      setContent(data || '')
       return
     }
     const fetchData = async () => {

--- a/libs/ui/src/hooks/fileapi.ts
+++ b/libs/ui/src/hooks/fileapi.ts
@@ -41,7 +41,7 @@ const useUserFile = (
   userFile: PlainWireRecord | undefined,
 ) => {
   const hasCoreData = userFile && "uesio/core.data" in userFile
-  const data = hasCoreData ? userFile["uesio/core.data"] as string : undefined
+  const data = hasCoreData ? (userFile["uesio/core.data"] as string) : undefined
   const [content, setContent] = useState<string>(data || "")
 
   const userFileId = userFile?.[ID_FIELD] as string

--- a/libs/ui/src/hooks/fileapi.ts
+++ b/libs/ui/src/hooks/fileapi.ts
@@ -40,15 +40,16 @@ const useUserFile = (
   context: Context,
   userFile: PlainWireRecord | undefined,
 ) => {
-  const data = userFile?.["uesio/core.data"] as string
+  const hasCoreData = userFile && "uesio/core.data" in userFile
+  const data = hasCoreData ? userFile["uesio/core.data"] as string : undefined
   const [content, setContent] = useState<string>(data || "")
 
   const userFileId = userFile?.[ID_FIELD] as string
   const updatedAt = userFile?.[UPDATED_AT_FIELD] as string
   const fileUrl = getUserFileURL(context, userFileId, updatedAt)
   useEffect(() => {
-    if (data || !fileUrl) {
-      setContent(data || '')
+    if (hasCoreData || !fileUrl) {
+      setContent(data || "")
       return
     }
     const fetchData = async () => {


### PR DESCRIPTION
# What does this PR do?

Fixes two issues with `useUserFile`:

1. If `uesio/core.data` existed, but its value was "empty string", the fetch would occur
2. Did not update `content` when `uesio/core.data` changed - The intended use of the hook is to provide the "current content", not just the original content since it is used in `FileText` component which passes it to monaco as an intended controlled input.  This created a bug where if you typed something in the editor, then hit the `Cancel` button, the wire data would change, however the hook would still return the original value which was passed to Monaco which detected that `value` hasn't changed so it should maintain it's internal buffer state resulting in the text that was typed staying visible in the editor.  Underneath, the wire was correct but the editor did not represent what was in the wire.  The fix for this was to ensure that the hook uses the current value of `uesio/core.data` and returns it instead of always returning the original.

# Testing

Tested manually and confirmed.
