### PR TITLE
fix: enforce single label subdomain

### DIFF
--- a/apps/platform/pkg/bot/systemdialect/systembot_before_sitedomain.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_before_sitedomain.go
@@ -95,7 +95,7 @@ func isValidDomain(details domainDetails) error {
 			return fmt.Errorf("a subdomain must have one label (e.g., 'mysubdomain'): %s", domain)
 		}
 		// Wildcard certs typically restrict to single label subdomains (e.g., *.example.com) and most cert providers will not issue multi-label wildcard certs. If a multi-label
-		// subdomain is required, an explicit certificate, either for the subdomain explicitly or a wildcard for the top-most level of the subdomain) must be used which requires
+		// subdomain is required, an explicit certificate, either for the subdomain explicitly or a wildcard for the top-most level of the subdomain, must be used which requires
 		// infrastructure configuration depending on the hosting environment.
 		if len(labels) > 1 {
 			return fmt.Errorf("a subdomain can only contain one label (e.g., 'mysubdomain'), contact your administrator if you require a multi-label subdomain: %s", domain)

--- a/apps/platform/pkg/bot/systemdialect/systembot_before_sitedomain.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_before_sitedomain.go
@@ -92,7 +92,13 @@ func isValidDomain(details domainDetails) error {
 	switch domainType {
 	case "subdomain":
 		if len(labels) < 1 {
-			return fmt.Errorf("a subdomain must have at least one label (e.g., 'mysubdomain'): %s", domain)
+			return fmt.Errorf("a subdomain must have one label (e.g., 'mysubdomain'): %s", domain)
+		}
+		// Wildcard certs typically restrict to single label subdomains (e.g., *.example.com) and most cert providers will not issue multi-label wildcard certs. If a multi-label
+		// subdomain is required, an explicit certificate, either for the subdomain explicitly or a wildcard for the top-most level of the subdomain) must be used which requires
+		// infrastructure configuration depending on the hosting environment.
+		if len(labels) > 1 {
+			return fmt.Errorf("a subdomain can only contain one label (e.g., 'mysubdomain'), contact your administrator if you require a multi-label subdomain: %s", domain)
 		}
 	case "domain":
 		if len(labels) < 2 {


### PR DESCRIPTION
# What does this PR do?

Enforces single label subdomains for sites.

Wildcard certs typically restrict to single label subdomains (e.g., *.example.com) and most cert providers will not issue multi-label wildcard certs. If a multi-label subdomain is required, an explicit certificate, either for the subdomain explicitly or a wildcard for the top-most level of the subdomain, must be used which requires infrastructure configuration depending on the hosting environment.

# Testing

Tested manually and confirmed single label subdomains are enforced.
