### PR TITLE
chore: migrates bot & agent views to standardized structure

### DIFF
--- a/libs/apps/uesio/studio/bundle/views/agent.yaml
+++ b/libs/apps/uesio/studio/bundle/views/agent.yaml
@@ -82,10 +82,14 @@ definition:
                                 components:
                                   - uesio/io.button:
                                       uesio.variant: uesio/appkit.secondary
+                                      icon: edit_square
+                                      iconFill: false
                                       text: $Label{uesio/io.edit}
                                       uesio.display:
-                                        - type: fieldMode
-                                          mode: READ
+                                        - type: mergeValue
+                                          operator: NOT_EQUALS
+                                          sourceValue: $FieldMode{}
+                                          value: EDIT
                                         - type: wireHasNoChanges
                                           wire: agents
                                         - type: wireHasNoChanges
@@ -93,18 +97,17 @@ definition:
                                       signals:
                                         - signal: component/CALL
                                           component: uesio/io.item
-                                          componentsignal: TOGGLE_MODE
+                                          componentsignal: SET_EDIT_MODE
                                           targettype: specific
                                           target: agentsItem
                                   - uesio/io.button:
                                       uesio.variant: uesio/appkit.primary
                                       text: $Label{uesio/io.save}
+                                      hotkey: "meta+s"
                                       uesio.display:
                                         - type: group
                                           conjunction: OR
                                           conditions:
-                                            - type: fieldMode
-                                              mode: EDIT
                                             - type: wireHasChanges
                                               wire: agents
                                             - type: wireHasChanges
@@ -114,6 +117,11 @@ definition:
                                           wires:
                                             - agents
                                             - attachments
+                                        - signal: component/CALL
+                                          component: uesio/io.item
+                                          componentsignal: SET_READ_MODE
+                                          targettype: specific
+                                          target: agentsItem
                                   - uesio/io.button:
                                       uesio.variant: uesio/appkit.secondary
                                       text: $Label{uesio/io.cancel}
@@ -137,19 +145,6 @@ definition:
                                           componentsignal: SET_READ_MODE
                                           targettype: specific
                                           target: agentsItem
-                                  - uesio/io.button:
-                                      uesio.variant: uesio/appkit.secondary
-                                      text: $Label{uesio/io.delete}
-                                      uesio.display:
-                                        - type: fieldMode
-                                          mode: READ
-                                        - type: wireHasNoChanges
-                                          wire: agents
-                                        - type: wireHasNoChanges
-                                          wire: attachments
-                                      signals:
-                                        - signal: panel/TOGGLE
-                                          panel: deleteAgent
                       - uesio/io.box:
                           uesio.variant: uesio/appkit.primarysection
                           components:
@@ -174,36 +169,22 @@ definition:
                             - uesio/io.list:
                                 uesio.id: agentAttachmentsList
                                 wire: attachments
-                                mode: EDIT
                                 components:
                                   - uesio/io.fileattachment:
                                       displayAs: TEXT
                                       textOptions:
                                         language: plaintext
                       - uesio/appkit.section_audit_info:
-  panels:
-    deleteAgent:
-      uesio.type: uesio/io.dialog
-      title: Delete Agent
-      width: 400px
-      height: 300px
-      components:
-        - uesio/io.text:
-            text: Are you sure you want to delete this agent?
-      actions:
-        - uesio/io.button:
-            text: $Label{uesio/io.delete}
-            uesio.variant: uesio/io.primary
-            signals:
-              - signal: wire/MARK_FOR_DELETE
-              - signal: wire/SAVE
-                wires:
-                  - agents
-              - signal: route/NAVIGATE
-                path: app/$Param{app}/workspace/$Param{workspacename}/agents
-        - uesio/io.button:
-            text: $Label{uesio/io.cancel}
-            uesio.variant: uesio/io.secondary
-            signals:
-              - signal: panel/TOGGLE
-                panel: deleteAgent
+                      - uesio/appkit.section_delete:
+                          editModeOnly: false
+                          confirm: true
+                          confirmTitle: Are you sure?
+                          confirmMessage: The agent ${uesio/studio.name} will be deleted. This action cannot be undone.
+                          subtitle: The agent will be permanently deleted from the system. Please be sure this what you want to do!
+                          signals:
+                            - signal: wire/MARK_FOR_DELETE
+                            - signal: wire/SAVE
+                              wires:
+                                - agents
+                            - signal: route/NAVIGATE
+                              path: app/$Param{app}/workspace/$Param{workspacename}/agents

--- a/libs/apps/uesio/studio/bundle/views/bot.yaml
+++ b/libs/apps/uesio/studio/bundle/views/bot.yaml
@@ -94,10 +94,14 @@ definition:
                                 components:
                                   - uesio/io.button:
                                       uesio.variant: uesio/appkit.secondary
