### PR TITLE
fix: build host key correctly

### DIFF
--- a/apps/platform/pkg/auth/cache.go
+++ b/apps/platform/pkg/auth/cache.go
@@ -123,7 +123,7 @@ func getHostKeyFromDomainId(id string) (string, error) {
 	}
 	domain := id[:idx]
 	domainType := id[idx+1:]
-	return getHostKey(domain, domainType), nil
+	return getHostKey(domainType, domain), nil
 }
 
 func InvalidateCache() error {


### PR DESCRIPTION
# What does this PR do?

Fixes the params passed to `getHostKey` to ensure the cache key is built correctly.

Regression from #5110.

# Testing

Manual testing to ensure cache key is deleted as expected.
