### PR TITLE
fix: ensure collectionId of user file matches collection of recordid

### DIFF
--- a/apps/platform/pkg/bot/systemdialect/systembot_after_userfile.go
+++ b/apps/platform/pkg/bot/systemdialect/systembot_after_userfile.go
@@ -2,6 +2,7 @@ package systemdialect
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/thecloudmasters/uesio/pkg/auth"
@@ -15,6 +16,7 @@ const (
 	userCollectionId       = "uesio/core.user"
 	studioFileCollectionId = "uesio/studio.file"
 	studioBotCollectionId  = "uesio/studio.bot"
+	userFileCollectionId   = "uesio/core.userfile"
 )
 
 func runUserFileAfterSaveBot(ctx context.Context, request *wire.SaveOp, connection wire.Connection, session *sess.Session) error {
@@ -68,6 +70,8 @@ func runUserFileAfterSaveBot(ctx context.Context, request *wire.SaveOp, connecti
 				commonfields.UpdatedAt: time.Now().Unix(),
 				commonfields.Id:        relatedRecordId,
 			})
+		case userFileCollectionId:
+			return fmt.Errorf("userfile cannot reference collection: %s", userFileCollectionId)
 		}
 		return nil
 	}); err != nil {

--- a/libs/apps/uesio/appkit/bundle/components/section_attachments.yaml
+++ b/libs/apps/uesio/appkit/bundle/components/section_attachments.yaml
@@ -5,6 +5,14 @@ properties:
   - name: title
     type: TEXT
     defaultValue: Attachments
+  - name: allowCreate
+    type: CHECKBOX
+    label: Allow Create
+    defaultValue: false
+  - name: allowDelete
+    type: CHECKBOX
+    label: Allow Delete
+    defaultValue: false
 definition:
   - uesio/io.box:
       uesio.variant: uesio/appkit.section
@@ -26,6 +34,7 @@ definition:
                     workspacename: $Param{workspacename}
                     allowCreate: $Prop{allowCreate}
                     allowDelete: $Prop{allowDelete}
+                    collectionId: $Collection{id}
 title: Attachments Section
 discoverable: true
 description: Attachments Section

--- a/libs/apps/uesio/appkit/bundle/views/file_attachments.yaml
+++ b/libs/apps/uesio/appkit/bundle/views/file_attachments.yaml
@@ -21,7 +21,7 @@ definition:
           value: $Param{recordid}
         - field: uesio/core.collectionid
           valueSource: VALUE
-          value: $Collection{id}
+          value: $Param{collectionId}
   components:
     - uesio/io.box:
         uesio.display:

--- a/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/userfile/userfile.tsx
+++ b/libs/apps/uesio/io/bundle/componentpacks/main/src/utilities/userfile/userfile.tsx
@@ -72,23 +72,35 @@ const UserFile: definition.UtilityComponent<UserFileUtilityProps> = (props) => {
     const fieldID = props.fieldId || userFile?.["uesio/core.fieldid"]
 
     if (!recordID || !collectionID) return
-    const uploadResult = await api.file.uploadFile(
-      context,
-      {
-        collectionID,
-        recordID,
-        fieldID,
-        params: context.getParams(),
-      },
-      file,
-    )
+    let uploadResult
+    try {
+      uploadResult = await api.file.uploadFile(
+        context,
+        {
+          collectionID,
+          recordID,
+          fieldID,
+          params: context.getParams(),
+        },
+        file,
+      )
+    } catch (e) {
+      api.notification.addError("Unable to upload file: " + e, context)
+      throw e
+    }
     await onUpload?.(uploadResult)
     return uploadResult
   }
 
   const onFileDelete = async () => {
     if (!userFileId) return
-    const deleteResult = await api.file.deleteFile(context, userFileId)
+    let deleteResult
+    try {
+      deleteResult = await api.file.deleteFile(context, userFileId)
+    } catch (e) {
+      api.notification.addError("Unable to delete file: " + e, context)
+      throw e
+    }
     await onDelete?.(deleteResult)
     return deleteResult
   }


### PR DESCRIPTION
# What does this PR do?

Fixes an issue where on 2nd (and subsequent) uploads of a userfile to and attachment, the `collection` would be `userfile` instead of the `id` of the collection that "owns" the userfile.  Additionally, adds server side validation to ensure that a userfile can never have a collection of `userfile` and adds toast notifications to `uploadFile` and `deleteFile` to surface errors to user in UI.

In [this commit](https://github.com/ues-io/uesio/commit/ade91a8913cd23735d86da29cd3270d70a35efc7#diff-55d7c9ea51b4f7299ecf6ba9cb00a07c2970652389e1e79b334a5eb303cb2f5dL24), the `collectionid` value was changed to use the `$Collection{id}`, however when there is a record in context for `userfile`, the collection is now `userfile`.

@humandad  - The hierarchy and flow of these components is a little odd in my opinion.  In short, [section_attachments](https://github.com/ues-io/uesio/pull/5119/files#diff-88f1f4feb81702fb98eadab44492744c30f50d3efecf1e61bd85536e408cdaa0R34), which is a component, directly uses `$Param`. Should components ever use `param` and should they only use `prop` and any view should transpose its params to props?  Seems like only views should ever use `params` as I don't believe there is a way to define `params` on a component in its definition.  As it stands, the hierarchy of all these components does not have complete definition of props/params so that needs to be adjusted, just want to confirm how to adjust.  This is not directly related to this PR, but indirectly.

# Testing

Manually tested `Files` & "Collection Record Data Management" (the only two places where this functionality is leveraged) to ensure that files are added as expected.