+                                      icon: edit_square
+                                      iconFill: false
                                       text: $Label{uesio/io.edit}
                                       uesio.display:
-                                        - type: fieldMode
-                                          mode: READ
+                                        - type: mergeValue
+                                          operator: NOT_EQUALS
+                                          sourceValue: $FieldMode{}
+                                          value: EDIT
                                         - type: wireHasNoChanges
                                           wire: bots
                                         - type: wireHasNoChanges
@@ -105,18 +109,17 @@ definition:
                                       signals:
                                         - signal: component/CALL
                                           component: uesio/io.item
-                                          componentsignal: TOGGLE_MODE
+                                          componentsignal: SET_EDIT_MODE
                                           targettype: specific
                                           target: botsItem
                                   - uesio/io.button:
                                       uesio.variant: uesio/appkit.primary
                                       text: $Label{uesio/io.save}
+                                      hotkey: "meta+s"
                                       uesio.display:
                                         - type: group
                                           conjunction: OR
                                           conditions:
-                                            - type: fieldMode
-                                              mode: EDIT
                                             - type: wireHasChanges
                                               wire: bots
                                             - type: wireHasChanges
@@ -126,6 +129,11 @@ definition:
                                           wires:
                                             - bots
                                             - attachments
+                                        - signal: component/CALL
+                                          component: uesio/io.item
+                                          componentsignal: SET_READ_MODE
+                                          targettype: specific
+                                          target: botsItem
                                   - uesio/io.button:
                                       uesio.variant: uesio/appkit.secondary
                                       text: $Label{uesio/io.cancel}
@@ -149,19 +157,6 @@ definition:
                                           componentsignal: SET_READ_MODE
                                           targettype: specific
                                           target: botsItem
-                                  - uesio/io.button:
-                                      uesio.variant: uesio/appkit.secondary
-                                      text: $Label{uesio/io.delete}
-                                      uesio.display:
-                                        - type: fieldMode
-                                          mode: READ
-                                        - type: wireHasNoChanges
-                                          wire: bots
-                                        - type: wireHasNoChanges
-                                          wire: attachments
-                                      signals:
-                                        - signal: panel/TOGGLE
-                                          panel: deleteBot
                       - uesio/io.box:
                           uesio.variant: uesio/appkit.primarysection
                           components:
@@ -205,7 +200,6 @@ definition:
                             - uesio/io.list:
                                 uesio.id: botAttachmentsList
                                 wire: attachments
-                                mode: EDIT
                                 components:
                                   - uesio/io.fileattachment:
                                       displayAs: TEXT
@@ -255,29 +249,16 @@ definition:
                                       fieldId: uesio/studio.params
                                       label: " "
                       - uesio/appkit.section_audit_info:
-  panels:
-    deleteBot:
-      uesio.type: uesio/io.dialog
-      title: Delete Bot
-      width: 400px
-      height: 300px
-      components:
-        - uesio/io.text:
-            text: Are you sure you want to delete this bot?
-      actions:
-        - uesio/io.button:
-            text: $Label{uesio/io.delete}
-            uesio.variant: uesio/io.primary
-            signals:
-              - signal: wire/MARK_FOR_DELETE
-              - signal: wire/SAVE
-                wires:
-                  - bots
-              - signal: route/NAVIGATE
-                path: app/$Param{app}/workspace/$Param{workspacename}/bots
-        - uesio/io.button:
-            text: $Label{uesio/io.cancel}
-            uesio.variant: uesio/io.secondary
-            signals:
-              - signal: panel/TOGGLE
-                panel: deleteBot
+                      - uesio/appkit.section_delete:
+                          editModeOnly: false
+                          confirm: true
+                          confirmTitle: Are you sure?
+                          confirmMessage: The bot ${uesio/studio.name} will be deleted. This action cannot be undone.
+                          subtitle: The bot will be permanently deleted from the system. Please be sure this what you want to do!
+                          signals:
+                            - signal: wire/MARK_FOR_DELETE
+                            - signal: wire/SAVE
+                              wires:
+                                - bots
+                            - signal: route/NAVIGATE
+                              path: app/$Param{app}/workspace/$Param{workspacename}/bots


### PR DESCRIPTION
# What does this PR do?

Migrates `bot` and `agent` views to the standardized structure/layout.

Resolves the following issues:

1. Consistent UI/UX relative to other "detail" type views
2. When navigating the view, the record was in "READ" mode but the monaco editor was in "EDIT" mode
3. After saving changes, the Monaco editor remained in "EDIT" mode

# Testing

Manually tested and confirmed expected behavior.
